### PR TITLE
update `--eth1-endpoints` flag

### DIFF
--- a/cli/actions/testdata/getContainers_tests/case_consensusNF/docker-compose.yml
+++ b/cli/actions/testdata/getContainers_tests/case_consensusNF/docker-compose.yml
@@ -86,7 +86,7 @@ services:
       - --target-peers=${CC_PEER_COUNT}
       - --execution-endpoints=${EC_AUTH_URL}
       - --execution-jwt=/tmp/jwt/jwtsecret
-      - --eth1-endpoints=${EC_API_URL}
+      - --eth1=${EC_API_URL}
       - --debug-level=${CC_LOG_LEVEL}
       - --suggested-fee-recipient=${FEE_RECIPIENT}
       - --validator-monitor-auto

--- a/cli/actions/testdata/getContainers_tests/case_consensusOnly/docker-compose.yml
+++ b/cli/actions/testdata/getContainers_tests/case_consensusOnly/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       - --target-peers=${CC_PEER_COUNT}
       - --execution-endpoints=${EC_AUTH_URL}
       - --execution-jwt=/tmp/jwt/jwtsecret
-      - --eth1-endpoints=${EC_API_URL}
+      - --eth1=${EC_API_URL}
       - --debug-level=${CC_LOG_LEVEL}
       - --suggested-fee-recipient=${FEE_RECIPIENT}
       - --validator-monitor-auto

--- a/cli/actions/testdata/getContainers_tests/case_executionNF/docker-compose.yml
+++ b/cli/actions/testdata/getContainers_tests/case_executionNF/docker-compose.yml
@@ -86,7 +86,7 @@ services:
       - --target-peers=${CC_PEER_COUNT}
       - --execution-endpoints=${EC_AUTH_URL}
       - --execution-jwt=/tmp/jwt/jwtsecret
-      - --eth1-endpoints=${EC_API_URL}
+      - --eth1=${EC_API_URL}
       - --debug-level=${CC_LOG_LEVEL}
       - --suggested-fee-recipient=${FEE_RECIPIENT}
       - --validator-monitor-auto

--- a/cli/actions/testdata/getContainers_tests/case_fullNode/docker-compose.yml
+++ b/cli/actions/testdata/getContainers_tests/case_fullNode/docker-compose.yml
@@ -86,7 +86,7 @@ services:
     - --target-peers=${CC_PEER_COUNT}
     - --execution-endpoints=${EC_AUTH_URL}
     - --execution-jwt=/tmp/jwt/jwtsecret
-    - --eth1-endpoints=${EC_API_URL}
+    - --eth1=${EC_API_URL}
     - --debug-level=${CC_LOG_LEVEL}
     - --suggested-fee-recipient=${FEE_RECIPIENT}
     - --validator-monitor-auto

--- a/cli/actions/testdata/getContainers_tests/case_fullNodeTag/docker-compose.yml
+++ b/cli/actions/testdata/getContainers_tests/case_fullNodeTag/docker-compose.yml
@@ -86,7 +86,7 @@ services:
     - --target-peers=${CC_PEER_COUNT}
     - --execution-endpoints=${EC_AUTH_URL}
     - --execution-jwt=/tmp/jwt/jwtsecret
-    - --eth1-endpoints=${EC_API_URL}
+    - --eth1=${EC_API_URL}
     - --debug-level=${CC_LOG_LEVEL}
     - --suggested-fee-recipient=${FEE_RECIPIENT}
     - --validator-monitor-auto

--- a/cli/actions/testdata/getContainers_tests/case_noExecution/docker-compose.yml
+++ b/cli/actions/testdata/getContainers_tests/case_noExecution/docker-compose.yml
@@ -47,7 +47,7 @@ services:
       - --target-peers=${CC_PEER_COUNT}
       - --execution-endpoints=${EC_AUTH_URL}
       - --execution-jwt=/tmp/jwt/jwtsecret
-      - --eth1-endpoints=${EC_API_URL}
+      - --eth1=${EC_API_URL}
       - --debug-level=${CC_LOG_LEVEL}
       - --suggested-fee-recipient=${FEE_RECIPIENT}
       - --validator-monitor-auto

--- a/cli/actions/testdata/getContainers_tests/case_noMev/docker-compose.yml
+++ b/cli/actions/testdata/getContainers_tests/case_noMev/docker-compose.yml
@@ -72,7 +72,7 @@ services:
       - --target-peers=${CC_PEER_COUNT}
       - --execution-endpoints=${EC_AUTH_URL}
       - --execution-jwt=/tmp/jwt/jwtsecret
