### PR TITLE
Fix containers showing wrong

### DIFF
--- a/cli/actions/generation_test.go
+++ b/cli/actions/generation_test.go
@@ -357,9 +357,9 @@ func TestGenerateDockerCompose(t *testing.T) {
 				if tc.genData.ConsensusClient != nil {
 					// Check that the consensus-health service is set.
 					assert.NotNil(t, cmpData.Services.ConsensusHealth)
+					// Check that the consensus-health image is set.
+					assert.Equal(t, "alpine/curl:latest", cmpData.Services.ConsensusHealth.Image)
 				}
-				// Check that the consensus-health image is set.
-				assert.Equal(t, "alpine/curl:latest", cmpData.Services.ConsensusHealth.Image)
 				// FIXME: Find a way to test the command. It gives sintax errors beacuse of the double $ sign to escape the $ signs. It works fine when running the command in docker compose.
 				// if runtime.GOOS != "windows" {
 				// 	// Check that the consensus-health bash command is valid

--- a/cli/actions/generation_test.go
+++ b/cli/actions/generation_test.go
@@ -354,8 +354,10 @@ func TestGenerateDockerCompose(t *testing.T) {
 					}
 				}
 
-				// Check that the consensus-health service is set.
-				assert.NotNil(t, cmpData.Services.ConsensusHealth)
+				if tc.genData.ConsensusClient != nil {
+					// Check that the consensus-health service is set.
+					assert.NotNil(t, cmpData.Services.ConsensusHealth)
+				}
 				// Check that the consensus-health image is set.
 				assert.Equal(t, "alpine/curl:latest", cmpData.Services.ConsensusHealth.Image)
 				// FIXME: Find a way to test the command. It gives sintax errors beacuse of the double $ sign to escape the $ signs. It works fine when running the command in docker compose.

--- a/cli/generate.go
+++ b/cli/generate.go
@@ -194,7 +194,7 @@ func runGenCmd(out io.Writer, flags *GenCmdFlags, sedgeAction actions.SedgeActio
 		ClExtraFlags:            flags.clExtraFlags,
 		VlExtraFlags:            flags.vlExtraFlags,
 		MapAllPorts:             flags.mapAllPorts,
-		Mev:                     !flags.noMev && utils.Contains(services, validator) && !flags.noValidator,
+		Mev:                     !flags.noMev && utils.Contains(services, validator) && utils.Contains(services, consensus) && !flags.noValidator,
 		MevImage:                flags.mevImage,
 		LoggingDriver:           configs.GetLoggingDriver(logging),
 		RelayURL:                flags.relayURL,

--- a/cli/sub_gen.go
+++ b/cli/sub_gen.go
@@ -227,6 +227,7 @@ func ValidatorSubCmd(sedgeAction actions.SedgeActions) *cobra.Command {
 			return preValidationGenerateCmd(network, logging)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			flags.noMev = true
 			return runGenCmd(cmd.OutOrStdout(), &flags, sedgeAction, []string{validator})
 		},
 	}

