### PR TITLE
Fix validator blocker generation with no-validator flag

### DIFF
--- a/cli/sub_gen.go
+++ b/cli/sub_gen.go
@@ -58,7 +58,10 @@ Additionally, you can use this syntax '<CLIENT>:<DOCKER_IMAGE>' to override the 
 			return preValidationGenerateCmd(network, logging, &flags)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			services := []string{execution, consensus, validator}
+			services := []string{execution, consensus}
+			if !flags.noValidator {
+				services = append(services, validator)
+			}
 			if !flags.noMev && !flags.noValidator {
 				services = append(services, mevBoost)
 			}


### PR DESCRIPTION
`validator-blocker` was generated with the `full-node` command and the `no-validator` flag. To fix this, the initial list of services in `FullNodeSubCmd` will only contain the `validator` service if the `no-validator` flag is not set.

## Types of changes

What types of changes does your code introduce?

- [x] Bugfix (non-breaking change which fixes an issue)
