### PR TITLE
Custom testnets configuration fixes

### DIFF
--- a/templates/envs/chiado/consensus/lighthouse.tmpl
+++ b/templates/envs/chiado/consensus/lighthouse.tmpl
@@ -14,7 +14,6 @@ CL_BOOTNODES="enr:-L64QOijsdi9aVIawMb5h5PWueaPM9Ai6P17GNPFlHzz7MGJQ8tFMdYrEx8WQi
 CONFIG_URL=https://github.com/gnosischain/configs/raw/main/chiado/config.yaml
 GENESIS_URL=https://github.com/gnosischain/configs/raw/main/chiado/genesis.ssz
 DEPLOY_BLOCK=0
-CHECKPOINT_SYNC_URL=https://chiado.checkpoint-sync.nethermind.io
 {{ end }}
 
 

--- a/templates/envs/chiado/consensus/lighthouse.tmpl
+++ b/templates/envs/chiado/consensus/lighthouse.tmpl
@@ -14,7 +14,7 @@ CL_BOOTNODES="enr:-L64QOijsdi9aVIawMb5h5PWueaPM9Ai6P17GNPFlHzz7MGJQ8tFMdYrEx8WQi
 CONFIG_URL=https://github.com/gnosischain/configs/raw/main/chiado/config.yaml
 GENESIS_URL=https://github.com/gnosischain/configs/raw/main/chiado/genesis.ssz
 DEPLOY_BLOCK=0
-CHECKPOINT_SYNC_URL=https://beacon.chiadochain.net/checkpoint-sync
+CHECKPOINT_SYNC_URL=https://chiado.checkpoint-sync.nethermind.io
 {{ end }}
 
 

--- a/templates/envs/chiado/consensus/lodestar.tmpl
+++ b/templates/envs/chiado/consensus/lodestar.tmpl
@@ -15,5 +15,5 @@ CC_LODESTAR_PRESET=gnosis
 CONFIG_URL=https://github.com/gnosischain/configs/raw/main/chiado/config.yaml
 GENESIS_URL=https://github.com/gnosischain/configs/raw/main/chiado/genesis.ssz
 DEPLOY_BLOCK=0
-CHECKPOINT_SYNC_URL=https://beacon.chiadochain.net/checkpoint-sync
+CHECKPOINT_SYNC_URL=https://chiado.checkpoint-sync.nethermind.io
 {{ end }}

--- a/templates/envs/chiado/consensus/lodestar.tmpl
+++ b/templates/envs/chiado/consensus/lodestar.tmpl
@@ -15,5 +15,4 @@ CC_LODESTAR_PRESET=gnosis
 CONFIG_URL=https://github.com/gnosischain/configs/raw/main/chiado/config.yaml
 GENESIS_URL=https://github.com/gnosischain/configs/raw/main/chiado/genesis.ssz
 DEPLOY_BLOCK=0
-CHECKPOINT_SYNC_URL=https://chiado.checkpoint-sync.nethermind.io
 {{ end }}

--- a/templates/envs/chiado/consensus/teku.tmpl
+++ b/templates/envs/chiado/consensus/teku.tmpl
@@ -14,5 +14,4 @@ CL_BOOTNODES="enr:-L64QOijsdi9aVIawMb5h5PWueaPM9Ai6P17GNPFlHzz7MGJQ8tFMdYrEx8WQi
 CONFIG_URL=https://github.com/gnosischain/configs/raw/main/chiado/config.yaml
 GENESIS_URL=https://github.com/gnosischain/configs/raw/main/chiado/genesis.ssz
 DEPLOY_BLOCK=0
-CHECKPOINT_SYNC_URL=https://chiado.checkpoint-sync.nethermind.io
 {{ end }}

--- a/templates/envs/chiado/consensus/teku.tmpl
+++ b/templates/envs/chiado/consensus/teku.tmpl
@@ -14,5 +14,5 @@ CL_BOOTNODES="enr:-L64QOijsdi9aVIawMb5h5PWueaPM9Ai6P17GNPFlHzz7MGJQ8tFMdYrEx8WQi
 CONFIG_URL=https://github.com/gnosischain/configs/raw/main/chiado/config.yaml
 GENESIS_URL=https://github.com/gnosischain/configs/raw/main/chiado/genesis.ssz
 DEPLOY_BLOCK=0
