### PR TITLE
Change the execution endpoint in consensus (Prysm)

### DIFF
--- a/templates/services/merge/consensus/prysm.tmpl
+++ b/templates/services/merge/consensus/prysm.tmpl
@@ -41,7 +41,7 @@
       - --datadir=/var/lib/prysm/
       - --verbosity=${CC_LOG_LEVEL}
       - --p2p-max-peers=${CC_PEER_COUNT}
-      - --execution-endpoint=${EC_AUTH_URL}{{range $url := .FallbackELUrls}}
+      - --http-web3provider=${EC_AUTH_URL}{{range $url := .FallbackELUrls}}
       - --fallback-web3provider={{$url}}{{end}}
       - --accept-terms-of-use{{with .FeeRecipient}}
       - --suggested-fee-recipient=${CL_FEE_RECIPIENT}{{end}}


### PR DESCRIPTION
 ```--execution-endpoint``` flag was giving error so changing it with the ```--http-web3provider```

Error: 
```
time="2022-10-03T14:55:12Z" level=error msg="flag provided but not defined: -execution-endpoint" prefix=main
```

Fixes | Closes | Resolves #

> Anything marked as optional that you didn't need to fill in, please remove it from the PR description. Choose one of the keywords above to refer to the issue this PR solves, followed by the issue number (e.g Fixes # 666). If there is no issue, remove the line. Remove this note after reading.
## Changes:
-
## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [ ] Yes
- [ ] No

**In case you checked yes, did you write tests?**

- [ ] Yes
- [ ] No

**Comments about testing , should you have some** (optional)

## Further comments (optional)

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