-      - --eth1-endpoints=${EC_API_URL}
+      - --eth1=${EC_API_URL}
       - --debug-level=${CC_LOG_LEVEL}
       - --suggested-fee-recipient=${FEE_RECIPIENT}
       - --validator-monitor-auto

--- a/cli/actions/testdata/getContainers_tests/case_noValidator/docker-compose.yml
+++ b/cli/actions/testdata/getContainers_tests/case_noValidator/docker-compose.yml
@@ -86,7 +86,7 @@ services:
       - --target-peers=${CC_PEER_COUNT}
       - --execution-endpoints=${EC_AUTH_URL}
       - --execution-jwt=/tmp/jwt/jwtsecret
-      - --eth1-endpoints=${EC_API_URL}
+      - --eth1=${EC_API_URL}
       - --debug-level=${CC_LOG_LEVEL}
       - --suggested-fee-recipient=${FEE_RECIPIENT}
       - --validator-monitor-auto

--- a/cli/actions/testdata/getContainers_tests/case_validatorNF/docker-compose.yml
+++ b/cli/actions/testdata/getContainers_tests/case_validatorNF/docker-compose.yml
@@ -86,7 +86,7 @@ services:
       - --target-peers=${CC_PEER_COUNT}
       - --execution-endpoints=${EC_AUTH_URL}
       - --execution-jwt=/tmp/jwt/jwtsecret
-      - --eth1-endpoints=${EC_API_URL}
+      - --eth1=${EC_API_URL}
       - --debug-level=${CC_LOG_LEVEL}
       - --suggested-fee-recipient=${FEE_RECIPIENT}
       - --validator-monitor-auto

--- a/cli/testdata/down_tests/case_1/sedge-data/docker-compose.yml
+++ b/cli/testdata/down_tests/case_1/sedge-data/docker-compose.yml
@@ -65,7 +65,7 @@ services:
       - --rest-api-host-allowlist=*
       - --rest-api-enabled=true
       - --rest-api-port=4000
-      - --eth1-endpoints=${EC_NODE}
+      - --eth1=${EC_NODE}
       - --eth1-deposit-contract-max-request-size=150
     logging:
       driver: "json-file"

--- a/cli/testdata/logs_tests/case_1/sedge-data/docker-compose.yml
+++ b/cli/testdata/logs_tests/case_1/sedge-data/docker-compose.yml
@@ -65,7 +65,7 @@ services:
       - --rest-api-host-allowlist=*
       - --rest-api-enabled=true
       - --rest-api-port=4000
-      - --eth1-endpoints=${EC_NODE}
+      - --eth1=${EC_NODE}
       - --eth1-deposit-contract-max-request-size=150
     logging:
       driver: "json-file"

--- a/cli/testdata/run_tests/no_env/docker-compose.yml
+++ b/cli/testdata/run_tests/no_env/docker-compose.yml
@@ -88,7 +88,7 @@ services:
     - --target-peers=${CC_PEER_COUNT}
     - --execution-endpoints=${EC_AUTH_URL}
     - --execution-jwt=/tmp/jwt/jwtsecret
-    - --eth1-endpoints=${EC_API_URL}
+    - --eth1=${EC_API_URL}
     - --debug-level=${CC_LOG_LEVEL}
     - --validator-monitor-auto
     - --subscribe-all-subnets

--- a/cli/testdata/run_tests/no_version/docker-compose.yml
+++ b/cli/testdata/run_tests/no_version/docker-compose.yml
@@ -87,7 +87,7 @@ services:
     - --target-peers=${CC_PEER_COUNT}
     - --execution-endpoints=${EC_AUTH_URL}
     - --execution-jwt=/tmp/jwt/jwtsecret
-    - --eth1-endpoints=${EC_API_URL}
+    - --eth1=${EC_API_URL}
     - --debug-level=${CC_LOG_LEVEL}
     - --validator-monitor-auto
     - --subscribe-all-subnets

--- a/cli/testdata/run_tests/valid/docker-compose.yml
+++ b/cli/testdata/run_tests/valid/docker-compose.yml
@@ -88,7 +88,7 @@ services:
     - --target-peers=${CC_PEER_COUNT}
     - --execution-endpoints=${EC_AUTH_URL}
     - --execution-jwt=/tmp/jwt/jwtsecret
