### PR TITLE
Add --externalcl flag to erigon in mainnet

### DIFF
--- a/internal/pkg/generate/generate_scripts.go
+++ b/internal/pkg/generate/generate_scripts.go
@@ -261,6 +261,7 @@ func ComposeFile(gd *GenData, at io.Writer) error {
 
 	data := DockerComposeData{
 		Services:            gd.Services,
+		Network:             gd.Network,
 		TTD:                 ttd,
 		XeeVersion:          xeeVersion,
 		Mev:                 gd.MevBoostService || (mevSupported && gd.Mev) || gd.MevBoostOnValidator,

--- a/internal/pkg/generate/types.go
+++ b/internal/pkg/generate/types.go
@@ -81,6 +81,7 @@ type GenData struct {
 // DockerComposeData : Struct Data object to be applied to docker-compose script
 type DockerComposeData struct {
 	Services                []string
+	Network                 string
 	TTD                     string
 	XeeVersion              bool
 	Mev                     bool

--- a/templates/services/merge/execution/erigon.tmpl
+++ b/templates/services/merge/execution/erigon.tmpl
@@ -22,7 +22,8 @@
     user: root
     command:
     - erigon{{if .TTD}}
-    - --override.terminaltotaldifficulty={{.TTD}}{{end}}
+    - --override.terminaltotaldifficulty={{.TTD}}{{end}}{{if eq .Network "mainnet"}}
+    - --externalcl{{end}}
     - --http
     - --http.addr=0.0.0.0
     - --http.port={{.ElApiPort}}


### PR DESCRIPTION
## Changes:
- Add --externalcl flag to erigon in mainnet to let it connect with external CL clients instead of connecting to new internal one.
## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] New feature (non-breaking change which adds functionality)

## Testing
**Requires testing**

- [x] Yes
- [ ] No

**In case you checked yes, did you write tests?**

- [ ] Yes
- [x] No

**Comments about testing , should you have some** (optional)

Manual tested. Some unit tests checking if this flag is generated only for mainnet should be added later.