### PR TITLE
Fix error when sedge logs command is interrupted

### DIFF
--- a/cli/actions/importKeys.go
+++ b/cli/actions/importKeys.go
@@ -249,7 +249,7 @@ func setupLighthouseValidatorImport(dockerClient client.APIClient, serviceManage
 		},
 	})
 	log.Infof(configs.RunningCommand, buildCmd.Cmd)
-	if _, err = commandRunner.RunCMD(buildCmd); err != nil {
+	if _, _, err = commandRunner.RunCMD(buildCmd); err != nil {
 		return "", err
 	}
 	mounts := []mount.Mount{
@@ -311,7 +311,7 @@ func setupTekuValidatorImport(dockerClient client.APIClient, serviceManager serv
 		Tag:  "sedge/validator-import-teku",
 	})
 	log.Infof(configs.RunningCommand, buildCmd.Cmd)
-	if _, err := commandRunner.RunCMD(buildCmd); err != nil {
+	if _, _, err := commandRunner.RunCMD(buildCmd); err != nil {
 		return "", err
 	}
 	// Mounts

--- a/cli/actions/run.go
+++ b/cli/actions/run.go
@@ -34,6 +34,6 @@ func (s *sedgeActions) RunContainers(options RunContainersOptions) error {
 		Services: options.Services,
 	})
 	log.Infof(configs.RunningCommand, upCmd.Cmd)
-	_, err := s.commandRunner.RunCMD(upCmd)
+	_, _, err := s.commandRunner.RunCMD(upCmd)
 	return err
 }

