### PR TITLE
Update docker api deprecated types

### DIFF
--- a/cli/actions/importKeys_test.go
+++ b/cli/actions/importKeys_test.go
@@ -342,7 +342,7 @@ func importKeysGoldenPath(t *testing.T, ctrl *gomock.Controller, withCustomImage
 	// Mock ContainerCreate
 	dockerClient.EXPECT().
 		ContainerCreate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), services.ServiceCtValidatorImport).
-		Return(container.ContainerCreateCreatedBody{ID: validatorImportCtId}, nil).
+		Return(container.CreateResponse{ID: validatorImportCtId}, nil).
 		Times(1)
 	// Mock ContainerStart
 	dockerClient.EXPECT().
@@ -354,8 +354,8 @@ func importKeysGoldenPath(t *testing.T, ctrl *gomock.Controller, withCustomImage
 		Return(nil).
 		Times(1)
 	// Mock ContainerWait
-	exitCh := make(chan container.ContainerWaitOKBody, 1)
-	exitCh <- container.ContainerWaitOKBody{
+	exitCh := make(chan container.WaitResponse, 1)
+	exitCh <- container.WaitResponse{
 		StatusCode: 0,
 	}
 	dockerClient.EXPECT().
@@ -406,7 +406,7 @@ func importKeysExitError(t *testing.T, ctrl *gomock.Controller) client.APIClient
 	// Mock ContainerCreate
 	dockerClient.EXPECT().
 		ContainerCreate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), services.ServiceCtValidatorImport).
-		Return(container.ContainerCreateCreatedBody{ID: validatorImportCtId}, nil).
+		Return(container.CreateResponse{ID: validatorImportCtId}, nil).
 		Times(1)
 	// Mock ContainerStart
 	dockerClient.EXPECT().
@@ -418,8 +418,8 @@ func importKeysExitError(t *testing.T, ctrl *gomock.Controller) client.APIClient
 		Return(nil).
 		Times(1)
 	// Mock ContainerWait
-	exitCh := make(chan container.ContainerWaitOKBody, 1)
-	exitCh <- container.ContainerWaitOKBody{
+	exitCh := make(chan container.WaitResponse, 1)
+	exitCh <- container.WaitResponse{
 		StatusCode: 1,
 	}
 	dockerClient.EXPECT().

--- a/cli/actions/slashing_test.go
+++ b/cli/actions/slashing_test.go
@@ -275,7 +275,7 @@ func slashingGoldenPath(t *testing.T, ctrl *gomock.Controller, containerTag stri
 	// Mock ContainerCreate
 	dockerClient.EXPECT().
 		ContainerCreate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), slashingCtName).
-		Return(container.ContainerCreateCreatedBody{ID: slashingCtId}, nil).
+		Return(container.CreateResponse{ID: slashingCtId}, nil).
 		Times(1)
 	// Mock ContainerStart
 	dockerClient.EXPECT().
@@ -287,8 +287,8 @@ func slashingGoldenPath(t *testing.T, ctrl *gomock.Controller, containerTag stri
 		Return(nil).
 		Times(1)
 	// Mock ContainerWait
-	exitCh := make(chan container.ContainerWaitOKBody, 1)
-	exitCh <- container.ContainerWaitOKBody{
+	exitCh := make(chan container.WaitResponse, 1)
+	exitCh <- container.WaitResponse{
 		StatusCode: 0,
 	}
 	dockerClient.EXPECT().

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -436,7 +436,7 @@ func runCliCmd(cmd *cobra.Command, args []string, flags *CliCmdFlags, clientImag
 			if err := runAndShowContainers(cmdRunner, []string{"validator-import"}, flags); err != nil {
 				return []error{err}
 			}
-			exitCode, err := func(exitCh <-chan dockerct.ContainerWaitOKBody, errCh <-chan error) (int64, error) {
+			exitCode, err := func(exitCh <-chan dockerct.WaitResponse, errCh <-chan error) (int64, error) {
 				for {
 					select {
 					case exitOk := <-exitCh:

--- a/internal/pkg/services/services.go
+++ b/internal/pkg/services/services.go
@@ -33,7 +33,7 @@ type ServiceManager interface {
 	Stop(service string) error
 	Start(service string) error
 	IsRunning(service string) (bool, error)
-	Wait(service string, condition container.WaitCondition) (<-chan container.ContainerWaitOKBody, <-chan error)
+	Wait(service string, condition container.WaitCondition) (<-chan container.WaitResponse, <-chan error)
 	ContainerId(service string) (string, error)
 }
 

--- a/internal/pkg/services/wait.go
+++ b/internal/pkg/services/wait.go
@@ -21,6 +21,6 @@ import (
 	"github.com/docker/docker/api/types/container"
 )
 
-func (s *serviceManager) Wait(service string, condition container.WaitCondition) (<-chan container.ContainerWaitOKBody, <-chan error) {
+func (s *serviceManager) Wait(service string, condition container.WaitCondition) (<-chan container.WaitResponse, <-chan error) {
 	return s.dockerClient.ContainerWait(context.Background(), service, condition)
 }

--- a/internal/pkg/services/wait_test.go
+++ b/internal/pkg/services/wait_test.go
@@ -40,7 +40,7 @@ func TestWaitErrCh(t *testing.T) {
 
 	dockerClient.EXPECT().
 		ContainerWait(context.Background(), "sedge-validator-client", gomock.Any()).
-		Return(make(chan container.ContainerWaitOKBody), wantErrCh).
+		Return(make(chan container.WaitResponse), wantErrCh).
 		Times(1)
 
 	serviceManager := services.NewServiceManager(dockerClient)
@@ -61,10 +61,10 @@ func TestWaitExitCh(t *testing.T) {
 	defer ctrl.Finish()
 
 	waitCh := time.After(3 * time.Second)
-	wantWait := container.ContainerWaitOKBody{
+	wantWait := container.WaitResponse{
 		StatusCode: 0,
 	}
-	wantWaitCh := make(chan container.ContainerWaitOKBody, 1)
+	wantWaitCh := make(chan container.WaitResponse, 1)
 	wantWaitCh <- wantWait
 
 	dockerClient.EXPECT().


### PR DESCRIPTION
We are using some deprecated types of the docker API package that we need to update to the suggested types. Follow reference links for more details.

## Changes:

- Replace these types:
  - `ContainerCreateCreatedBody` -> `CreateResponse` ([reference](https://pkg.go.dev/github.com/docker/docker/api/types/container#ContainerCreateCreatedBody))
  - `ContainerWaitOKBody` -> `WaitResponse` ([reference](https://pkg.go.dev/github.com/docker/docker/api/types/container#ContainerWaitOKBody))


## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Update dependencies

## Testing
**Requires testing**

- [x] No
