### PR TITLE
Support for running generated docker-compose script

### DIFF
--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -79,6 +79,12 @@ Finally, it will run the generated docker-compose script`,
 		if err != nil {
 			log.Fatal(err)
 		}
+
+		// Run docker-compose scripts
+		err = utils.RunDockerCompose(generationPath + "/docker-compose.yml")
+		if err != nil {
+			log.Fatal(err)
+		}
 	},
 }
 

--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -92,15 +92,16 @@ func init() {
 	rootCmd.AddCommand(cliCmd)
 
 	// Local flags
-	cliCmd.Flags().StringVar(&executionName, "execution", "", "Execution engine client, e.g. Geth, Nethermind, Besu, Erigon")
+	cliCmd.Flags().StringVarP(&executionName, "execution", "e", "", "Execution engine client, e.g. Geth, Nethermind, Besu, Erigon")
 
-	cliCmd.Flags().StringVar(&consensusName, "consensus", "", "Consensus engine client, e.g. Teku, Lodestar, Prysm, Lighthouse, Nimbus")
+	cliCmd.Flags().StringVarP(&consensusName, "consensus", "c", "", "Consensus engine client, e.g. Teku, Lodestar, Prysm, Lighthouse, Nimbus")
 
-	cliCmd.Flags().StringVar(&validatorName, "validator", "", "Validator engine client, e.g. Teku, Lodestar, Prysm, Lighthouse, Nimbus")
+	cliCmd.Flags().StringVarP(&validatorName, "validator", "v", "", "Validator engine client, e.g. Teku, Lodestar, Prysm, Lighthouse, Nimbus")
 
-	cliCmd.Flags().StringVar(&generationPath, "path", configs.DefaultDockerComposeScriptsPath, "docker-compose scripts generation path")
+	cliCmd.Flags().StringVarP(&generationPath, "path", "p", configs.DefaultDockerComposeScriptsPath, "docker-compose scripts generation path")
 
 	cliCmd.Flags().BoolVarP(&randomize, "randomize", "r", false, "Randomize combination of clients")
+
 }
 
 func installOrShowInstructions(pending []string) (err error) {

--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -26,6 +26,7 @@ var (
 	generationPath string
 	randomize      bool
 	install        bool
+	run            bool
 )
 
 const (
@@ -86,9 +87,16 @@ Finally, it will run the generated docker-compose script`,
 			log.Fatal(err)
 		}
 
-		// Let the user decide to see the instructions for executing the scripts and exit or let the tool execute them
-		if err = runScriptOrExit(); err != nil {
-			log.Fatal(err)
+		if run {
+			// Run docker-compose script
+			if err = utils.RunDockerCompose(generationPath + "/docker-compose.yml"); err != nil {
+				log.Fatalf(configs.RunningDockerComposeError, err)
+			}
+		} else {
+			// Let the user decide to see the instructions for executing the scripts and exit or let the tool execute them
+			if err = runScriptOrExit(); err != nil {
+				log.Fatal(err)
+			}
 		}
 	},
 }