--- a/cli/actions/run_test.go
+++ b/cli/actions/run_test.go
@@ -52,9 +52,9 @@ func TestRunContainers(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			commandRunner := &test.SimpleCMDRunner{
-				SRunCMD: func(c commands.Command) (string, error) {
+				SRunCMD: func(c commands.Command) (string, int, error) {
 					assert.Equal(t, tc.expectedCommand, c.Cmd)
-					return "", nil
+					return "", 0, nil
 				},
 			}
 			sedgeActions := actions.NewSedgeActions(actions.SedgeActionsOptions{

--- a/cli/actions/setup.go
+++ b/cli/actions/setup.go
@@ -35,7 +35,7 @@ func (s *sedgeActions) SetupContainers(options SetupContainersOptions) error {
 		Services: options.Services,
 	})
 	log.Infof(configs.RunningCommand, buildCmd.Cmd)
-	if _, err := s.commandRunner.RunCMD(buildCmd); err != nil {
+	if _, _, err := s.commandRunner.RunCMD(buildCmd); err != nil {
 		return err
 	}
 	pullCmd := s.commandRunner.BuildDockerComposePullCMD(commands.DockerComposePullOptions{
@@ -43,7 +43,7 @@ func (s *sedgeActions) SetupContainers(options SetupContainersOptions) error {
 		Services: options.Services,
 	})
 	log.Infof(configs.RunningCommand, pullCmd.Cmd)
-	if _, err := s.commandRunner.RunCMD(pullCmd); err != nil {
+	if _, _, err := s.commandRunner.RunCMD(pullCmd); err != nil {
 		return err
 	}
 	createCmd := s.commandRunner.BuildDockerComposeCreateCMD(commands.DockerComposeCreateOptions{
@@ -51,7 +51,7 @@ func (s *sedgeActions) SetupContainers(options SetupContainersOptions) error {
 		Services: options.Services,
 	})
 	log.Infof(configs.RunningCommand, createCmd.Cmd)
-	if _, err := s.commandRunner.RunCMD(createCmd); err != nil {
+	if _, _, err := s.commandRunner.RunCMD(createCmd); err != nil {
 		return err
 	}
 	return nil

--- a/cli/actions/setup_test.go
+++ b/cli/actions/setup_test.go
@@ -58,9 +58,9 @@ func TestSetupContainers(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			commandRunner := &test.SimpleCMDRunner{
-				SRunCMD: func(c commands.Command) (string, error) {
+				SRunCMD: func(c commands.Command) (string, int, error) {
 					assert.Contains(t, []string{tc.expectedBuildCmd, tc.expectedPullCmd, tc.expectedCreateCmd}, c.Cmd)
-					return "", nil
+					return "", 0, nil
 				},
 			}
 			sedgeActions := actions.NewSedgeActions(actions.SedgeActionsOptions{

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -192,14 +192,14 @@ func buildCliTestCase(
 
 	// TODO: allow runner edition
 	tc.runner = &test.SimpleCMDRunner{
-		SRunCMD: func(c commands.Command) (string, error) {
+		SRunCMD: func(c commands.Command) (string, int, error) {
 			// For getContainerIP logic
 			if strings.Contains(c.Cmd, "ps --quiet") {
-				return "666", nil
+				return "666", 0, nil
 			} else if strings.Contains(c.Cmd, "docker inspect 666") {
-				return inspectOut, nil
+				return inspectOut, 0, nil
 			}
-			return "", nil
+			return "", 0, nil
 		},
 		SRunBash: func(bs commands.ScriptFile) (string, error) {
 			return "", nil

--- a/cli/cli_utils.go
+++ b/cli/cli_utils.go
@@ -245,7 +245,7 @@ func checkRunDependencies(cmdRunner commands.CommandRunner, generationPath strin
 	})
 	psCMD.GetOutput = true
 	log.Infof(configs.RunningCommand, psCMD.Cmd)
-	if _, err := cmdRunner.RunCMD(psCMD); err != nil {
+	if _, _, err := cmdRunner.RunCMD(psCMD); err != nil {
 		return fmt.Errorf(configs.DockerEngineOffError, err)
 	}
 	// Check that compose plugin is installed with docker running 'docker compose ps'
@@ -254,7 +254,7 @@ func checkRunDependencies(cmdRunner commands.CommandRunner, generationPath strin
 	})
 	log.Debugf(configs.RunningCommand, dockerComposePsCMD.Cmd)
 	dockerComposePsCMD.GetOutput = true
-	_, err := cmdRunner.RunCMD(dockerComposePsCMD)
+	_, _, err := cmdRunner.RunCMD(dockerComposePsCMD)
 	if err != nil {
 		return fmt.Errorf(configs.DockerComposeOffError, err)
 	}
@@ -268,7 +268,7 @@ func buildImages(cmdRunner commands.CommandRunner, services []string, generation
 		Services: services,
 	})
 	log.Infof(configs.RunningCommand, buildCmd.Cmd)
-	if _, err := cmdRunner.RunCMD(buildCmd); err != nil {
+	if _, _, err := cmdRunner.RunCMD(buildCmd); err != nil {
 		return fmt.Errorf(configs.CommandError, buildCmd.Cmd, err)
 	}
 	return nil
@@ -281,14 +281,14 @@ func downloadImages(cmdRunner commands.CommandRunner, services []string, generat
 		Services: services,
 	})
 	log.Infof(configs.RunningCommand, pullCmd.Cmd)
-	if _, err := cmdRunner.RunCMD(pullCmd); err != nil {
+	if _, _, err := cmdRunner.RunCMD(pullCmd); err != nil {
 		return fmt.Errorf(configs.CommandError, pullCmd.Cmd, err)
 	}
 	return nil
 }
 
 func createContainers(cmdRunner commands.CommandRunner, services []string, generationPath string) error {
-	if _, err := cmdRunner.RunCMD(cmdRunner.BuildDockerComposeCreateCMD(commands.DockerComposeCreateOptions{
+	if _, _, err := cmdRunner.RunCMD(cmdRunner.BuildDockerComposeCreateCMD(commands.DockerComposeCreateOptions{
 		Path:     filepath.Join(generationPath, configs.DefaultDockerComposeScriptName),
 		Services: services,
 	})); err != nil {
@@ -321,7 +321,7 @@ func runAndShowContainers(cmdRunner commands.CommandRunner, services []string, f
 		Services: services,
 	})
 	log.Infof(configs.RunningCommand, upCMD.Cmd)
-	if _, err := cmdRunner.RunCMD(upCMD); err != nil {
+	if _, _, err := cmdRunner.RunCMD(upCMD); err != nil {
 		return fmt.Errorf(configs.CommandError, upCMD.Cmd, err)
 	}
 
@@ -331,7 +331,7 @@ func runAndShowContainers(cmdRunner commands.CommandRunner, services []string, f
 		FilterRunning: true,
 	})
 	log.Infof(configs.RunningCommand, dcpsCMD.Cmd)
-	if _, err := cmdRunner.RunCMD(dcpsCMD); err != nil {
+	if _, _, err := cmdRunner.RunCMD(dcpsCMD); err != nil {
 		return fmt.Errorf(configs.CommandError, dcpsCMD.Cmd, err)
 	}
 

--- a/cli/down.go
+++ b/cli/down.go
@@ -53,7 +53,7 @@ func DownCmd(cmdRunner commands.CommandRunner) *cobra.Command {
 			})
 
 			log.Debugf(configs.RunningCommand, downCMD.Cmd)
-			if _, err := cmdRunner.RunCMD(downCMD); err != nil {
+			if _, _, err := cmdRunner.RunCMD(downCMD); err != nil {
 				return fmt.Errorf(configs.CommandError, downCMD.Cmd, err)
 			}
 

--- a/cli/down_test.go
+++ b/cli/down_test.go
@@ -56,8 +56,8 @@ func buildDownTestCase(t *testing.T, caseName string, isErr bool) *downCmdTestCa
 
 	// TODO: allow runner edition
 	tc.runner = &test.SimpleCMDRunner{
-		SRunCMD: func(c commands.Command) (string, error) {
-			return "", nil
+		SRunCMD: func(c commands.Command) (string, int, error) {
+			return "", 0, nil
 		},
 		SRunBash: func(bs commands.ScriptFile) (string, error) {
 			return "", nil
@@ -99,11 +99,11 @@ func TestDown_Error(t *testing.T) {
 	// docker compose ps error, PreCheck error
 	desc := "docker compose ps error, PreCheck error"
 	runner := &test.SimpleCMDRunner{
-		SRunCMD: func(c commands.Command) (string, error) {
+		SRunCMD: func(c commands.Command) (string, int, error) {
 			if strings.Contains(c.Cmd, "docker compose") && strings.Contains(c.Cmd, "ps") {
-				return "", errors.New("runner error")
+				return "", 1, errors.New("runner error")
 			}
-			return "", nil
+			return "", 0, nil
 		},
 		SRunBash: func(bs commands.ScriptFile) (string, error) {
 			return "", nil
@@ -125,11 +125,11 @@ func TestDown_Error(t *testing.T) {
 	// docker compose ps --status running error, Check Containers error
 	desc = "docker compose ps --status running error, Check Containers error"
 	runner = &test.SimpleCMDRunner{
-		SRunCMD: func(c commands.Command) (string, error) {
+		SRunCMD: func(c commands.Command) (string, int, error) {
 			if strings.Contains(c.Cmd, "docker compose") && strings.Contains(c.Cmd, "ps") && strings.Contains(c.Cmd, "--filter status=running") {
-				return "", errors.New("runner error")
+				return "", 1, errors.New("runner error")
 			}
-			return "", nil
+			return "", 0, nil
 		},
 		SRunBash: func(bs commands.ScriptFile) (string, error) {
 			return "", nil
@@ -150,11 +150,11 @@ func TestDown_Error(t *testing.T) {
 	// docker compose down error
 	desc = "docker compose down error"
 	runner = &test.SimpleCMDRunner{
-		SRunCMD: func(c commands.Command) (string, error) {
+		SRunCMD: func(c commands.Command) (string, int, error) {
 			if strings.Contains(c.Cmd, "docker compose") && strings.Contains(c.Cmd, "down") {
-				return "", errors.New("runner error")
+				return "", 1, errors.New("runner error")
 			}
-			return "", nil
+			return "", 0, nil
 		},
 		SRunBash: func(bs commands.ScriptFile) (string, error) {
 			return "", nil
@@ -175,8 +175,8 @@ func TestDown_Error(t *testing.T) {
 	// Generation path error
 	desc = "Generation path error"
 	runner = &test.SimpleCMDRunner{
-		SRunCMD: func(c commands.Command) (string, error) {
-			return "", nil
+		SRunCMD: func(c commands.Command) (string, int, error) {
+			return "", 0, nil
 		},
 		SRunBash: func(bs commands.ScriptFile) (string, error) {
 			return "", nil

--- a/cli/keys.go
+++ b/cli/keys.go
@@ -176,7 +176,7 @@ func saveMnemonic(cmdRunner commands.CommandRunner, mnemonic string) error {
 	})
 	openTextEditorCmd.ForceNoSudo = true
 
-	_, err = cmdRunner.RunCMD(openTextEditorCmd)
+	_, _, err = cmdRunner.RunCMD(openTextEditorCmd)
 	if err != nil {
 		return fmt.Errorf(configs.ShowMnemonicError, err)
 	}

--- a/cli/logs.go
+++ b/cli/logs.go
@@ -71,10 +71,15 @@ func LogsCmd(cmdRunner commands.CommandRunner) *cobra.Command {
 			})
 
 			log.Debugf(configs.RunningCommand, logsCMD.Cmd)
-			if _, err := cmdRunner.RunCMD(logsCMD); err != nil {
+			_, exitCode, err := cmdRunner.RunCMD(logsCMD)
+			if exitCode == 130 {
+				// A job with exit code 130 was terminated with signal 2 (SIGINT on most systems).
+				// Process interrupted by user (Ctrl+C)
+				return nil
+			}
+			if err != nil {
 				return fmt.Errorf(configs.GettingLogsError, strings.Join(services, " "), err)
 			}
-
 			return nil
 		},
 	}

--- a/cli/logs_test.go
+++ b/cli/logs_test.go
@@ -73,11 +73,11 @@ func buildLogsTestCase(t *testing.T, testName string, tail int, services []strin
 
 	// TODO: allow modification of the simple runner
 	runner := test.SimpleCMDRunner{
-		SRunCMD: func(c commands.Command) (string, error) {
+		SRunCMD: func(c commands.Command) (string, int, error) {
 			if strings.Contains(c.Cmd, "docker compose") {
 				if strings.Contains(c.Cmd, "logs") {
 					tc.dcLogsRuns += 1
-					return "some logs", nil
+					return "some logs", 0, nil
 				}
 				if strings.Contains(c.Cmd, "ps") {
 					tc.dcPsRuns += 1
@@ -85,10 +85,10 @@ func buildLogsTestCase(t *testing.T, testName string, tail int, services []strin
 					----------------------------------------------------------------------------
 					execution            bash              Up                  0.0.0.0:80->80/tcp
 					consensus            bash              Up                  0.0.0.0:80->80/tcp
-					validator            bash              Up                  0.0.0.0:80->80/tcp`, nil
+					validator            bash              Up                  0.0.0.0:80->80/tcp`, 0, nil
 				}
 			}
-			return "", nil
+			return "", 0, nil
 		},
 		SRunBash: func(bs commands.ScriptFile) (string, error) {
 			return "", nil
@@ -158,11 +158,11 @@ func TestLogs_Error(t *testing.T) {
 	// docker compose ps error, PreCheck error
 	desc := "docker compose ps error, PreCheck error"
 	runner := &test.SimpleCMDRunner{
-		SRunCMD: func(c commands.Command) (string, error) {
+		SRunCMD: func(c commands.Command) (string, int, error) {
 			if strings.Contains(c.Cmd, "docker compose") && strings.Contains(c.Cmd, "ps") {
-				return "", errors.New("runner error")
+				return "", 1, errors.New("runner error")
 			}
-			return "", nil
+			return "", 0, nil
 		},
 		SRunBash: func(bs commands.ScriptFile) (string, error) {
 			return "", nil
@@ -184,11 +184,11 @@ func TestLogs_Error(t *testing.T) {
 	// docker compose ps --status running error, Check Containers error
 	desc = "docker compose ps --status running error, Check Containers error"
 	runner = &test.SimpleCMDRunner{
-		SRunCMD: func(c commands.Command) (string, error) {
+		SRunCMD: func(c commands.Command) (string, int, error) {
 			if strings.Contains(c.Cmd, "docker compose") && strings.Contains(c.Cmd, "ps") && strings.Contains(c.Cmd, "--filter status=running") {
-				return "", errors.New("runner error")
+				return "", 1, errors.New("runner error")
 			}
-			return "", nil
+			return "", 0, nil
 		},
 		SRunBash: func(bs commands.ScriptFile) (string, error) {
 			return "", nil
@@ -209,11 +209,11 @@ func TestLogs_Error(t *testing.T) {
 	// docker compose down error
 	desc = "docker compose down error"
 	runner = &test.SimpleCMDRunner{
-		SRunCMD: func(c commands.Command) (string, error) {
+		SRunCMD: func(c commands.Command) (string, int, error) {
 			if strings.Contains(c.Cmd, "docker compose") && strings.Contains(c.Cmd, "down") {
-				return "", errors.New("runner error")
+				return "", 1, errors.New("runner error")
 			}
-			return "", nil
+			return "", 0, nil
 		},
 		SRunBash: func(bs commands.ScriptFile) (string, error) {
 			return "", nil
@@ -234,8 +234,8 @@ func TestLogs_Error(t *testing.T) {
 	// Generation path error
 	desc = "Generation path error"
 	runner = &test.SimpleCMDRunner{
-		SRunCMD: func(c commands.Command) (string, error) {
-			return "", nil
+		SRunCMD: func(c commands.Command) (string, int, error) {
+			return "", 0, nil
 		},
 		SRunBash: func(bs commands.ScriptFile) (string, error) {
 			return "", nil

--- a/internal/pkg/commands/cmd_runner_helper_unix.go
+++ b/internal/pkg/commands/cmd_runner_helper_unix.go
@@ -42,7 +42,7 @@ The output of the command.
 b. error
 Error if any
 */
-func runCmd(cmd string, getOutput bool) (out string, err error) {
+func runCmd(cmd string, getOutput bool) (out string, exitCode int, err error) {
 	r := strings.ReplaceAll(cmd, "\n", "")
 	spl := strings.Split(r, " ")
 	c, args := spl[0], spl[1:]
@@ -66,6 +66,7 @@ func runCmd(cmd string, getOutput bool) (out string, err error) {
 	}
 	// Return this error at the end as we need to check if the output from stderr is to be returned
 	err = exc.Wait()
+	exitCode = exc.ProcessState.ExitCode()
 
 	if getOutput {
 		out = combinedOut.String()

--- a/internal/pkg/commands/cmd_runner_unix.go
+++ b/internal/pkg/commands/cmd_runner_unix.go
@@ -170,7 +170,7 @@ func (cr *UnixCMDRunner) BuildOpenTextEditor(options OpenTextEditorOptions) Comm
 	return Command{Cmd: fmt.Sprintf("less %s", options.FilePath)}
 }
 
-func (cr *UnixCMDRunner) RunCMD(cmd Command) (string, error) {
+func (cr *UnixCMDRunner) RunCMD(cmd Command) (string, int, error) {
 	if cr.RunWithSudo && !cmd.ForceNoSudo {
 		log.Debug(`Running command with sudo.`)
 		cmd.Cmd = fmt.Sprintf("sudo %s", cmd.Cmd)

--- a/internal/pkg/commands/cmd_runner_windows.go
+++ b/internal/pkg/commands/cmd_runner_windows.go
@@ -196,7 +196,7 @@ func (cr *WindowsCMDRunner) RunCMD(cmd Command) (string, int, error) {
 	}
 
 	if err := exc.Start(); err != nil {
-		return out, err
+		return out, -1, err
 	}
 
 	err := exc.Wait()

--- a/internal/pkg/commands/cmd_runner_windows.go
+++ b/internal/pkg/commands/cmd_runner_windows.go
@@ -173,7 +173,7 @@ func (cr *WindowsCMDRunner) BuildOpenTextEditor(options OpenTextEditorOptions) C
 	return Command{Cmd: fmt.Sprintf("notepad %s", options.FilePath), IgnoreTerminal: true}
 }
 
-func (cr *WindowsCMDRunner) RunCMD(cmd Command) (string, error) {
+func (cr *WindowsCMDRunner) RunCMD(cmd Command) (string, int, error) {
 	var out string
 	r := strings.ReplaceAll(cmd.Cmd, "\n", "")
 
@@ -200,12 +200,13 @@ func (cr *WindowsCMDRunner) RunCMD(cmd Command) (string, error) {
 	}
 
 	err := exc.Wait()
+	exitCode := exc.ProcessState.ExitCode()
 	if cmd.GetOutput {
 		out = combinedOut.String()
 		out = strings.ReplaceAll(out, "\r", "") // Remove windows \r character
 	}
 
-	return out, err
+	return out, exitCode, err
 }
 
 func (cr *WindowsCMDRunner) RunScript(script ScriptFile) (string, error) {

--- a/internal/pkg/commands/commands.go
+++ b/internal/pkg/commands/commands.go
@@ -44,7 +44,7 @@ type CommandRunner interface {
 
 	BuildOpenTextEditor(options OpenTextEditorOptions) Command
 
-	RunCMD(cmd Command) (string, error)
+	RunCMD(cmd Command) (string, int, error)
 
 	RunScript(script ScriptFile) (string, error)
 }

--- a/internal/pkg/commands/commands_unix_test.go
+++ b/internal/pkg/commands/commands_unix_test.go
@@ -51,7 +51,7 @@ func TestRunCmd(t *testing.T) {
 	for _, input := range inputs {
 		descr := fmt.Sprintf("RunCmd(%s,%t)", input.cmd, input.getOutput)
 
-		got, err := runner.RunCMD(Command{
+		got, _, err := runner.RunCMD(Command{
 			Cmd:       input.cmd,
 			GetOutput: input.getOutput,
 		})

--- a/internal/pkg/commands/commands_windows_test.go
+++ b/internal/pkg/commands/commands_windows_test.go
@@ -51,7 +51,7 @@ func TestRunCmd(t *testing.T) {
 	for _, input := range inputs {
 		descr := fmt.Sprintf("RunCmd(%s,%t)", input.cmd, input.getOutput)
 
-		got, err := runner.RunCMD(Command{
+		got, _, err := runner.RunCMD(Command{
 			Cmd:       input.cmd,
 			GetOutput: input.getOutput,
 		})

--- a/internal/utils/checks.go
+++ b/internal/utils/checks.go
@@ -75,7 +75,7 @@ func PreCheck(cmdRunner commands.CommandRunner, generationPath string) error {
 	dockerPsCMD := cmdRunner.BuildDockerPSCMD(commands.DockerPSOptions{All: true})
 	log.Debugf(configs.RunningCommand, dockerPsCMD.Cmd)
 	dockerPsCMD.GetOutput = true
-	_, err := cmdRunner.RunCMD(dockerPsCMD)
+	_, _, err := cmdRunner.RunCMD(dockerPsCMD)
 	if err != nil {
 		return fmt.Errorf(configs.DockerEngineOffError, err)
 	}
@@ -91,7 +91,7 @@ func PreCheck(cmdRunner commands.CommandRunner, generationPath string) error {
 	dockerComposePsCMD := cmdRunner.BuildDockerComposePSCMD(commands.DockerComposePsOptions{Path: file})
 	log.Debugf(configs.RunningCommand, dockerComposePsCMD.Cmd)
 	dockerComposePsCMD.GetOutput = true
-	_, err = cmdRunner.RunCMD(dockerComposePsCMD)
+	_, _, err = cmdRunner.RunCMD(dockerComposePsCMD)
 	if err != nil {
 		return fmt.Errorf(configs.DockerComposeOffError, err)
 	}
@@ -122,7 +122,7 @@ func CheckContainers(cmdRunner commands.CommandRunner, generationPath string) (s
 	})
 	log.Debugf(configs.RunningCommand, psCMD.Cmd)
 	psCMD.GetOutput = true
-	rawServices, err := cmdRunner.RunCMD(psCMD)
+	rawServices, _, err := cmdRunner.RunCMD(psCMD)
 	if err != nil || rawServices == "\n" {
 		if rawServices == "\n" && err == nil {
 			err = fmt.Errorf(configs.DockerComposePsReturnedEmptyError)

--- a/internal/utils/checks_test.go
+++ b/internal/utils/checks_test.go
@@ -90,8 +90,8 @@ func TestPreCheck(t *testing.T) {
 			caseTestDataDir: "case_1",
 			path:            t.TempDir(),
 			runner: &test.SimpleCMDRunner{
-				SRunCMD: func(c commands.Command) (string, error) {
-					return "", nil
+				SRunCMD: func(c commands.Command) (string, int, error) {
+					return "", 0, nil
 				},
 				SRunBash: func(bs commands.ScriptFile) (string, error) {
 					return "", nil
@@ -106,8 +106,8 @@ func TestPreCheck(t *testing.T) {
 			caseTestDataDir: "case_1",
 			path:            t.TempDir(),
 			runner: &test.SimpleCMDRunner{
-				SRunCMD: func(c commands.Command) (string, error) {
-					return "", nil
+				SRunCMD: func(c commands.Command) (string, int, error) {
+					return "", 0, nil
 				},
 				SRunBash: func(bs commands.ScriptFile) (string, error) {
 					return "", nil
@@ -120,8 +120,8 @@ func TestPreCheck(t *testing.T) {
 			caseTestDataDir: "case_2",
 			path:            t.TempDir(),
 			runner: &test.SimpleCMDRunner{
-				SRunCMD: func(c commands.Command) (string, error) {
-					return "", nil
+				SRunCMD: func(c commands.Command) (string, int, error) {
+					return "", 0, nil
 				},
 				SRunBash: func(bs commands.ScriptFile) (string, error) {
 					return "", nil
@@ -134,8 +134,8 @@ func TestPreCheck(t *testing.T) {
 			caseTestDataDir: "case_1",
 			path:            t.TempDir(),
 			runner: &test.SimpleCMDRunner{
-				SRunCMD: func(c commands.Command) (string, error) {
-					return "", fmt.Errorf("test unknown error")
+				SRunCMD: func(c commands.Command) (string, int, error) {
+					return "", 1, fmt.Errorf("test unknown error")
 				},
 				SRunBash: func(bs commands.ScriptFile) (string, error) {
 					return "", nil
@@ -198,13 +198,13 @@ func buildCheckContainersTestCase(t *testing.T, caseName string, isErr bool) *ch
 	tc := checkContainersTC{}
 	tc.path = dcPath
 	tc.runner = &test.SimpleCMDRunner{
-		SRunCMD: func(c commands.Command) (string, error) {
+		SRunCMD: func(c commands.Command) (string, int, error) {
 			if strings.Contains(c.Cmd, "docker compose") && strings.Contains(c.Cmd, "ps") {
 				tc.psRunned += 1
 				_, err := os.Lstat(filepath.Join(dcPath, configs.DefaultDockerComposeScriptName))
-				return "", err
+				return "", 1, err
 			}
-			return "", nil
+			return "", 0, nil
 		},
 		SRunBash: func(bs commands.ScriptFile) (string, error) {
 			return "", nil

--- a/internal/utils/handle_dependencies_test.go
+++ b/internal/utils/handle_dependencies_test.go
@@ -215,8 +215,8 @@ func TestInstallDependency(t *testing.T) {
 		{
 			dependency: "docker",
 			runner: &test.SimpleCMDRunner{
-				SRunCMD: func(c commands.Command) (string, error) {
-					return "", nil
+				SRunCMD: func(c commands.Command) (string, int, error) {
+					return "", 0, nil
 				},
 				SRunBash: func(bs commands.ScriptFile) (string, error) {
 					return "", nil
@@ -227,8 +227,8 @@ func TestInstallDependency(t *testing.T) {
 		{
 			dependency: "docker-compose",
 			runner: &test.SimpleCMDRunner{
-				SRunCMD: func(c commands.Command) (string, error) {
-					return "", nil
+				SRunCMD: func(c commands.Command) (string, int, error) {
+					return "", 0, nil
 				},
 				SRunBash: func(bs commands.ScriptFile) (string, error) {
 					return "", fmt.Errorf("test unexpected error")
@@ -239,8 +239,8 @@ func TestInstallDependency(t *testing.T) {
 		{
 			dependency: "docker-comp0se",
 			runner: &test.SimpleCMDRunner{
-				SRunCMD: func(c commands.Command) (string, error) {
-					return "", nil
+				SRunCMD: func(c commands.Command) (string, int, error) {
+					return "", 0, nil
 				},
 				SRunBash: func(bs commands.ScriptFile) (string, error) {
 					return "", nil

--- a/test/test.go
+++ b/test/test.go
@@ -58,7 +58,7 @@ func DeleteFakeDep(depPath string) {
 
 // Struct for creating a commands.CommandRunner mocks
 type SimpleCMDRunner struct {
-	SRunCMD  func(commands.Command) (string, error)
+	SRunCMD  func(commands.Command) (string, int, error)
 	SRunBash func(commands.ScriptFile) (string, error)
 }
 
@@ -160,9 +160,9 @@ func (cr *SimpleCMDRunner) BuildOpenTextEditor(options commands.OpenTextEditorOp
 	return r.BuildOpenTextEditor(options)
 }
 
-func (cr *SimpleCMDRunner) RunCMD(cmd commands.Command) (string, error) {
+func (cr *SimpleCMDRunner) RunCMD(cmd commands.Command) (string, int, error) {
 	if cr.SRunCMD == nil {
-		return "", nil
+		return "", 0, nil
 	}
 	return cr.SRunCMD(cmd)
 }


### PR DESCRIPTION
## Changes:
- Add `exitCode` to `CommandRunner`.`RunCMD` 
- Fix the error when the user interrupts logs in the `sedge logs` command.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)