-    - --eth1-endpoints=${EC_API_URL}
+    - --eth1=${EC_API_URL}
     - --debug-level=${CC_LOG_LEVEL}
     - --validator-monitor-auto
     - --subscribe-all-subnets

--- a/internal/utils/testdata/checks_tests/case_1/sedge-data/docker-compose.yml
+++ b/internal/utils/testdata/checks_tests/case_1/sedge-data/docker-compose.yml
@@ -65,7 +65,7 @@ services:
       - --rest-api-host-allowlist=*
       - --rest-api-enabled=true
       - --rest-api-port=4000
-      - --eth1-endpoints=${EC_NODE}
+      - --eth1=${EC_NODE}
       - --eth1-deposit-contract-max-request-size=150
     logging:
       driver: "json-file"

--- a/internal/utils/testdata/checks_tests/case_2/sedge-data/no-docker-compose.yml
+++ b/internal/utils/testdata/checks_tests/case_2/sedge-data/no-docker-compose.yml
@@ -65,7 +65,7 @@ services:
       - --rest-api-host-allowlist=*
       - --rest-api-enabled=true
       - --rest-api-port=4000
-      - --eth1-endpoints=${EC_NODE}
+      - --eth1=${EC_NODE}
       - --eth1-deposit-contract-max-request-size=150
     logging:
       driver: "json-file"

--- a/internal/utils/testdata/validate_compose_tests/no_env/docker-compose.yml
+++ b/internal/utils/testdata/validate_compose_tests/no_env/docker-compose.yml
@@ -88,7 +88,7 @@ services:
     - --target-peers=${CC_PEER_COUNT}
     - --execution-endpoints=${EC_AUTH_URL}
     - --execution-jwt=/tmp/jwt/jwtsecret
-    - --eth1-endpoints=${EC_API_URL}
+    - --eth1=${EC_API_URL}
     - --debug-level=${CC_LOG_LEVEL}
     - --validator-monitor-auto
     - --subscribe-all-subnets

--- a/internal/utils/testdata/validate_compose_tests/no_version/docker-compose.yml
+++ b/internal/utils/testdata/validate_compose_tests/no_version/docker-compose.yml
@@ -87,7 +87,7 @@ services:
     - --target-peers=${CC_PEER_COUNT}
     - --execution-endpoints=${EC_AUTH_URL}
     - --execution-jwt=/tmp/jwt/jwtsecret
-    - --eth1-endpoints=${EC_API_URL}
+    - --eth1=${EC_API_URL}
     - --debug-level=${CC_LOG_LEVEL}
     - --validator-monitor-auto
     - --subscribe-all-subnets

--- a/internal/utils/testdata/validate_compose_tests/valid/docker-compose.yml
+++ b/internal/utils/testdata/validate_compose_tests/valid/docker-compose.yml
@@ -88,7 +88,7 @@ services:
     - --target-peers=${CC_PEER_COUNT}
     - --execution-endpoints=${EC_AUTH_URL}
     - --execution-jwt=/tmp/jwt/jwtsecret
-    - --eth1-endpoints=${EC_API_URL}
+    - --eth1=${EC_API_URL}
     - --debug-level=${CC_LOG_LEVEL}
     - --validator-monitor-auto
     - --subscribe-all-subnets

--- a/templates/services/merge/consensus/lighthouse.tmpl
+++ b/templates/services/merge/consensus/lighthouse.tmpl
@@ -38,7 +38,7 @@
       - --boot-nodes={{.CCBootnodes}}{{end}}
       - --execution-endpoints=${EC_AUTH_URL}
       - --execution-jwt=/tmp/jwt/jwtsecret
-      - --eth1-endpoints=${EC_API_URL}{{range $url := .FallbackELUrls}},{{$url}}{{end}}
+      - --eth1=${EC_API_URL}{{range $url := .FallbackELUrls}},{{$url}}{{end}}
       - --debug-level=${CC_LOG_LEVEL}{{with .FeeRecipient}}
       - --suggested-fee-recipient=${FEE_RECIPIENT}{{end}}
       - --validator-monitor-auto


### PR DESCRIPTION
Sedge consensus client does not build, instead it's throwing an error

```sh
sedge-consensus-client  | error: Found argument '--eth1-endpoints' which wasn't expected, or isn't valid in this context
```

Fixes | Closes | Resolves ##354

## Changes:
- Renaming instances of `--eth1-endpoints` to `--eth1` in `docker-compost.yml` and `lighthouse.tmpl`

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [ ] Yes
- [x] No

**In case you checked yes, did you write tests?**

- [ ] Yes
- [x] No