@@ -108,6 +116,8 @@ func init() {
 	cliCmd.Flags().BoolVarP(&randomize, "randomize", "r", false, "Randomize combination of clients")
 
 	cliCmd.Flags().BoolVarP(&install, "install", "i", false, "Install dependencies if not installed without asking")
+
+	cliCmd.Flags().BoolVarP(&run, "run", "r", false, "Run the generated docker-compose scripts without asking")
 }
 
 func installOrShowInstructions(pending []string) (err error) {

--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -74,8 +74,7 @@ Finally, it will run the generated docker-compose script`,
 				}
 			} else {
 				// Let the user decide to see the instructions for installing dependencies and exit or let the tool install them and continue
-			err := installOrShowInstructions(pending)
-			if err != nil {
+				if err := installOrShowInstructions(pending); err != nil {
 					log.Fatal(err)
 				}
 			}
@@ -83,14 +82,14 @@ Finally, it will run the generated docker-compose script`,
 		log.Info(configs.DependenciesOK)
 
 		// Generate docker-compose scripts
-		err = utils.GenerateScripts(combinedClients.Execution.Name, combinedClients.Consensus.Name, combinedClients.Validator.Name, generationPath)
-		if err != nil {
+		if err = utils.GenerateScripts(combinedClients.Execution.Name, combinedClients.Consensus.Name, combinedClients.Validator.Name, generationPath); err != nil {
 			log.Fatal(err)
 		}
 
 		// Run docker-compose scripts
 		err = utils.RunDockerCompose(generationPath + "/docker-compose.yml")
 		if err != nil {
+		if err = runScriptOrExit(); err != nil {
 			log.Fatal(err)
 		}
 	},
@@ -127,8 +126,7 @@ func installOrShowInstructions(pending []string) (err error) {
 
 	switch result {
 	case optShow:
-		err = utils.HandleInstructions(pending, utils.ShowInstructions)
-		if err != nil {
+		if err = utils.HandleInstructions(pending, utils.ShowInstructions); err != nil {
 			return fmt.Errorf(configs.ShowingInstructionsError, err)
 		}
 		err = installOrShowInstructions(pending)
@@ -220,16 +218,13 @@ func validateClients(allClients clients.OrderedClients) (clients.Clients, error)
 			Validator: allClients[validator][validatorName],
 		}
 
-		err = clients.ValidateClient(combinedClients.Execution, execution)
-		if err != nil {
+		if err = clients.ValidateClient(combinedClients.Execution, execution); err != nil {
 			return combinedClients, err
 		}
-		err = clients.ValidateClient(combinedClients.Consensus, consensus)
-		if err != nil {
+		if err = clients.ValidateClient(combinedClients.Consensus, consensus); err != nil {
 			return combinedClients, err
 		}
-		err = clients.ValidateClient(combinedClients.Validator, validator)
-		if err != nil {
+		if err = clients.ValidateClient(combinedClients.Validator, validator); err != nil {
 			return combinedClients, err
 		}
 	}

--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -117,7 +117,7 @@ func init() {
 
 	cliCmd.Flags().BoolVarP(&install, "install", "i", false, "Install dependencies if not installed without asking")
 
-	cliCmd.Flags().BoolVarP(&run, "run", "r", false, "Run the generated docker-compose scripts without asking")
+	cliCmd.Flags().BoolVar(&run, "run", false, "Run the generated docker-compose scripts without asking")
 }
 
 func installOrShowInstructions(pending []string) (err error) {

--- a/configs/errors.go
+++ b/configs/errors.go
@@ -20,4 +20,5 @@ const (
 	LoadingTemplatesError       = "error loading templates: %s"
 	PrintingFileError           = "something went wrong printing file %s. Error: %s"
 	DependenciesPending         = "pending dependencies: %s"
+	RunningDockerComposeError   = "failed to execute docker-compose script. Error: %s"
 )

--- a/configs/messages.go
+++ b/configs/messages.go
@@ -20,4 +20,6 @@ const (
 	PrintingFile                    = "File %s :"
 	SupportedClients                = "Supported clients of type %s: %v"
 	ConfigClients                   = "Provided clients of type %s in configuration file: %v"
+	DockerComposeCMD                = "sudo docker-compose -f %s up -d"
+	RunningDockerCompose            = "Running docker-compose script"
 )

--- a/internal/utils/run_scripts.go
+++ b/internal/utils/run_scripts.go
@@ -10,7 +10,7 @@ import (
 
 /*
 RunDockerCompose :
-This function is responsible for running the generated doccker-compose script.
+This function is responsible for running the generated docker-compose script.
 
 params :-
 a. path string

--- a/internal/utils/run_scripts.go
+++ b/internal/utils/run_scripts.go
@@ -3,11 +3,26 @@ package utils
 import (
 	"fmt"
 	"text/template"
+
+	"github.com/NethermindEth/1Click/configs"
+	log "github.com/sirupsen/logrus"
 )
 
-// Run docker-compose scripts
+/*
+RunDockerCompose :
+This function is responsible for running the generated doccker-compose script.
+
+params :-
+a. path string
+Path of generated script
+
+returns :-
+a. error
+Error if any
+*/
 func RunDockerCompose(path string) error {
-	cmd := fmt.Sprintf("sudo docker-compose -f %s up -d", path)
+	log.Info(configs.RunningDockerCompose)
+	cmd := fmt.Sprintf(configs.DockerComposeCMD, path)
 	tmp, err := template.New("script").Parse(cmd)
 	if err != nil {
 		return err

--- a/internal/utils/run_scripts.go
+++ b/internal/utils/run_scripts.go
@@ -1,14 +1,16 @@
 package utils
 
 import (
-	"os"
-	"os/exec"
+	"fmt"
+	"text/template"
 )
 
 // Run docker-compose scripts
 func RunDockerCompose(path string) error {
-	cmd := exec.Command("docker-compose", "-f", path, "up", "-d")
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	return cmd.Run()
+	cmd := fmt.Sprintf("sudo docker-compose -f %s up -d", path)
+	tmp, err := template.New("script").Parse(cmd)
+	if err != nil {
+		return err
+	}
+	return executeScript(tmp)
 }

--- a/internal/utils/run_scripts.go
+++ b/internal/utils/run_scripts.go
@@ -1,0 +1,14 @@
+package utils
+
+import (
+	"os"
+	"os/exec"
+)
+
+// Run docker-compose scripts
+func RunDockerCompose(path string) error {
+	cmd := exec.Command("docker-compose", "-f", path, "up", "-d")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}

--- a/templates/envs/consensus/lighthouse.tmpl
+++ b/templates/envs/consensus/lighthouse.tmpl
@@ -1,5 +1,5 @@
 {{/* lighthouse.tmpl */}}
-LH_PEER_COUNT=50
+CC_PEER_COUNT=50
 CC_LOG_LEVEL=info
 NETWORK=mainnet
 EC_NODE={{.ExecutionNodeURL}}

--- a/templates/envs/consensus/lodestar.tmpl
+++ b/templates/envs/consensus/lodestar.tmpl
@@ -4,4 +4,4 @@ CC_LOG_LEVEL=info
 NETWORK=mainnet
 EC_NODE={{.ExecutionNodeURL}}
 INSTANCE_NAME=Lodestar
-CC_IMAGE_VERSION=
+CC_IMAGE_VERSION=chainsafe/lodestar

--- a/templates/envs/consensus/lodestar.tmpl
+++ b/templates/envs/consensus/lodestar.tmpl
@@ -1,5 +1,5 @@
 {{/* lodestar.tmpl */}}
-LH_PEER_COUNT=50
+CC_PEER_COUNT=50
 CC_LOG_LEVEL=info
 NETWORK=mainnet
 EC_NODE={{.ExecutionNodeURL}}

--- a/templates/envs/consensus/prysm.tmpl
+++ b/templates/envs/consensus/prysm.tmpl
@@ -4,4 +4,4 @@ CC_LOG_LEVEL=info
 NETWORK=mainnet
 EC_NODE={{.ExecutionNodeURL}}
 INSTANCE_NAME=Prysm
-CC_IMAGE_VERSION=
+CC_IMAGE_VERSION=gcr.io/prysmaticlabs/prysm/beacon-chain:stable

--- a/templates/envs/consensus/prysm.tmpl
+++ b/templates/envs/consensus/prysm.tmpl
@@ -1,5 +1,5 @@
 {{/* prysm.tmpl */}}
-LH_PEER_COUNT=50
+CC_PEER_COUNT=50
 CC_LOG_LEVEL=info
 NETWORK=mainnet
 EC_NODE={{.ExecutionNodeURL}}

--- a/templates/envs/consensus/teku.tmpl
+++ b/templates/envs/consensus/teku.tmpl
@@ -1,5 +1,5 @@
 {{/* teku.tmpl */}}
-LH_PEER_COUNT=50
+CC_PEER_COUNT=50
 CC_LOG_LEVEL=info
 NETWORK=mainnet
 EC_NODE={{.ExecutionNodeURL}}

--- a/templates/envs/consensus/teku.tmpl
+++ b/templates/envs/consensus/teku.tmpl
@@ -4,4 +4,4 @@ CC_LOG_LEVEL=info
 NETWORK=mainnet
 EC_NODE={{.ExecutionNodeURL}}
 INSTANCE_NAME=Teku
-CC_IMAGE_VERSION=
+CC_IMAGE_VERSION=consensys/teku:latest

--- a/templates/envs/validator/lighthouse.tmpl
+++ b/templates/envs/validator/lighthouse.tmpl
@@ -3,4 +3,4 @@ CC_NODE={{.ConsensusNodeURL}}
 GRAFFITI={{.ExecutionEngineName}}
 VL_LOG_LEVEL=info
 INSTANCE_NAME=LighthouseValidator
-VL_IMAGE_VERSION=
+VL_IMAGE_VERSION=sigp/lighthouse:latest

--- a/templates/envs/validator/lodestar.tmpl
+++ b/templates/envs/validator/lodestar.tmpl
@@ -3,4 +3,4 @@ CC_NODE={{.ConsensusNodeURL}}
 GRAFFITI={{.ExecutionEngineName}}
 VL_LOG_LEVEL=info
 INSTANCE_NAME=LodestarValidator
-VL_IMAGE_VERSION=
+VL_IMAGE_VERSION=chainsafe/lodestar

--- a/templates/envs/validator/prysm.tmpl
+++ b/templates/envs/validator/prysm.tmpl
@@ -3,4 +3,4 @@ CC_NODE={{.ConsensusNodeURL}}
 GRAFFITI={{.ExecutionEngineName}}
 VL_LOG_LEVEL=info
 INSTANCE_NAME=PrysmValidator
-VL_IMAGE_VERSION=
+VL_IMAGE_VERSION=gcr.io/prysmaticlabs/prysm/validator:stable

--- a/templates/envs/validator/teku.tmpl
+++ b/templates/envs/validator/teku.tmpl
@@ -4,5 +4,5 @@ NETWORK=mainnet
 GRAFFITI={{.ExecutionEngineName}}
 VL_LOG_LEVEL=info
 INSTANCE_NAME=TekuValidator
-VL_IMAGE_VERSION=
+VL_IMAGE_VERSION=consensys/teku:latest
 JAVA_OPTS=-XX:SoftMaxHeapSize=2g -Xmx4g

--- a/templates/services/consensus/lighthouse.tmpl
+++ b/templates/services/consensus/lighthouse.tmpl
@@ -19,7 +19,7 @@
       - --http-address=0.0.0.0
       - --http-port=4000
       - --network=${NETWORK}
-      - --target-peers=${PEER_COUNT}
+      - --target-peers=${CC_PEER_COUNT}
       - --eth1-endpoints=${EC_NODE}
       - --eth1-blocks-per-log-query=150
       - --debug-level=${CC_LOG_LEVEL}

--- a/templates/services/consensus/lodestar.tmpl
+++ b/templates/services/consensus/lodestar.tmpl
@@ -24,7 +24,7 @@
       - --network.localMultiaddrs="/ip4/0.0.0.0/tcp/9000"
       - --eth1.providerUrl=${EC_NODE}
       - --weakSubjectivitySyncLatest=${LS_RAPID_SYNC}
-      - --network.targetPeers=${PEERS_COUNT}
+      - --network.targetPeers=${CC_PEER_COUNT}
     network_mode: host
     logging:
       driver: "json-file"

--- a/templates/services/consensus/prysm.tmpl
+++ b/templates/services/consensus/prysm.tmpl
@@ -15,7 +15,7 @@
       - --${NETWORK}
       - --p2p-tcp-port=13000
       - --p2p-udp-port=12000
-      - --p2p-max-peers=${PEER_COUNT}
+      - --p2p-max-peers=${CC_PEER_COUNT}
       - --rpc-host=0.0.0.0
       - --grpc-gateway-host=0.0.0.0
       - --grpc-gateway-port=4000

--- a/templates/services/consensus/teku.tmpl
+++ b/templates/services/consensus/teku.tmpl
@@ -18,7 +18,7 @@
       - --logging=${CC_LOG_LEVEL}
       - --network=${NETWORK}
       - --p2p-port=9000
-      - --p2p-peer-upper-bound=${PEER_COUNT}
+      - --p2p-peer-upper-bound=${CC_PEER_COUNT}
       - --rest-api-host-allowlist=*
       - --rest-api-enabled=true
       - --rest-api-port=4000

--- a/templates/services/execution/nethermind.tmpl
+++ b/templates/services/execution/nethermind.tmpl
@@ -17,7 +17,7 @@
       - --Init.WebSocketsEnabled=true
       - --JsonRpc.Enabled=true
       - --JsonRpc.Host=0.0.0.0
-      - --JsonRpc.EnabledModules=${NETHERMIND_JSONRPCCONFIG_ENABLEDMODULES  }
+      - --JsonRpc.EnabledModules=${NETHERMIND_JSONRPCCONFIG_ENABLEDMODULES}
       - --HealthChecks.Enabled=${NETHERMIND_HEALTHCHECKSCONFIG_ENABLED}
       - --Pruning.CacheMb=${NETHERMIND_PRUNINGCONFIG_CACHEMB}
       - --EthStats.Enabled=${NETHERMIND_ETHSTATSCONFIG_ENABLED}


### PR DESCRIPTION
## Changes:
- Add logic for running the generated docker-compose script.
- Add Select to let the user choose between running the script or not, or showing instructions to run the script.
- Add `-i` and `--run` flags to install dependencies and run the script directly without asking the user.
- Add missing images names to consensus/validator env templates.
- Did some code refactor.

> Manually tested