-CHECKPOINT_SYNC_URL=https://beacon.chiadochain.net/checkpoint-sync
+CHECKPOINT_SYNC_URL=https://chiado.checkpoint-sync.nethermind.io
 {{ end }}

--- a/templates/services/merge/validator/lighthouse.tmpl
+++ b/templates/services/merge/validator/lighthouse.tmpl
@@ -6,7 +6,7 @@
       context: github.com/NethermindEth/lighthouse-init-validator
       args:
         LH_VERSION: ${VL_IMAGE_VERSION}
-        NETWORK: {{if .SplittedNetwork}}${CL_NETWORK}{{else}}${NETWORK}{{end}}{{with .VlCustomCfg}}
+        NETWORK: {{if .VlCustomCfg}}CUSTOM{{else}}{{if .SplittedNetwork}}${CL_NETWORK}{{else}}${NETWORK}{{end}}{{end}}{{with .VlCustomCfg}}
     depends_on:
       config_consensus:
         condition: service_completed_successfully{{end}}
@@ -14,7 +14,10 @@
       - sedge
     volumes:
       - ${KEYSTORE_DIR}:/keystore
-      - ${VL_DATA_DIR}:/data{{if .LoggingDriver}}
+      - ${VL_DATA_DIR}:/data{{if .VlCustomCfg}}{{if .VlRemoteCfg}}
+      - ./config.yml:/network_config/config.yaml{{end}}{{if .VlRemoteGen}}
+      - ./genesis.ssz:/network_config/genesis.ssz{{end}}{{if .VlRemoteDpl}}
+      - ./deploy_block.txt:/network_config/deploy_block.txt{{end}}{{end}}{{if .LoggingDriver}}
     logging:
       driver: "{{.LoggingDriver}}"{{if eq .LoggingDriver "json-file"}}
       options:

--- a/templates/services/merge/validator/lodestar.tmpl
+++ b/templates/services/merge/validator/lodestar.tmpl
@@ -15,7 +15,8 @@
       - ./genesis.ssz:/network_config/genesis.ssz{{end}}{{if .VlRemoteDpl}}
       - ./deploy_block.txt:/network_config/deploy_block.txt{{end}}{{end}}
     command: |
-      validator import{{if not .VlCustomCfg}}
+      validator import
+      --preset=${VL_LODESTAR_PRESET}{{if not .VlCustomCfg}}
       --network={{if .SplittedNetwork}}${CL_NETWORK}{{else}}${NETWORK}{{end}}{{else}}
       --paramsFile /network_config/config.yaml{{end}}
       --dataDir=/data
@@ -41,7 +42,8 @@
       - ./config.yml:/network_config/config.yml{{end}}{{if .VlRemoteGen}}
       - ./genesis.ssz:/network_config/genesis.ssz{{end}}{{end}}
     command: 
-      - validator{{if .VlCustomCfg}}{{if .VlRemoteCfg}}
+      - validator
+      - --preset=${VL_LODESTAR_PRESET}{{if .VlCustomCfg}}{{if .VlRemoteCfg}}
       - --paramsFile=/network_config/config.yml{{end}}{{else}}
       - --network={{if .SplittedNetwork}}${CL_NETWORK}{{else}}${NETWORK}{{end}}{{end}}
       - --dataDir=/data/validator


### PR DESCRIPTION
Custom testnet configuration was not working for LH `validator-import`, and Lodestar `validator` and `validator-import`services.

## Changes:
- Update [lighthouse-init-validator](https://github.com/NethermindEth/lighthouse-init-validator) to get custom `config.yaml`.
- Update Lodestar validators flags to provide `preset`.
- 
## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)

## Testing
**Requires testing**

- [x] Yes
- [ ] No

**In case you checked yes, did you write tests?**

- [ ] Yes
- [x] No

**Comments about testing , should you have some** (optional)

Manually tested using Chiado network