### PR TITLE
Add logging flag

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -61,7 +61,7 @@ var (
 	mapAllPorts       bool
 	noMev             bool
 	noValidator       bool
-	loggingDriver     string
+	loggingFlag       string
 )
 
 const (
@@ -163,8 +163,8 @@ func preRunCliCmd(cmd *cobra.Command, args []string) error {
 		validatorImage = strings.Join(validatorParts[1:], ":")
 	}
 
-	if loggingDriver == "none" {
-		loggingDriver = ""
+	if err := configs.ValidateLoggingFlag(loggingFlag); err != nil {
+		return err
 	}
 
 	return nil
@@ -260,7 +260,7 @@ func runCliCmd(cmd *cobra.Command, args []string) []error {
 		MapAllPorts:       mapAllPorts,
 		Mev:               !noMev && !noValidator,
 		MevImage:          mevImage,
-		LoggingDriver:     loggingDriver,
+		LoggingDriver:     configs.GetLoggingDriver(loggingFlag),
 	}
 	results, err := generate.GenerateScripts(gd)
 	if err != nil {
@@ -384,7 +384,7 @@ func init() {
 
 	vlExtraFlags = cliCmd.Flags().StringArray("vl-extra-flag", []string{}, "Additional flag to configure the validator client service in the generated docker-compose script. Example: 'sedge cli --vl-extra-flag \"<flag1>=value1\" --vl-extra-flag \"<flag2>=\\\"value2\\\"\"'")
 
-	cliCmd.Flags().StringVar(&loggingDriver, "logging", "json-file", "Docker logging driver used by all the services. Set 'none' to use the default docker logging driver")
+	cliCmd.Flags().StringVar(&loggingFlag, "logging", "json", fmt.Sprintf("Docker logging driver used by all the services. Set 'none' to use the default docker logging driver. Possible values: %v", configs.ValidLoggingFlags()))
 
 	// Initialize monitoring tool
 	initMonitor(func() MonitoringTool {

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -384,7 +384,7 @@ func init() {
 
 	vlExtraFlags = cliCmd.Flags().StringArray("vl-extra-flag", []string{}, "Additional flag to configure the validator client service in the generated docker-compose script. Example: 'sedge cli --vl-extra-flag \"<flag1>=value1\" --vl-extra-flag \"<flag2>=\\\"value2\\\"\"'")
 
-	cliCmd.Flags().StringVar(&loggingDriver, "logging", "json-file", "Docker logging driver used by all the services")
+	cliCmd.Flags().StringVar(&loggingDriver, "logging", "json-file", "Docker logging driver used by all the services. Set 'none' to use the default docker logging driver")
 
 	// Initialize monitoring tool
 	initMonitor(func() MonitoringTool {

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -61,6 +61,7 @@ var (
 	mapAllPorts       bool
 	noMev             bool
 	noValidator       bool
+	loggingDriver     string
 )
 
 const (
@@ -162,6 +163,10 @@ func preRunCliCmd(cmd *cobra.Command, args []string) error {
 		validatorImage = strings.Join(validatorParts[1:], ":")
 	}
 
+	if loggingDriver == "none" {
+		loggingDriver = ""
+	}
+
 	return nil
 }
 
@@ -255,6 +260,7 @@ func runCliCmd(cmd *cobra.Command, args []string) []error {
 		MapAllPorts:       mapAllPorts,
 		Mev:               !noMev && !noValidator,
 		MevImage:          mevImage,
+		LoggingDriver:     loggingDriver,
 	}
 	results, err := generate.GenerateScripts(gd)
 	if err != nil {
@@ -377,6 +383,8 @@ func init() {
 	clExtraFlags = cliCmd.Flags().StringArray("cl-extra-flag", []string{}, "Additional flag to configure the consensus client service in the generated docker-compose script. Example: 'sedge cli --cl-extra-flag \"<flag1>=value1\" --cl-extra-flag \"<flag2>=\\\"value2\\\"\"'")
 
 	vlExtraFlags = cliCmd.Flags().StringArray("vl-extra-flag", []string{}, "Additional flag to configure the validator client service in the generated docker-compose script. Example: 'sedge cli --vl-extra-flag \"<flag1>=value1\" --vl-extra-flag \"<flag2>=\\\"value2\\\"\"'")
+
+	cliCmd.Flags().StringVar(&loggingDriver, "logging", "json-file", "Docker logging driver used by all the services")
 
 	// Initialize monitoring tool
 	initMonitor(func() MonitoringTool {

--- a/cli/keys_test.go
+++ b/cli/keys_test.go
@@ -107,7 +107,8 @@ func TestKeysCmd(t *testing.T) {
 			tc.name,
 			func(t *testing.T) {
 				resetKeysCmd()
-				rootCmd.SetArgs([]string{"keys",
+				rootCmd.SetArgs([]string{
+					"keys",
 					"--config", tc.configPath,
 					"--network", tc.network,
 					"--path", tc.keystorePath,

--- a/configs/errors.go
+++ b/configs/errors.go
@@ -95,4 +95,5 @@ const (
 	DepositDataEncodingError          = "could not encode deposit data to json: %v"
 	InvalidNumberOfValidatorsError    = "invalid number of validators: %v"
 	NumberOfValidatorsRetryError      = "provided numbers do not match"
+	InvalidLoggingFlag                = "bad logging flag: %v"
 )

--- a/configs/init.go
+++ b/configs/init.go
@@ -15,9 +15,11 @@ limitations under the License.
 */
 package configs
 
+// TODO: Remove public level to this variable (NetworksConfigs), use getters to access instead
 var NetworksConfigs map[string]NetworkConfig
 
 func init() {
+	// TODO: This initialization can be made in the variable declaration
 	NetworksConfigs = map[string]NetworkConfig{
 		"mainnet": {
 			Name:               "mainnet",

--- a/configs/logging.go
+++ b/configs/logging.go
@@ -1,0 +1,27 @@
+package configs
+
+import "fmt"
+
+var loggingDrivers = map[string]string{
+	"none": "",
+	"json": "json-file",
+}
+
+func ValidateLoggingFlag(loggingFlag string) error {
+	if _, ok := loggingDrivers[loggingFlag]; !ok {
+		return fmt.Errorf(InvalidLoggingFlag, loggingFlag)
+	}
+	return nil
+}
+
+func GetLoggingDriver(loggingFlag string) string {
+	return loggingDrivers[loggingFlag]
+}
+
+func ValidLoggingFlags() []string {
+	flags := make([]string, 0, len(loggingDrivers))
+	for flag := range loggingDrivers {
+		flags = append(flags, flag)
+	}
+	return flags
+}

--- a/configs/logging.go
+++ b/configs/logging.go
@@ -7,6 +7,20 @@ var loggingDrivers = map[string]string{
 	"json": "json-file",
 }
 
+/*
+ValidateLoggingFlag:
+Validates the provider loggingFlag. A loggingFlag is valid
+if is exactly equal to supported flags, for example: none, json.
+
+params :-
+a. loggingFlag string
+Flag to validate.
+
+returns :-
+a. error
+If the provided flag is valid then this error will be nil when returns, in
+another case, the proper error is returned.
+*/
 func ValidateLoggingFlag(loggingFlag string) error {
 	if _, ok := loggingDrivers[loggingFlag]; !ok {
 		return fmt.Errorf(InvalidLoggingFlag, loggingFlag)
@@ -14,10 +28,31 @@ func ValidateLoggingFlag(loggingFlag string) error {
 	return nil
 }
 
+/*
+GetLoggingDriver:
+Returns the logging driver name assocaited with the provided logging flag. Panics
+if the loggingFlag is not valid.
+
+params :-
+a. loggingFlag string
+Flag of which want to know the associated driver.
+
+returns :-
+a. string
+The associated logging driver.
+*/
 func GetLoggingDriver(loggingFlag string) string {
 	return loggingDrivers[loggingFlag]
 }
 
+/*
+ValidLoggingFlags:
+Provides the list of supported logging flags.
+
+returns :-
+a. []string
+The list of supported logging flags.
+*/
 func ValidLoggingFlags() []string {
 	flags := make([]string, 0, len(loggingDrivers))
 	for flag := range loggingDrivers {

--- a/internal/pkg/generate/generate_scripts.go
+++ b/internal/pkg/generate/generate_scripts.go
@@ -248,6 +248,7 @@ func generateDockerComposeScripts(gd GenerationData) (dockerComposePath string, 
 		MapAllPorts:         gd.MapAllPorts,
 		SplittedNetwork:     splittedNetwork,
 		ClCheckpointSyncUrl: clCheckpointSyncUrl,
+		LoggingDriver:       gd.LoggingDriver,
 	}
 
 	dockerComposePath = filepath.Join(gd.GenerationPath, configs.DefaultDockerComposeScriptName)

--- a/internal/pkg/generate/types.go
+++ b/internal/pkg/generate/types.go
@@ -56,6 +56,7 @@ type GenerationData struct {
 	MevImage          string
 	Ports             map[string]string
 	Graffiti          string
+	LoggingDriver     string
 }
 
 // DockerComposeData : Struct Data object to be applied to docker-compose script
@@ -93,6 +94,7 @@ type DockerComposeData struct {
 	MapAllPorts         bool
 	SplittedNetwork     bool
 	ClCheckpointSyncUrl bool
+	LoggingDriver       string
 }
 
 // GenerationResults: Struct for storing results of the generation process

--- a/internal/pkg/keystores/keystore_external_utils.go
+++ b/internal/pkg/keystores/keystore_external_utils.go
@@ -157,7 +157,6 @@ func NewWalletWriter(entries uint64, passphrase string) *WalletWriter {
 		entries:           make([]*KeyEntry, entries),
 		generalPassphrase: passphrase,
 	}
-
 }
 
 func (ww *WalletWriter) InsertAccount(priv e2types.PrivateKey, keyPath string, insecure bool, idx uint64) error {
@@ -191,7 +190,7 @@ func (ww *WalletWriter) WriteOutputs(fpath string) error {
 			}
 			keystoreFilename := fmt.Sprintf("keystore-%s.json", strings.ReplaceAll(e.path, "/", "_"))
 			{
-				if err := os.WriteFile(filepath.Join(valKeysPath, keystoreFilename), dat, 0644); err != nil {
+				if err := os.WriteFile(filepath.Join(valKeysPath, keystoreFilename), dat, 0o644); err != nil {
 					return err
 				}
 			}
@@ -200,7 +199,7 @@ func (ww *WalletWriter) WriteOutputs(fpath string) error {
 	}
 	// Write passphrase file
 	passFileName := "keystore_password.txt"
-	if err := os.WriteFile(filepath.Join(fpath, passFileName), []byte(ww.generalPassphrase), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(fpath, passFileName), []byte(ww.generalPassphrase), 0o644); err != nil {
 		return err
 	}
 
@@ -233,7 +232,6 @@ func selectVals(sourceMnemonic string,
 	output WalletOutput,
 	insecure bool,
 ) error {
-
 	valSeed, err := mnemonicToSeed(sourceMnemonic)
 	if err != nil {
 		return err
@@ -376,7 +374,7 @@ func CreateDepositData(
 		depositData.WriteString("]")
 	}
 
-	err = os.WriteFile(depositPath, depositData.Bytes(), 0644)
+	err = os.WriteFile(depositPath, depositData.Bytes(), 0o644)
 	if err != nil {
 		return fmt.Errorf(configs.DepositFileWriteError, err)
 	}

--- a/internal/utils/version.go
+++ b/internal/utils/version.go
@@ -18,9 +18,10 @@ package utils
 import (
 	"context"
 	"errors"
+	"text/template"
+
 	"github.com/NethermindEth/sedge/internal/pkg/commands"
 	"github.com/google/go-github/v47/github"
-	"text/template"
 )
 
 const (

--- a/templates/services/docker-compose_base.tmpl
+++ b/templates/services/docker-compose_base.tmpl
@@ -27,10 +27,10 @@ services:
     command: >
       sh -c "{{if or .CcRemoteCfg .VlRemoteCfg }}wget -O /tmp/app/config.yml ${CONFIG_URL};{{end}}{{if or .CcRemoteGen .VlRemoteGen }}wget -O /tmp/app/genesis.ssz ${GENESIS_URL};{{end}}{{if or .CcRemoteDpl .VlRemoteDpl }}echo -n ${DEPLOY_BLOCK} > /tmp/app/deploy_block.txt;{{end}}"{{end}}{{if .LoggingDriver}}
     logging:
-      driver: "{{.LoggingDriver}}"
+      driver: "{{.LoggingDriver}}"{{if eq .LoggingDriver "json-file"}}
       options:
         max-size: "10m"
-        max-file: "10"{{end}}
+        max-file: "10"{{end}}{{end}}
 {{template "consensus" .}}
 {{template "validator" .}}
 

--- a/templates/services/docker-compose_base.tmpl
+++ b/templates/services/docker-compose_base.tmpl
@@ -25,7 +25,12 @@ services:
     volumes:
       - ./:/tmp/app
     command: >
-      sh -c "{{if or .CcRemoteCfg .VlRemoteCfg }}wget -O /tmp/app/config.yml ${CONFIG_URL};{{end}}{{if or .CcRemoteGen .VlRemoteGen }}wget -O /tmp/app/genesis.ssz ${GENESIS_URL};{{end}}{{if or .CcRemoteDpl .VlRemoteDpl }}echo -n ${DEPLOY_BLOCK} > /tmp/app/deploy_block.txt;{{end}}"{{end}}
+      sh -c "{{if or .CcRemoteCfg .VlRemoteCfg }}wget -O /tmp/app/config.yml ${CONFIG_URL};{{end}}{{if or .CcRemoteGen .VlRemoteGen }}wget -O /tmp/app/genesis.ssz ${GENESIS_URL};{{end}}{{if or .CcRemoteDpl .VlRemoteDpl }}echo -n ${DEPLOY_BLOCK} > /tmp/app/deploy_block.txt;{{end}}"{{end}}{{if .LoggingDriver}}
+    logging:
+      driver: "{{.LoggingDriver}}"
+      options:
+        max-size: "10m"
+        max-file: "10"{{end}}
 {{template "consensus" .}}
 {{template "validator" .}}
 

--- a/templates/services/merge/consensus/lighthouse.tmpl
+++ b/templates/services/merge/consensus/lighthouse.tmpl
@@ -54,8 +54,8 @@
       - --{{$flag}}{{end}}{{if .Mev}}
       - --builder=http://mevboost:{{.MevPort}}{{end}}{{if .LoggingDriver}}
     logging:
-      driver: "{{.LoggingDriver}}"
+      driver: "{{.LoggingDriver}}"{{if eq .LoggingDriver "json-file"}}
       options:
         max-size: "10m"
-        max-file: "10"{{end}}
+        max-file: "10"{{end}}{{end}}
 {{ end }}

--- a/templates/services/merge/consensus/lighthouse.tmpl
+++ b/templates/services/merge/consensus/lighthouse.tmpl
@@ -52,10 +52,10 @@
       - --metrics-address=0.0.0.0{{if or .ClCheckpointSyncUrl .CheckpointSyncUrl}}
       - --checkpoint-sync-url={{if .CheckpointSyncUrl}}{{ .CheckpointSyncUrl }}{{else}}${CHECKPOINT_SYNC_URL}{{end}}{{end}}{{range $flag := .ClExtraFlags}}
       - --{{$flag}}{{end}}{{if .Mev}}
-      - --builder=http://mevboost:{{.MevPort}}{{end}}
+      - --builder=http://mevboost:{{.MevPort}}{{end}}{{if .LoggingDriver}}
     logging:
-      driver: "json-file"
+      driver: "{{.LoggingDriver}}"
       options:
         max-size: "10m"
-        max-file: "10"
+        max-file: "10"{{end}}
 {{ end }}

--- a/templates/services/merge/consensus/lodestar.tmpl
+++ b/templates/services/merge/consensus/lodestar.tmpl
@@ -55,8 +55,8 @@
       - --builder=true
       - --builder.urls http://mevboost:{{.MevPort}}{{end}}{{if .LoggingDriver}}
     logging:
-      driver: "{{.LoggingDriver}}"
+      driver: "{{.LoggingDriver}}"{{if eq .LoggingDriver "json-file"}}
       options:
         max-size: "10m"
-        max-file: "10"{{end}}
+        max-file: "10"{{end}}{{end}}
 {{ end }}

--- a/templates/services/merge/consensus/lodestar.tmpl
+++ b/templates/services/merge/consensus/lodestar.tmpl
@@ -53,10 +53,10 @@
       - --checkpointSyncUrl={{if .CheckpointSyncUrl}}{{ .CheckpointSyncUrl }}{{else}}${CHECKPOINT_SYNC_URL}{{end}}{{end}}{{range $flag := .ClExtraFlags}}
       - --{{$flag}}{{end}}{{if .Mev}}
       - --builder=true
-      - --builder.urls http://mevboost:{{.MevPort}}{{end}}
+      - --builder.urls http://mevboost:{{.MevPort}}{{end}}{{if .LoggingDriver}}
     logging:
-      driver: "json-file"
+      driver: "{{.LoggingDriver}}"
       options:
         max-size: "10m"
-        max-file: "10"
+        max-file: "10"{{end}}
 {{ end }}

--- a/templates/services/merge/consensus/prysm.tmpl
+++ b/templates/services/merge/consensus/prysm.tmpl
@@ -52,8 +52,8 @@
       - --{{$flag}}{{end}}{{if .Mev}}
       - --http-mev-relay=http://mevboost:{{.MevPort}}{{end}}{{if .LoggingDriver}}
     logging:
-      driver: "{{.LoggingDriver}}"
+      driver: "{{.LoggingDriver}}"{{if eq .LoggingDriver "json-file"}}
       options:
         max-size: "10m"
-        max-file: "10"{{end}}
+        max-file: "10"{{end}}{{end}}
 {{ end }}

--- a/templates/services/merge/consensus/prysm.tmpl
+++ b/templates/services/merge/consensus/prysm.tmpl
@@ -50,10 +50,10 @@
       - --checkpoint-sync-url={{if .CheckpointSyncUrl}}{{ .CheckpointSyncUrl }}{{else}}${CHECKPOINT_SYNC_URL}{{end}}
       - --genesis-beacon-api-url={{if .CheckpointSyncUrl}}{{ .CheckpointSyncUrl }}{{else}}${CHECKPOINT_SYNC_URL}{{end}}{{end}}{{range $flag := .ClExtraFlags}}
       - --{{$flag}}{{end}}{{if .Mev}}
-      - --http-mev-relay=http://mevboost:{{.MevPort}}{{end}}
+      - --http-mev-relay=http://mevboost:{{.MevPort}}{{end}}{{if .LoggingDriver}}
     logging:
-      driver: "json-file"
+      driver: "{{.LoggingDriver}}"
       options:
         max-size: "10m"
-        max-file: "10"
+        max-file: "10"{{end}}
 {{ end }}

--- a/templates/services/merge/consensus/teku.tmpl
+++ b/templates/services/merge/consensus/teku.tmpl
@@ -56,10 +56,10 @@
       - --initial-state={{if .CheckpointSyncUrl}}{{ .CheckpointSyncUrl }}{{else}}${CHECKPOINT_SYNC_URL}{{end}}/eth/v2/debug/beacon/states/finalized{{end}}{{range $flag := .ClExtraFlags}}
       - --{{$flag}}{{end}}{{if .Mev}}
       - --builder-endpoint=http://mevboost:{{.MevPort}}{{end}}{{if .XeeVersion}}
-      - --Xee-version=${XEE_VERSION}{{end}}
+      - --Xee-version=${XEE_VERSION}{{end}}{{if .LoggingDriver}}
     logging:
-      driver: "json-file"
+      driver: "{{.LoggingDriver}}"
       options:
         max-size: "10m"
-        max-file: "10"
+        max-file: "10"{{end}}
 {{ end }}

--- a/templates/services/merge/consensus/teku.tmpl
+++ b/templates/services/merge/consensus/teku.tmpl
@@ -58,8 +58,8 @@
       - --builder-endpoint=http://mevboost:{{.MevPort}}{{end}}{{if .XeeVersion}}
       - --Xee-version=${XEE_VERSION}{{end}}{{if .LoggingDriver}}
     logging:
-      driver: "{{.LoggingDriver}}"
+      driver: "{{.LoggingDriver}}"{{if eq .LoggingDriver "json-file"}}
       options:
         max-size: "10m"
-        max-file: "10"{{end}}
+        max-file: "10"{{end}}{{end}}
 {{ end }}

--- a/templates/services/merge/execution/geth.tmpl
+++ b/templates/services/merge/execution/geth.tmpl
@@ -47,10 +47,10 @@
       - --authrpc.vhosts=*
       - ${EC_METRICS_ENABLED:-""}
       - --metrics.port={{.ElMetricsPort}}{{range $flag := .ElExtraFlags}}
-      - --{{$flag}}{{end}}
+      - --{{$flag}}{{end}}{{if .LoggingDriver}}
     logging:
-      driver: "json-file"
+      driver: "{{.LoggingDriver}}"
       options:
         max-size: "10m"
-        max-file: "10"
+        max-file: "10"{{end}}
 {{ end }}

--- a/templates/services/merge/execution/geth.tmpl
+++ b/templates/services/merge/execution/geth.tmpl
@@ -49,8 +49,8 @@
       - --metrics.port={{.ElMetricsPort}}{{range $flag := .ElExtraFlags}}
       - --{{$flag}}{{end}}{{if .LoggingDriver}}
     logging:
-      driver: "{{.LoggingDriver}}"
+      driver: "{{.LoggingDriver}}"{{if eq .LoggingDriver "json-file"}}
       options:
         max-size: "10m"
-        max-file: "10"{{end}}
+        max-file: "10"{{end}}{{end}}
 {{ end }}

--- a/templates/services/merge/execution/nethermind.tmpl
+++ b/templates/services/merge/execution/nethermind.tmpl
@@ -34,10 +34,10 @@
       - --Network.DiscoveryPort={{.ElDiscoveryPort}}
       - --HealthChecks.Enabled=${NETHERMIND_HEALTH_CHECKS_ENABLED}
       - --Pruning.CacheMb=${NETHERMIND_PRUNING_CACHEMB}{{range $flag := .ElExtraFlags}}
-      - --{{$flag}}{{end}}
+      - --{{$flag}}{{end}}{{if .LoggingDriver}}
     logging:
-      driver: "json-file"
+      driver: "{{.LoggingDriver}}"
       options:
         max-size: "10m"
-        max-file: "10"
+        max-file: "10"{{end}}
 {{ end }}

--- a/templates/services/merge/execution/nethermind.tmpl
+++ b/templates/services/merge/execution/nethermind.tmpl
@@ -36,8 +36,8 @@
       - --Pruning.CacheMb=${NETHERMIND_PRUNING_CACHEMB}{{range $flag := .ElExtraFlags}}
       - --{{$flag}}{{end}}{{if .LoggingDriver}}
     logging:
-      driver: "{{.LoggingDriver}}"
+      driver: "{{.LoggingDriver}}"{{if eq .LoggingDriver "json-file"}}
       options:
         max-size: "10m"
-        max-file: "10"{{end}}
+        max-file: "10"{{end}}{{end}}
 {{ end }}

--- a/templates/services/merge/validator/lighthouse.tmpl
+++ b/templates/services/merge/validator/lighthouse.tmpl
@@ -16,10 +16,10 @@
       - ${KEYSTORE_DIR}:/keystore
       - ${VL_DATA_DIR}:/data{{if .LoggingDriver}}
     logging:
-      driver: "{{.LoggingDriver}}"
+      driver: "{{.LoggingDriver}}"{{if eq .LoggingDriver "json-file"}}
       options:
         max-size: "10m"
-        max-file: "10"{{end}}
+        max-file: "10"{{end}}{{end}}
 
   validator:
     container_name: validator-client
@@ -52,8 +52,8 @@
       - --{{$flag}}{{end}}{{if .Mev}}
       - --builder-proposals{{end}}{{if .LoggingDriver}}
     logging:
-      driver: "{{.LoggingDriver}}"
+      driver: "{{.LoggingDriver}}"{{if eq .LoggingDriver "json-file"}}
       options:
         max-size: "10m"
-        max-file: "10"{{end}}
+        max-file: "10"{{end}}{{end}}
 {{ end }}

--- a/templates/services/merge/validator/lighthouse.tmpl
+++ b/templates/services/merge/validator/lighthouse.tmpl
@@ -14,7 +14,12 @@
       - sedge
     volumes:
       - ${KEYSTORE_DIR}:/keystore
-      - ${VL_DATA_DIR}:/data 
+      - ${VL_DATA_DIR}:/data{{if .LoggingDriver}}
+    logging:
+      driver: "{{.LoggingDriver}}"
+      options:
+        max-size: "10m"
+        max-file: "10"{{end}}
 
   validator:
     container_name: validator-client
@@ -45,10 +50,10 @@
       - --metrics-port={{.VlMetricsPort}}
       - --metrics-address=0.0.0.0{{range $flag := .VlExtraFlags}}
       - --{{$flag}}{{end}}{{if .Mev}}
-      - --builder-proposals{{end}}
+      - --builder-proposals{{end}}{{if .LoggingDriver}}
     logging:
-      driver: "json-file"
+      driver: "{{.LoggingDriver}}"
       options:
         max-size: "10m"
-        max-file: "10"
+        max-file: "10"{{end}}
 {{ end }}

--- a/templates/services/merge/validator/lodestar.tmpl
+++ b/templates/services/merge/validator/lodestar.tmpl
@@ -53,8 +53,8 @@
       - --builder=true{{end}}
       - --graffiti=${GRAFFITI}{{if .LoggingDriver}}
     logging:
-      driver: "{{.LoggingDriver}}"
+      driver: "{{.LoggingDriver}}"{{if eq .LoggingDriver "json-file"}}
       options:
         max-size: "10m"
-        max-file: "10"{{end}}
+        max-file: "10"{{end}}{{end}}
 {{ end }}

--- a/templates/services/merge/validator/lodestar.tmpl
+++ b/templates/services/merge/validator/lodestar.tmpl
@@ -20,7 +20,12 @@
       --paramsFile /network_config/config.yaml{{end}}
       --dataDir=/data
       --importKeystores=/keystore/validator_keys
-      --importKeystoresPassword=/keystore/keystore_password.txt
+      --importKeystoresPassword=/keystore/keystore_password.txt{{if .LoggingDriver}}
+    logging:
+      driver: "{{.LoggingDriver}}"
+      options:
+        max-size: "10m"
+        max-file: "10"{{end}}
   validator:
     container_name: validator-client
     image: ${VL_IMAGE_VERSION}
@@ -46,10 +51,10 @@
       - --suggestedFeeRecipient=${CL_FEE_RECIPIENT}{{end}}{{range $flag := .VlExtraFlags}}
       - --{{$flag}}{{end}}{{if .Mev}}
       - --builder=true{{end}}
-      - --graffiti=${GRAFFITI}
+      - --graffiti=${GRAFFITI}{{if .LoggingDriver}}
     logging:
-      driver: "json-file"
+      driver: "{{.LoggingDriver}}"
       options:
         max-size: "10m"
-        max-file: "10"
+        max-file: "10"{{end}}
 {{ end }}

--- a/templates/services/merge/validator/prysm.tmpl
+++ b/templates/services/merge/validator/prysm.tmpl
@@ -22,10 +22,10 @@
       --wallet-password-file=/keystore/keystore_password.txt
       --account-password-file=/keystore/keystore_password.txt{{if .LoggingDriver}}
     logging:
-      driver: "{{.LoggingDriver}}"
+      driver: "{{.LoggingDriver}}"{{if eq .LoggingDriver "json-file"}}
       options:
         max-size: "10m"
-        max-file: "10"{{end}}
+        max-file: "10"{{end}}{{end}}
 
   validator:
     container_name: validator-client
@@ -58,8 +58,8 @@
       - --enable-builder
       - --enable-validator-registration{{end}}{{if .LoggingDriver}}
     logging:
-      driver: "{{.LoggingDriver}}"
+      driver: "{{.LoggingDriver}}"{{if eq .LoggingDriver "json-file"}}
       options:
         max-size: "10m"
-        max-file: "10"{{end}}
+        max-file: "10"{{end}}{{end}}
 {{ end }}

--- a/templates/services/merge/validator/prysm.tmpl
+++ b/templates/services/merge/validator/prysm.tmpl
@@ -20,7 +20,12 @@
       --keys-dir=/keystore/validator_keys
       --wallet-dir=/data/wallet
       --wallet-password-file=/keystore/keystore_password.txt
-      --account-password-file=/keystore/keystore_password.txt
+      --account-password-file=/keystore/keystore_password.txt{{if .LoggingDriver}}
+    logging:
+      driver: "{{.LoggingDriver}}"
+      options:
+        max-size: "10m"
+        max-file: "10"{{end}}
 
   validator:
     container_name: validator-client
@@ -51,10 +56,10 @@
       - --{{$flag}}{{end}}{{with .FeeRecipient}}
       - --suggested-fee-recipient=${CL_FEE_RECIPIENT}{{end}}{{if .Mev}}
       - --enable-builder
-      - --enable-validator-registration{{end}}
+      - --enable-validator-registration{{end}}{{if .LoggingDriver}}
     logging:
-      driver: "json-file"
+      driver: "{{.LoggingDriver}}"
       options:
         max-size: "10m"
-        max-file: "10"
+        max-file: "10"{{end}}
 {{ end }}

--- a/templates/services/merge/validator/teku.tmpl
+++ b/templates/services/merge/validator/teku.tmpl
@@ -9,7 +9,12 @@
         condition: service_completed_successfully{{end}}
     volumes:
       - ${VL_DATA_DIR}:/data
-      - ${KEYSTORE_DIR}:/keystore
+      - ${KEYSTORE_DIR}:/keystore{{if .LoggingDriver}}
+    logging:
+      driver: "{{.LoggingDriver}}"
+      options:
+        max-size: "10m"
+        max-file: "10"{{end}}
 
   validator:
     container_name: validator-client
@@ -42,10 +47,10 @@
       - --validators-proposer-default-fee-recipient=${CL_FEE_RECIPIENT}{{end}}{{range $flag := .VlExtraFlags}}
       - --{{$flag}}{{end}}{{if .Mev}}
       - --validators-builder-registration-default-enabled=true
-      - --Xvalidators-builder-registration-default-gas-limit=29000000{{end}}
+      - --Xvalidators-builder-registration-default-gas-limit=29000000{{end}}{{if .LoggingDriver}}
     logging:
-      driver: "json-file"
+      driver: "{{.LoggingDriver}}"
       options:
         max-size: "10m"
-        max-file: "10"
+        max-file: "10"{{end}}
 {{ end }}

--- a/templates/services/merge/validator/teku.tmpl
+++ b/templates/services/merge/validator/teku.tmpl
@@ -49,8 +49,8 @@
       - --validators-builder-registration-default-enabled=true
       - --Xvalidators-builder-registration-default-gas-limit=29000000{{end}}{{if .LoggingDriver}}
     logging:
-      driver: "{{.LoggingDriver}}"
+      driver: "{{.LoggingDriver}}"{{if eq .LoggingDriver "json-file"}}
       options:
         max-size: "10m"
-        max-file: "10"{{end}}
+        max-file: "10"{{end}}{{end}}
 {{ end }}


### PR DESCRIPTION
Currently, some services have `json-file` as the logging driver, and others not, to improve logging driver configuration the `--logging` flag is added. If `--logging` flag is not `none` the logging section is generated for each service, using the provided value as the driver name. The default value is `json`.

### Generate without logging section
```
sedge cli --logging none
```

### Generate with `json-file` logging driver
```
sedge cli
```
or
```
sedge cli --logging json
```

## Changes:
- New flag: `--logging`
- Update the logging section in all service templates

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [ ] Yes
- [ ] No

**In case you checked yes, did you write tests?**

- [ ] Yes
- [ ] No