--- a/internal/pkg/generate/generate_scripts.go
+++ b/internal/pkg/generate/generate_scripts.go
@@ -179,9 +179,12 @@ func ComposeFile(gd *GenData, at io.Writer) error {
 	validatorBlockerTemplate, consensusHealthTemplate := "", ""
 	if cls[validator] != nil {
 		validatorBlockerTemplate = "validator-blocker"
-		consensusHealthTemplate = "consensus-health"
 	} else {
 		validatorBlockerTemplate = "empty-validator-blocker"
+	}
+	if cls[consensus] != nil {
+		consensusHealthTemplate = "consensus-health"
+	} else {
 		consensusHealthTemplate = "empty-consensus-health"
 	}
 
@@ -275,7 +278,8 @@ func ComposeFile(gd *GenData, at io.Writer) error {
 		Network:             gd.Network,
 		TTD:                 ttd,
 		XeeVersion:          xeeVersion,
-		Mev:                 gd.MevBoostService || (mevSupported && gd.Mev) || gd.MevBoostOnValidator,
+		Mev:                 gd.MevBoostService || (mevSupported && gd.Mev),
+		MevBoostOnValidator: gd.MevBoostService || (mevSupported && gd.Mev) || gd.MevBoostOnValidator,
 		MevPort:             gd.Ports["MevPort"],
 		MevBoostEndpoint:    gd.MevBoostEndpoint,
 		MevImage:            gd.MevImage,

--- a/internal/pkg/generate/generate_scripts.go
+++ b/internal/pkg/generate/generate_scripts.go
@@ -176,17 +176,7 @@ func ComposeFile(gd *GenData, at io.Writer) error {
 			return err
 		}
 	}
-	validatorBlockerTemplate, consensusHealthTemplate := "", ""
-	if cls[validator] != nil {
-		validatorBlockerTemplate = "validator-blocker"
-	} else {
-		validatorBlockerTemplate = "empty-validator-blocker"
-	}
-	if cls[consensus] != nil {
-		consensusHealthTemplate = "consensus-health"
-	} else {
-		consensusHealthTemplate = "empty-consensus-health"
-	}
+	validatorBlockerTemplate, consensusHealthTemplate := "validator-blocker", "consensus-health"
 
 	// Parse validator-blocker template
 	tmp, err := templates.Services.ReadFile(strings.Join([]string{"services", validatorBlockerTemplate + ".tmpl"}, "/"))

--- a/internal/pkg/generate/types.go
+++ b/internal/pkg/generate/types.go
@@ -85,6 +85,7 @@ type DockerComposeData struct {
 	TTD                     string
 	XeeVersion              bool
 	Mev                     bool
+	MevBoostOnValidator     bool
 	MevPort                 uint16
 	MevImage                string
 	MevBoostEndpoint        string

--- a/internal/pkg/generate/types.go
+++ b/internal/pkg/generate/types.go
@@ -126,11 +126,20 @@ type DockerComposeData struct {
 	ContainerTag            string
 }
 
-// WithConsensusClient returns true if the consensus client is explicitly required
-// by the user, with the --run-clients flag.
+// WithConsensusClient returns true if the consensus client is set
 func (d DockerComposeData) WithConsensusClient() bool {
 	for _, service := range d.Services {
 		if service == consensus {
+			return true
+		}
+	}
+	return false
+}
+
+// WithValidatorClient returns true if the validator client is set
+func (d DockerComposeData) WithValidatorClient() bool {
+	for _, service := range d.Services {
+		if service == validator {
 			return true
 		}
 	}

--- a/internal/pkg/generate/types_test.go
+++ b/internal/pkg/generate/types_test.go
@@ -35,9 +35,23 @@ func TestDockerComposeData_WithConsensusClient(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "with consensus client",
+			data: DockerComposeData{
+				Services: []string{"consensus"},
+			},
+			want: true,
+		},
+		{
 			name: "without consensus client",
 			data: DockerComposeData{
 				Services: []string{"execution", "validator"},
+			},
+			want: false,
+		},
+		{
+			name: "without consensus client",
+			data: DockerComposeData{
+				Services: []string{"execution"},
 			},
 			want: false,
 		},
@@ -52,6 +66,56 @@ func TestDockerComposeData_WithConsensusClient(t *testing.T) {
 	for _, tC := range tests {
 		t.Run(tC.name, func(t *testing.T) {
 			out := tC.data.WithConsensusClient()
+			assert.Equal(t, out, tC.want)
+		})
+	}
+}
+
+func TestDockerComposeData_WithValidatorClient(t *testing.T) {
+	tests := []struct {
+		name string
+		data DockerComposeData
+		want bool
+	}{
+		{
+			name: "with validator client",
+			data: DockerComposeData{
+				Services: []string{"execution", "consensus", "validator"},
+			},
+			want: true,
+		},
+		{
+			name: "with validator client",
+			data: DockerComposeData{
+				Services: []string{"validator"},
+			},
+			want: true,
+		},
+		{
+			name: "without validator client",
+			data: DockerComposeData{
+				Services: []string{"execution", "consensus"},
+			},
+			want: false,
+		},
+		{
+			name: "without validator client",
+			data: DockerComposeData{
+				Services: []string{"execution"},
+			},
+			want: false,
+		},
+		{
+			name: "with nil services",
+			data: DockerComposeData{
+				Services: nil,
+			},
+			want: false,
+		},
+	}
+	for _, tC := range tests {
+		t.Run(tC.name, func(t *testing.T) {
+			out := tC.data.WithValidatorClient()
 			assert.Equal(t, out, tC.want)
 		})
 	}

--- a/templates/services/docker-compose_base.tmpl
+++ b/templates/services/docker-compose_base.tmpl
@@ -20,8 +20,9 @@ services:
       - -relays
       - ${RELAY_URL}{{end}}
 {{template "consensus" .}}
+{{ if .WithValidatorClient}}
 {{template "consensus-health" .}}
-{{template "validator-blocker" .}}
+{{template "validator-blocker" .}}{{end}}
 {{template "validator" .}}
 
 networks:

--- a/templates/services/empty-consensus-health.tmpl
+++ b/templates/services/empty-consensus-health.tmpl
@@ -1,3 +1,0 @@
-{{/* empty-consensus-health.tmpl */}}
-{{ define "consensus-health" }}
-{{ end }}

--- a/templates/services/empty-validator-blocker.tmpl
+++ b/templates/services/empty-validator-blocker.tmpl
@@ -1,3 +1,0 @@
-{{/* empty-validator-blocker.tmpl */}}
-{{ define "validator-blocker" }}
-{{ end }}

--- a/templates/services/merge/validator/lighthouse.tmpl
+++ b/templates/services/merge/validator/lighthouse.tmpl
@@ -30,7 +30,7 @@
       - --metrics
       - --metrics-port={{.VlMetricsPort}}
       - --metrics-address=0.0.0.0{{range $flag := .VlExtraFlags}}
-      - --{{$flag}}{{end}}{{if .Mev}}
+      - --{{$flag}}{{end}}{{if .MevBoostOnValidator}}
       - --builder-proposals{{end}}{{if .LoggingDriver}}
     logging:
       driver: "{{.LoggingDriver}}"{{if eq .LoggingDriver "json-file"}}

--- a/templates/services/merge/validator/lodestar.tmpl
+++ b/templates/services/merge/validator/lodestar.tmpl
@@ -28,7 +28,7 @@
       - --metrics.address=0.0.0.0
       - --metrics.port={{.VlMetricsPort}}{{with .FeeRecipient}}
       - --suggestedFeeRecipient=${CC_FEE_RECIPIENT}{{end}}{{range $flag := .VlExtraFlags}}
-      - --{{$flag}}{{end}}{{if .Mev}}
+      - --{{$flag}}{{end}}{{if .MevBoostOnValidator}}
       - --builder=true{{end}}
       - --graffiti=${GRAFFITI}{{if .LoggingDriver}}
     logging:

--- a/templates/services/merge/validator/prysm.tmpl
+++ b/templates/services/merge/validator/prysm.tmpl
@@ -29,7 +29,7 @@
       - --monitoring-host=0.0.0.0
       - --monitoring-port={{.VlMetricsPort}}{{range $flag := .VlExtraFlags}}
       - --{{$flag}}{{end}}{{with .FeeRecipient}}
-      - --suggested-fee-recipient=${CC_FEE_RECIPIENT}{{end}}{{if .Mev}}
+      - --suggested-fee-recipient=${CC_FEE_RECIPIENT}{{end}}{{if .MevBoostOnValidator}}
       - --enable-builder{{end}}{{if .LoggingDriver}}
     logging:
       driver: "{{.LoggingDriver}}"{{if eq .LoggingDriver "json-file"}}

--- a/templates/services/merge/validator/teku.tmpl
+++ b/templates/services/merge/validator/teku.tmpl
@@ -29,7 +29,7 @@
       - --metrics-interface=0.0.0.0
       - --metrics-port={{.VlMetricsPort}}{{with .FeeRecipient}}
       - --validators-proposer-default-fee-recipient=${CC_FEE_RECIPIENT}{{end}}{{range $flag := .VlExtraFlags}}
-      - --{{$flag}}{{end}}{{if .Mev}}
+      - --{{$flag}}{{end}}{{if .MevBoostOnValidator}}
       - --validators-proposer-blinded-blocks-enabled=true
       - --validators-builder-registration-default-enabled=true
       - --Xvalidators-builder-registration-default-gas-limit=29000000{{end}}{{if .LoggingDriver}}


### PR DESCRIPTION
## Changes:
- Fix the error of `mev-boost` showing all the time for `validator`.
- Fix the error of `consensus-health` container showing all the time.
## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
