### PR TITLE
Put missing v on documentation wget and curl of binary

### DIFF
--- a/docs/docs/quickstart/complete-guide.mdx
+++ b/docs/docs/quickstart/complete-guide.mdx
@@ -41,14 +41,14 @@ want to use another installation method:
   <TabItem value="curl" label="curl">
 
   ```
-  curl -L https://github.com/NethermindEth/sedge/releases/download/1.0.0/sedge-v1.0.0-linux-amd64 --output sedge
+  curl -L https://github.com/NethermindEth/sedge/releases/download/v1.0.0/sedge-v1.0.0-linux-amd64 --output sedge
   ```
 
   </TabItem>
   <TabItem value="wget" label="wget">
 
   ```
-  wget https://github.com/NethermindEth/sedge/releases/download/1.0.0/sedge-v1.0.0-linux-amd64 -O sedge
+  wget https://github.com/NethermindEth/sedge/releases/download/v1.0.0/sedge-v1.0.0-linux-amd64 -O sedge
   ```
 
   </TabItem>


### PR DESCRIPTION
## Changes:
- Put missing `v` on documentation `wget` and `curl` of binary

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
