### PR TITLE
Add better formatting rules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,8 @@ jobs:
       with:
         go-version: '1.18.2'
 
-    - name: Check Go fmt
-      run: make gofmt
+    - name: Check Format
+      run: make format-check
 
     - name: Check go mod status
       run: |

--- a/Makefile
+++ b/Makefile
@@ -26,10 +26,15 @@ codecov-test: ## unit tests with coverage using the courtney tool
 	@mkdir -p coverage
 	@courtney/courtney -v -o coverage/coverage.out ./...
 
-install-deps: ## Install some project dependencies
+install-gofumpt: ## install gofumpt
+	go install mvdan.cc/gofumpt@latest
+
+install-courtney: ## Install courtney for code coverage
 	@git clone https://github.com/stdevMac/courtney
 	@(cd courtney && go get  ./... && go build courtney.go)
 	@go get ./...
+
+install-deps: | install-gofumpt install-courtney ## Install some project dependencies
 
 coverage: coverage/coverage.out ## show tests coverage
 	@go tool cover -html=coverage/coverage.out -o coverage/coverage.html
@@ -45,8 +50,13 @@ all: compile run ## build and run
 gomod_tidy: ## go mod tidy
 	 go mod tidy
 
-gofmt: ## go fmt
-	go fmt -x ./...
+format: ## run code formatting
+	gofumpt -l -w .
+
+format-check: ## check formatting
+	# assert `gofumpt -l` produces no output
+	test ! $$(gofumpt -l . | tee /dev/stderr)
+
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -218,7 +218,7 @@ func runCliCmd(cmd *cobra.Command, args []string) []error {
 		if err = handleJWTSecret(); err != nil {
 			return []error{err}
 		}
-	} else if filepath.IsAbs(jwtPath) { //Ensure jwtPath is absolute
+	} else if filepath.IsAbs(jwtPath) { // Ensure jwtPath is absolute
 		if jwtPath, err = filepath.Abs(jwtPath); err != nil {
 			return []error{err}
 		}
@@ -302,8 +302,8 @@ func runCliCmd(cmd *cobra.Command, args []string) []error {
 		// Run validator after execution and consensus clients are synced, unless the user intencionally wants to run the validator service in the previous step
 		if !utils.Contains(*services, validator) {
 			// Wait for clients to start
-			//log.Info(configs.WaitingForNodesToStart)
-			//time.Sleep(waitingTime)
+			// log.Info(configs.WaitingForNodesToStart)
+			// time.Sleep(waitingTime)
 			// Track sync of execution and consensus clients
 			// TODO: Parameterize wait arg of trackSync
 			if err = trackSync(monitor, results.ELPort, results.CLPort, time.Minute*5); err != nil {

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -37,6 +37,7 @@ var (
 	inspectExecutionUrl = "http://192.168.128.3"
 	inspectConsensusUrl = "http://192.168.128.3"
 )
+
 var inspectOut = `
 [
 	{

--- a/cli/cli_utils.go
+++ b/cli/cli_utils.go
@@ -100,7 +100,8 @@ func randomizeClients(allClients clients.OrderedClients) (clients.Clients, error
 	combinedClients = clients.Clients{
 		Execution: executionClient,
 		Consensus: consensusClient,
-		Validator: consensusClient}
+		Validator: consensusClient,
+	}
 	return combinedClients, nil
 }
 
@@ -377,7 +378,7 @@ func handleJWTSecret() error {
 
 	// Create scripts directory if not exists
 	if _, err := os.Stat(generationPath); os.IsNotExist(err) {
-		err = os.MkdirAll(generationPath, 0755)
+		err = os.MkdirAll(generationPath, 0o755)
 		if err != nil {
 			return err
 		}
@@ -429,7 +430,6 @@ func feeRecipientPrompt() error {
 	}
 
 	result, err := prompt.Run()
-
 	if err != nil {
 		return fmt.Errorf(configs.PromptFailedError, err)
 	}
@@ -446,14 +446,14 @@ func preRunTeku() error {
 		if s == "all" || s == consensus {
 			// Prepare consensus datadir
 			path := filepath.Join(generationPath, configs.ConsensusDefaultDataDir)
-			if err := os.MkdirAll(path, 0777); err != nil {
+			if err := os.MkdirAll(path, 0o777); err != nil {
 				return fmt.Errorf(configs.TekuDatadirError, consensus, err)
 			}
 		}
 		if s == "all" || s == validator {
 			// Prepare validator datadir
 			path := filepath.Join(generationPath, configs.ValidatorDefaultDataDir)
-			if err := os.MkdirAll(path, 0777); err != nil {
+			if err := os.MkdirAll(path, 0o777); err != nil {
 				return fmt.Errorf(configs.TekuDatadirError, validator, err)
 			}
 		}

--- a/cli/down_test.go
+++ b/cli/down_test.go
@@ -77,7 +77,7 @@ func buildDownTestCase(t *testing.T, caseName string, isErr bool) *downCmdTestCa
 }
 
 func TestDownCmd(t *testing.T) {
-	//TODO: allow to test error programs
+	// TODO: allow to test error programs
 	tcs := []downCmdTestCase{
 		*buildDownTestCase(t, "case_1", false),
 	}

--- a/cli/keys.go
+++ b/cli/keys.go
@@ -37,10 +37,8 @@ var (
 	existingMnemonic      bool
 )
 
-var (
-	//Windows and Unix path
-	rePath = regexp.MustCompile(`^[a-zA-Z]+:(\\[a-zA-Z0-9_.-]+)+|^~{0,1}\/[a-zA-Z0-9~]+(\/[a-zA-Z0-9_.-]+)+`)
-)
+// Windows and Unix path
+var rePath = regexp.MustCompile(`^[a-zA-Z]+:(\\[a-zA-Z0-9_.-]+)+|^~{0,1}\/[a-zA-Z0-9~]+(\/[a-zA-Z0-9_.-]+)+`)
 
 // keysCmd represents the keys command
 var keysCmd = &cobra.Command{
@@ -90,7 +88,7 @@ New mnemonic will be generated if -e/--existing flag is not provided.`,
 
 		// Create keystore folder
 		log.Info(configs.GeneratingKeystore)
-		if err := os.MkdirAll(filepath.Join(path, "keystore"), 0766); err != nil {
+		if err := os.MkdirAll(filepath.Join(path, "keystore"), 0o766); err != nil {
 			log.Fatal(err)
 		}
 
@@ -115,7 +113,6 @@ New mnemonic will be generated if -e/--existing flag is not provided.`,
 
 			log.Warn(configs.ReviewKeystorePath)
 		}
-
 	},
 }
 
@@ -148,7 +145,6 @@ func passwordPrompt() string {
 	}
 
 	result, err := prompt.Run()
-
 	if err != nil {
 		log.Errorf(configs.PromptFailedError, err)
 		return ""
@@ -225,7 +221,6 @@ func eth1WithdrawalPrompt() error {
 	}
 
 	result, err := prompt.Run()
-
 	if err != nil {
 		return fmt.Errorf(configs.PromptFailedError, err)
 	}

--- a/cli/keys_test.go
+++ b/cli/keys_test.go
@@ -78,7 +78,7 @@ func buildKeysTestCase(t *testing.T, caseName, caseNetwork string, mnemonic, isE
 }
 
 func TestKeysCmd(t *testing.T) {
-	//TODO: allow to test error programs
+	// TODO: allow to test error programs
 	tcs := []keysCmdTestCase{
 		*buildKeysTestCase(t, "case_1", "mainnet", false, false),
 		*buildKeysTestCase(t, "case_1", "mainnet", true, false),

--- a/cli/listClients_test.go
+++ b/cli/listClients_test.go
@@ -80,5 +80,4 @@ func TestListClientsCmd(t *testing.T) {
 			}
 		})
 	}
-
 }

--- a/cli/logs.go
+++ b/cli/logs.go
@@ -27,9 +27,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-var (
-	tail int
-)
+var tail int
 
 // logsCmd represents the logs command
 var logsCmd = &cobra.Command{

--- a/cli/logs_test.go
+++ b/cli/logs_test.go
@@ -89,7 +89,7 @@ func buildLogsTestCase(t *testing.T, testName string, tail int, services []strin
 
 	fdOut := new(bytes.Buffer)
 
-	//TODO: allow modification of the simple runner
+	// TODO: allow modification of the simple runner
 	runner := test.SimpleCMDRunner{
 		SRunCMD: func(c commands.Command) (string, error) {
 			if strings.Contains(c.Cmd, "docker compose") {

--- a/internal/pkg/clients/clients_test.go
+++ b/internal/pkg/clients/clients_test.go
@@ -25,7 +25,7 @@ import (
 // TODO: Add testcases for other networks
 
 func validateSupportedClients(t *testing.T, clientType string, supportedClients []string) {
-	//TODO: validate supported clients
+	// TODO: validate supported clients
 }
 
 func TestSupportedClients(t *testing.T) {
@@ -79,7 +79,7 @@ func cleanAll() {
 }
 
 func validateClients(resultClients OrderedClients, tc clientsTestCase) bool {
-	//Check if all query clients types are in the result types
+	// Check if all query clients types are in the result types
 Loop1:
 	for _, queryType := range tc.query {
 		for resultType := range resultClients {

--- a/internal/pkg/commands/commands_test.go
+++ b/internal/pkg/commands/commands_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func TestRunCmd(t *testing.T) {
-	//TODO: improve test and fix pty commands tests
+	// TODO: improve test and fix pty commands tests
 	inputs := []struct {
 		cmd       string
 		getOutput bool
@@ -124,7 +124,7 @@ func TestRunBashScript(t *testing.T) {
 	}
 }
 
-//TODO: add test cases for building and executing docker commands
+// TODO: add test cases for building and executing docker commands
 
 func TestBuildCommands(t *testing.T) {
 	inputs := [...]struct {

--- a/internal/pkg/generate/clean_scripts.go
+++ b/internal/pkg/generate/clean_scripts.go
@@ -11,13 +11,11 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-var (
-	protectedFlags = map[string]bool{
-		"bootnodes":             true,
-		"bootstrap-node":        true,
-		"fallback-web3provider": true,
-	}
-)
+var protectedFlags = map[string]bool{
+	"bootnodes":             true,
+	"bootstrap-node":        true,
+	"fallback-web3provider": true,
+}
 
 /*
 cleanFlags
@@ -224,7 +222,7 @@ func CleanEnvFile(envFilePath string) error {
 		return fmt.Errorf(configs.CleaningEnvFileError, err)
 	}
 
-	var ReENVVAR = regexp.MustCompile(`^ *(?P<VAR>[a-zA-Z0-9_]+) *= *(?P<VAL>.+) *$`) // Variable regex
+	ReENVVAR := regexp.MustCompile(`^ *(?P<VAR>[a-zA-Z0-9_]+) *= *(?P<VAL>.+) *$`) // Variable regex
 
 	// Find duplicated vars
 	existingVars := make(map[string]int, 0)

--- a/internal/pkg/generate/generate_config_test.go
+++ b/internal/pkg/generate/generate_config_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func validateGeneratedConfig(t *testing.T, path string) {
-	//TODO: validate generated config
+	// TODO: validate generated config
 }
 
 func TestGenerateConfig(t *testing.T) {

--- a/internal/pkg/generate/generate_scripts.go
+++ b/internal/pkg/generate/generate_scripts.go
@@ -49,7 +49,7 @@ Error if any
 func GenerateScripts(gd GenerationData) (result GenerationResults, err error) {
 	// Create scripts directory if not exists
 	if _, err := os.Stat(gd.GenerationPath); os.IsNotExist(err) {
-		err = os.MkdirAll(gd.GenerationPath, 0755)
+		err = os.MkdirAll(gd.GenerationPath, 0o755)
 		if err != nil {
 			return GenerationResults{}, err
 		}
@@ -367,7 +367,7 @@ func writeTemplateToFile(template *template.Template, file string, data interfac
 	var f *os.File
 
 	if append {
-		f, err = os.OpenFile(file, os.O_APPEND|os.O_WRONLY, 0666)
+		f, err = os.OpenFile(file, os.O_APPEND|os.O_WRONLY, 0o666)
 		if err != nil {
 			return fmt.Errorf(configs.CreatingFileError, file, err)
 		}

--- a/internal/pkg/generate/generate_scripts_test.go
+++ b/internal/pkg/generate/generate_scripts_test.go
@@ -77,7 +77,7 @@ func generateTestCases(t *testing.T) (tests []generateTestCase) {
 }
 
 func validateGeneratedFiles(t *testing.T, testCase generateTestCase) {
-	//TODO: validate generated files
+	// TODO: validate generated files
 }
 
 func TestGenerateScripts(t *testing.T) {

--- a/internal/ui/tables.go
+++ b/internal/ui/tables.go
@@ -78,7 +78,6 @@ returns :-
 None
 */
 func WriteRandomizedClientsTable(w io.Writer, data RandomizedClientsTable) {
-
 	headers := []*simpletable.Cell{
 		{Align: simpletable.AlignCenter, Text: "Type of Client"},
 		{Align: simpletable.AlignCenter, Text: "Randomized Client"},
@@ -123,9 +122,9 @@ returns :-
 None
 */
 func WriteSimpleTable(w io.Writer, data *SimpleTableData) {
-	//Initialize table
+	// Initialize table
 	table := simpletable.New()
-	//Get maxium dimensions
+	// Get maxium dimensions
 	n := 0
 	for _, column := range data.Columns {
 		if n < len(column) {
@@ -138,7 +137,7 @@ func WriteSimpleTable(w io.Writer, data *SimpleTableData) {
 		return
 	}
 
-	//Add headers to table
+	// Add headers to table
 	table.Header = &simpletable.Header{
 		Cells: data.Headers,
 	}
@@ -151,29 +150,29 @@ func WriteSimpleTable(w io.Writer, data *SimpleTableData) {
 
 	if len(data.Headers) > 0 { // Don't write rows if no headers are provided
 		for x := 0; x < n; x++ {
-			//Initialize new row
+			// Initialize new row
 			row := []*simpletable.Cell{}
-			if data.Enumerate { //Add row number cell
+			if data.Enumerate { // Add row number cell
 				row = append(row, &simpletable.Cell{
 					Align: simpletable.AlignCenter,
 					Text:  fmt.Sprint(x + 1),
 				})
 			}
 			for y := 0; y < m; y++ {
-				if y < len(data.Columns) && x < len(data.Columns[y]) { //Add existing cell to row
+				if y < len(data.Columns) && x < len(data.Columns[y]) { // Add existing cell to row
 					row = append(row, data.Columns[y][x])
-				} else { //Add empty cell to row
+				} else { // Add empty cell to row
 					row = append(row, &simpletable.Cell{
 						Align: data.DefaultAlign,
 						Text:  "-",
 					})
 				}
 			}
-			//Add new row to table
+			// Add new row to table
 			table.Body.Cells = append(table.Body.Cells, row)
 		}
 	}
-	//Print table
+	// Print table
 	table.SetStyle(simpletable.StyleCompact)
 	fmt.Fprintln(w, table.String())
 	fmt.Fprintln(w)

--- a/internal/utils/checks_test.go
+++ b/internal/utils/checks_test.go
@@ -130,7 +130,6 @@ func TestPreCheck(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-
 			descr := fmt.Sprintf("PreCheck(%s)", tc.path)
 			dPath, dcPath := "", ""
 

--- a/internal/utils/get_distro_test.go
+++ b/internal/utils/get_distro_test.go
@@ -29,7 +29,7 @@ func TestGetDistro(t *testing.T) {
 		t.Errorf("getOsInfo() failed: %v", err)
 	}
 
-	//TODO: validate distro info
+	// TODO: validate distro info
 }
 
 func TestGetDistroName(t *testing.T) {
@@ -41,5 +41,5 @@ func TestGetDistroName(t *testing.T) {
 		t.Errorf("GetDistroName() failed: %v", err)
 	}
 
-	//TODO: validate distro name
+	// TODO: validate distro name
 }

--- a/internal/utils/handle_dependencies.go
+++ b/internal/utils/handle_dependencies.go
@@ -62,7 +62,7 @@ func HandleInstructions(dependencies []string, handler func(string) error) (err 
 					return
 				}
 			} else {
-				//TODO: Get OS version for other OS like Windows and Darwin
+				// TODO: Get OS version for other OS like Windows and Darwin
 				OS = runtime.GOOS
 			}
 			log.Errorf(configs.InstallNotSupported, dependency, OS)

--- a/internal/utils/handle_dependencies_test.go
+++ b/internal/utils/handle_dependencies_test.go
@@ -58,7 +58,7 @@ func TestGetScriptPath(t *testing.T) {
 			if err != nil {
 				t.Errorf("%s failed: %v", descr, err)
 			} else {
-				//TODO: improve results tests
+				// TODO: improve results tests
 
 				// Check if path have correct format for dependency
 				match, err := regexp.MatchString(`^setup/.+/`+input.dependency+`/.*\.sh$`, path)
@@ -66,7 +66,7 @@ func TestGetScriptPath(t *testing.T) {
 					t.Errorf("returned path %s is invalid", path)
 				}
 
-				//TODO: validate if installation path distro is correct
+				// TODO: validate if installation path distro is correct
 			}
 		}
 
@@ -74,7 +74,7 @@ func TestGetScriptPath(t *testing.T) {
 }
 
 func TestDependencySupported(t *testing.T) {
-	if runtime.GOOS != "linux" { //TODO: update when other os's are supported
+	if runtime.GOOS != "linux" { // TODO: update when other os's are supported
 		t.Skipf("this os is not supported")
 	}
 

--- a/internal/utils/networks_test.go
+++ b/internal/utils/networks_test.go
@@ -25,7 +25,6 @@ var networks = []string{"mainnet", "kiln", "ropsten", "goerli", "sepolia", "denv
 
 func TestSupportedNetworks(t *testing.T) {
 	names, err := SupportedNetworks()
-
 	if err != nil {
 		t.Errorf("GetSupportedNetworks() failed, gave error: %v", err)
 	}

--- a/internal/utils/zip_test.go
+++ b/internal/utils/zip_test.go
@@ -45,7 +45,6 @@ Loop:
 			}
 		}
 	}
-
 }
 
 func TestZipStrings(t *testing.T) {


### PR DESCRIPTION
We will use `gofumpt`, which is a fork of the gofmt with steroids

## Changes:
- Add `gofumpt` for project formating.

## Types of changes
- [x] Code style update (formatting, renaming)

## Testing
**Requires testing**
- [x] No
