### PR TITLE
Remove obsolete version field

### DIFF
--- a/cli/actions/testdata/getContainers_tests/case_consensusNF/docker-compose.yml
+++ b/cli/actions/testdata/getContainers_tests/case_consensusNF/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.9"
 services:
   execution:
     stop_grace_period: 30s

--- a/cli/actions/testdata/getContainers_tests/case_consensusOnly/docker-compose.yml
+++ b/cli/actions/testdata/getContainers_tests/case_consensusOnly/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.9"
 services:
   consensus:
     stop_grace_period: 30s

--- a/cli/actions/testdata/getContainers_tests/case_executionNF/docker-compose.yml
+++ b/cli/actions/testdata/getContainers_tests/case_executionNF/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.9"
 services:
   execution:
     stop_grace_period: 30s

--- a/cli/actions/testdata/getContainers_tests/case_executionOnly/docker-compose.yml
+++ b/cli/actions/testdata/getContainers_tests/case_executionOnly/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.9"
 services:
   execution:
     stop_grace_period: 30s

--- a/cli/actions/testdata/getContainers_tests/case_fullNode/docker-compose.yml
+++ b/cli/actions/testdata/getContainers_tests/case_fullNode/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.9"
 services:
   execution:
     stop_grace_period: 30s

--- a/cli/actions/testdata/getContainers_tests/case_noMev/docker-compose.yml
+++ b/cli/actions/testdata/getContainers_tests/case_noMev/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.9"
 services:
   execution:
     stop_grace_period: 30s

--- a/cli/actions/testdata/getContainers_tests/case_noValidator/docker-compose.yml
+++ b/cli/actions/testdata/getContainers_tests/case_noValidator/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.9"
 services:
   execution:
     stop_grace_period: 30s

--- a/cli/actions/testdata/getContainers_tests/case_validatorNF/docker-compose.yml
+++ b/cli/actions/testdata/getContainers_tests/case_validatorNF/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.9"
 services:
   execution:
     stop_grace_period: 30s

--- a/cli/testdata/run_tests/no_image/docker-compose.yml
+++ b/cli/testdata/run_tests/no_image/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.9"
 services:
   execution:
     stop_grace_period: 30m

--- a/cli/testdata/run_tests/valid/docker-compose.yml
+++ b/cli/testdata/run_tests/valid/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.9"
 services:
   execution:
     stop_grace_period: 30s

--- a/templates/services/docker-compose_base.tmpl
+++ b/templates/services/docker-compose_base.tmpl
@@ -1,6 +1,5 @@
 {{/* docker-compose_base.tmpl */}}
 {{ define "docker-compose" }}
-version: "3.9"
 
 services:
 {{template "execution" .}}


### PR DESCRIPTION
Version field now is obsolete and every time docker container created with that docker compose file is stopped/started it produces warning:
WARN[0000] /root/docker-compose.yml: `version` is obsolete

So removing that field solves that.