### PR TITLE
[Fix] AssignPorts test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix inconsistent behavior of `AssignPorts` function test.
+
 ## [v0.5.1] - 2022-12-2
 
 ### Fixed
@@ -30,7 +34,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add missing `depends_on` tag to lodestar validator.
 - Fix wrong fork version in Gnosis network config.
-- Fix inconsistent behavior of `AssignPorts` function test
 
 ## [v0.4.0] - 2022-10-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add checkpoint sync url for Chiado.
 
-### Changed 
+### Changed
 
 - Update Gnosis and Chiado networks default clients images to merge ready versions.
 - Update client versions.
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add missing `depends_on` tag to lodestar validator.
 - Fix wrong fork version in Gnosis network config.
+- Fix inconsistent behavior of `AssignPorts` function test
 
 ## [v0.4.0] - 2022-10-25
 

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -222,7 +222,7 @@ func buildCliTestCase(
 		"ELApi": configs.DefaultApiPortEL,
 		"CLApi": configs.DefaultApiPortCL,
 	}
-	ports, err := utils.AssingPorts("localhost", defaultsPorts)
+	ports, err := utils.AssignPorts("localhost", defaultsPorts)
 	if err != nil {
 		t.Fatalf(configs.PortOccupationError, err)
 	}

--- a/internal/pkg/generate/generate_scripts.go
+++ b/internal/pkg/generate/generate_scripts.go
@@ -69,7 +69,7 @@ func GenerateScripts(gd GenerationData) (result GenerationResults, err error) {
 		"VLMetrics":       configs.DefaultMetricsPortVL,
 		"MevPort":         configs.DefaultMevPort,
 	}
-	ports, err := utils.AssingPorts("localhost", defaultsPorts)
+	ports, err := utils.AssignPorts("localhost", defaultsPorts)
 	if err != nil {
 		return GenerationResults{}, fmt.Errorf(configs.PortOccupationError, err)
 	}

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"net"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -135,7 +136,14 @@ func AssignPorts(host string, defaults map[string]string) (ports map[string]stri
 	ports = make(map[string]string)
 	mask := make(map[string]bool)
 
-	for k, v := range defaults {
+	keys := make([]string, 0, len(defaults))
+	for k := range defaults {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for _, k := range keys {
+		v := defaults[k]
 		if v == "" {
 			return ports, fmt.Errorf(configs.DefaultPortEmptyError, k)
 		}

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -118,7 +118,7 @@ func IsAddress(a string) bool {
 }
 
 /*
-AssingPorts :
+AssignPorts :
 Checks if port is occupied in a given host
 
 params :-
@@ -131,7 +131,7 @@ returns :-
 a. bool
 True if <port> is available. False otherwise
 */
-func AssingPorts(host string, defaults map[string]string) (ports map[string]string, err error) {
+func AssignPorts(host string, defaults map[string]string) (ports map[string]string, err error) {
 	ports = make(map[string]string)
 	mask := make(map[string]bool)
 
@@ -169,7 +169,7 @@ a. bool
 True if <port> is available. False otherwise
 */
 func portAvailable(host, port string, timeout time.Duration) bool {
-	log.Debugf("Checking port ocuppation of %s\n", net.JoinHostPort(host, port))
+	log.Debugf("Checking port occupation of %s\n", net.JoinHostPort(host, port))
 	conn, err := net.DialTimeout("tcp", net.JoinHostPort(host, port), timeout)
 	if err != nil {
 		log.Debugf("Port seems available, got connecting error: %v", err)

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -163,7 +163,7 @@ func TestPortAvailable(t *testing.T) {
 	}
 }
 
-func TestAssingPorts(t *testing.T) {
+func TestAssignPorts(t *testing.T) {
 	server := httptest.NewServer(
 		http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 			rw.WriteHeader(http.StatusOK)
@@ -219,7 +219,7 @@ func TestAssingPorts(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := AssingPorts(tc.host, tc.defaults)
+			got, err := AssignPorts(tc.host, tc.defaults)
 
 			descr := fmt.Sprintf("AssingPorts(%s, %+v)", tc.host, tc.defaults)
 			if cerr := CheckErr(descr, tc.isErr, err); cerr != nil {


### PR DESCRIPTION
Currently, the `AssignPorts` test behavior isn't consistent, and the main reason is the way _default ports_ map keys are traversed during a port assignation because Go doesn't traverse the keys in order. To avoid this keys are sorted now before processing them.

## Changes:
- Fix some typos
- Update the `AssignPorts` util function

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)

## Testing
**Requires testing**

- [x] Yes

**In case you checked yes, did you write tests?**

- [x] No, because tests are already written 

