### PR TITLE
Exclude validator from full node setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add support for gnosis merge testnets named chiado and denver
 - Add support for custom testnets by allowing custom remote config and genesis files
+- Add `--no-validator` flag to exclude the validator node from the full node setup
 
 ### Changed
 - Remove Nethermind metrics configuration

--- a/internal/pkg/clients/clients_test.go
+++ b/internal/pkg/clients/clients_test.go
@@ -184,18 +184,18 @@ func TestValidateClient(t *testing.T) {
 		},
 		{
 			client: Client{
-				"nethermind",
-				"execution",
-				true,
+				Name:      "nethermind",
+				Type:      "execution",
+				Supported: true,
 			},
 			clientType: "execution",
 			isErr:      false,
 		},
 		{
 			client: Client{
-				"nethermind",
-				"execution",
-				false,
+				Name:      "nethermind",
+				Type:      "execution",
+				Supported: false,
 			},
 			clientType: "execution",
 			isErr:      true,

--- a/internal/pkg/clients/types.go
+++ b/internal/pkg/clients/types.go
@@ -19,7 +19,10 @@ package clients
 type Client struct {
 	Name      string
 	Type      string
+	Image     string
+	Endpoint  string
 	Supported bool
+	Omited    bool
 }
 
 // Client : Struct Represent a combination of execution, consensus and validator clients

--- a/internal/pkg/clients/utils_test.go
+++ b/internal/pkg/clients/utils_test.go
@@ -32,19 +32,19 @@ func TestRandomChoice(t *testing.T) {
 		{
 			ClientMap{
 				"a": Client{
-					"a",
-					"A",
-					true,
+					Name:      "a",
+					Type:      "A",
+					Supported: true,
 				},
 				"b": Client{
-					"b",
-					"A",
-					true,
+					Name:      "b",
+					Type:      "A",
+					Supported: true,
 				},
 				"c": Client{
-					"c",
-					"A",
-					true,
+					Name:      "c",
+					Type:      "A",
+					Supported: true,
 				},
 			},
 			false,
@@ -52,19 +52,19 @@ func TestRandomChoice(t *testing.T) {
 		{
 			ClientMap{
 				"a": Client{
-					"a",
-					"A",
-					true,
+					Name:      "a",
+					Type:      "A",
+					Supported: true,
 				},
 				"b": Client{
-					"b",
-					"A",
-					true,
+					Name:      "b",
+					Type:      "A",
+					Supported: true,
 				},
 				"c": Client{
-					"c",
-					"A",
-					false,
+					Name:      "c",
+					Type:      "A",
+					Supported: false,
 				},
 			},
 			false,
@@ -72,14 +72,14 @@ func TestRandomChoice(t *testing.T) {
 		{
 			ClientMap{
 				"a": Client{
-					"a",
-					"A",
-					false,
+					Name:      "a",
+					Type:      "A",
+					Supported: false,
 				},
 				"b": Client{
-					"b",
-					"A",
-					false,
+					Name:      "b",
+					Type:      "A",
+					Supported: false,
 				},
 			},
 			true,

--- a/internal/pkg/generate/types.go
+++ b/internal/pkg/generate/types.go
@@ -15,6 +15,8 @@ limitations under the License.
 */
 package generate
 
+import "github.com/NethermindEth/sedge/internal/pkg/clients"
+
 // EnvData : Struct Data object to be applied to the docker-compose script environment (.env) template
 type EnvData struct {
 	ElImage                   string
@@ -35,14 +37,9 @@ type EnvData struct {
 
 // GenerationData : Struct Data object for script's generation
 type GenerationData struct {
-	ExecutionClient   string
-	ExecutionImage    string
-	ExecutionEndpoint string
-	ConsensusClient   string
-	ConsensusImage    string
-	ConsensusEndpoint string
-	ValidatorClient   string
-	ValidatorImage    string
+	ExecutionClient   clients.Client
+	ConsensusClient   clients.Client
+	ValidatorClient   clients.Client
 	GenerationPath    string
 	Network           string
 	CheckpointSyncUrl string

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -181,3 +181,29 @@ func portAvailable(host, port string, timeout time.Duration) bool {
 	}
 	return conn == nil
 }
+
+/*
+Filter :
+Filter a slice given a predicate
+
+params :-
+a. list []K
+List to be filtered
+b. filter func(K) bool
+Predicate to be applied to each element of the list
+
+returns :-
+a. []K
+Filtered list
+*/
+func Filter[K comparable](list []K, filter func(K) bool) []K {
+	n := 0
+	for _, v := range list {
+		if filter(v) {
+			list[n] = v
+			n++
+		}
+	}
+
+	return list[:n]
+}

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -196,7 +196,7 @@ returns :-
 a. []K
 Filtered list
 */
-func Filter[K comparable](list []K, filter func(K) bool) []K {
+func Filter[K any](list []K, filter func(K) bool) []K {
 	n := 0
 	for _, v := range list {
 		if filter(v) {

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strconv"
 	"strings"
 	"testing"
@@ -231,6 +232,42 @@ func TestAssingPorts(t *testing.T) {
 						t.Errorf("A mismatch in the result has been found. Expected (key: %s, value: %s); got (key: %s, value %s). Call: %s. Expected object: %+v, Got: %+v", k, tc.want[k], k, got[k], descr, tc.want, got)
 					}
 				}
+			}
+		})
+	}
+}
+
+func TestFilter(t *testing.T) {
+	tcs := []struct {
+		name   string
+		in     []string
+		want   []string
+		filter func(string) bool
+	}{
+		{
+			"Test case 1, no filter",
+			[]string{"a", "b", "c"},
+			[]string{"a", "b", "c"},
+			func(s string) bool {
+				return true
+			},
+		},
+		{
+			"Test case 2, filter",
+			[]string{"a", "b", "c"},
+			[]string{"a", "c"},
+			func(s string) bool {
+				return s != "b"
+			},
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Filter(tc.in, tc.filter)
+
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("Filter(%+v) failed; expected: %+v, got: %+v", tc.in, tc.want, got)
 			}
 		})
 	}

--- a/templates/services/mainnet/validator/empty.tmpl
+++ b/templates/services/mainnet/validator/empty.tmpl
@@ -1,0 +1,3 @@
+{{/* empty.tmpl */}}
+{{ define "validator" }}
+{{ end }}

--- a/templates/services/merge/validator/empty.tmpl
+++ b/templates/services/merge/validator/empty.tmpl
@@ -1,0 +1,3 @@
+{{/* empty.tmpl */}}
+{{ define "validator" }}
+{{ end }}


### PR DESCRIPTION
## Changes:
- [BREAKING] Add `--no-validator` flag to exclude the validator node from full node setup.
- Refactor generation of compose script and .env logic, functionality added to skip the generation of a template within the base template.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [x] Yes
- [ ] No

**In case you checked yes, did you write tests?**

- [x] Yes
- [ ] No

**Comments about testing , should you have some** (optional)

Requires smoke tests
