### PR TITLE
Add missing depends_on tag to lodestar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Added missing `depends_on` tag to lodestar validator
 - Fixed wrong fork version in Gnosis network config
 
 ## [v0.4.0] - 2022-10-25

--- a/templates/services/merge/validator/lodestar.tmpl
+++ b/templates/services/merge/validator/lodestar.tmpl
@@ -29,6 +29,9 @@
   validator:
     container_name: validator-client
     image: ${VL_IMAGE_VERSION}
+    depends_on:
+      validator-import:
+        condition: service_completed_successfully
     networks:
       - sedge
     ports:


### PR DESCRIPTION
Resolves #176 
Resolves #175 

## Changes:
- Add missing depends_on tag to lodestar validator client

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
