### PR TITLE
Fix invalid `--eth1` flag usage in Lighthouse template

### DIFF
--- a/cli/actions/testdata/getContainers_tests/case_consensusNF/docker-compose.yml
+++ b/cli/actions/testdata/getContainers_tests/case_consensusNF/docker-compose.yml
@@ -85,7 +85,7 @@ services:
       - --target-peers=${CC_PEER_COUNT}
       - --execution-endpoints=${EC_AUTH_URL}
       - --execution-jwt=/tmp/jwt/jwtsecret
-      - --eth1=${EC_API_URL}
+      - --eth1
       - --debug-level=${CC_LOG_LEVEL}
       - --suggested-fee-recipient=${FEE_RECIPIENT}
       - --validator-monitor-auto

--- a/cli/actions/testdata/getContainers_tests/case_consensusOnly/docker-compose.yml
+++ b/cli/actions/testdata/getContainers_tests/case_consensusOnly/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       - --target-peers=${CC_PEER_COUNT}
       - --execution-endpoints=${EC_AUTH_URL}
       - --execution-jwt=/tmp/jwt/jwtsecret
-      - --eth1=${EC_API_URL}
+      - --eth1
       - --debug-level=${CC_LOG_LEVEL}
       - --suggested-fee-recipient=${FEE_RECIPIENT}
       - --validator-monitor-auto

--- a/cli/actions/testdata/getContainers_tests/case_executionNF/docker-compose.yml
+++ b/cli/actions/testdata/getContainers_tests/case_executionNF/docker-compose.yml
@@ -85,7 +85,7 @@ services:
       - --target-peers=${CC_PEER_COUNT}
       - --execution-endpoints=${EC_AUTH_URL}
       - --execution-jwt=/tmp/jwt/jwtsecret
-      - --eth1=${EC_API_URL}
+      - --eth1
       - --debug-level=${CC_LOG_LEVEL}
       - --suggested-fee-recipient=${FEE_RECIPIENT}
       - --validator-monitor-auto

--- a/cli/actions/testdata/getContainers_tests/case_fullNode/docker-compose.yml
+++ b/cli/actions/testdata/getContainers_tests/case_fullNode/docker-compose.yml
@@ -85,7 +85,7 @@ services:
     - --target-peers=${CC_PEER_COUNT}
     - --execution-endpoints=${EC_AUTH_URL}
     - --execution-jwt=/tmp/jwt/jwtsecret
-    - --eth1=${EC_API_URL}
+    - --eth1
     - --debug-level=${CC_LOG_LEVEL}
     - --suggested-fee-recipient=${FEE_RECIPIENT}
     - --validator-monitor-auto

--- a/cli/actions/testdata/getContainers_tests/case_fullNodeTag/docker-compose.yml
+++ b/cli/actions/testdata/getContainers_tests/case_fullNodeTag/docker-compose.yml
@@ -86,7 +86,7 @@ services:
     - --target-peers=${CC_PEER_COUNT}
     - --execution-endpoints=${EC_AUTH_URL}
     - --execution-jwt=/tmp/jwt/jwtsecret
-    - --eth1=${EC_API_URL}
+    - --eth1
     - --debug-level=${CC_LOG_LEVEL}
     - --suggested-fee-recipient=${FEE_RECIPIENT}
     - --validator-monitor-auto

--- a/cli/actions/testdata/getContainers_tests/case_noExecution/docker-compose.yml
+++ b/cli/actions/testdata/getContainers_tests/case_noExecution/docker-compose.yml
@@ -47,7 +47,7 @@ services:
       - --target-peers=${CC_PEER_COUNT}
       - --execution-endpoints=${EC_AUTH_URL}
       - --execution-jwt=/tmp/jwt/jwtsecret
-      - --eth1=${EC_API_URL}
+      - --eth1
       - --debug-level=${CC_LOG_LEVEL}
       - --suggested-fee-recipient=${FEE_RECIPIENT}
       - --validator-monitor-auto

--- a/cli/actions/testdata/getContainers_tests/case_noMev/docker-compose.yml
+++ b/cli/actions/testdata/getContainers_tests/case_noMev/docker-compose.yml
@@ -71,7 +71,7 @@ services:
       - --target-peers=${CC_PEER_COUNT}
       - --execution-endpoints=${EC_AUTH_URL}
       - --execution-jwt=/tmp/jwt/jwtsecret
-      - --eth1=${EC_API_URL}
+      - --eth1
       - --debug-level=${CC_LOG_LEVEL}
       - --suggested-fee-recipient=${FEE_RECIPIENT}
       - --validator-monitor-auto

--- a/cli/actions/testdata/getContainers_tests/case_noValidator/docker-compose.yml
+++ b/cli/actions/testdata/getContainers_tests/case_noValidator/docker-compose.yml
@@ -85,7 +85,7 @@ services:
       - --target-peers=${CC_PEER_COUNT}
       - --execution-endpoints=${EC_AUTH_URL}
       - --execution-jwt=/tmp/jwt/jwtsecret
-      - --eth1=${EC_API_URL}
+      - --eth1
       - --debug-level=${CC_LOG_LEVEL}
       - --suggested-fee-recipient=${FEE_RECIPIENT}
       - --validator-monitor-auto

--- a/cli/actions/testdata/getContainers_tests/case_validatorNF/docker-compose.yml
+++ b/cli/actions/testdata/getContainers_tests/case_validatorNF/docker-compose.yml
@@ -85,7 +85,7 @@ services:
       - --target-peers=${CC_PEER_COUNT}
       - --execution-endpoints=${EC_AUTH_URL}
       - --execution-jwt=/tmp/jwt/jwtsecret
-      - --eth1=${EC_API_URL}
+      - --eth1
       - --debug-level=${CC_LOG_LEVEL}
       - --suggested-fee-recipient=${FEE_RECIPIENT}
       - --validator-monitor-auto

--- a/cli/testdata/run_tests/no_env/docker-compose.yml
+++ b/cli/testdata/run_tests/no_env/docker-compose.yml
@@ -88,7 +88,7 @@ services:
     - --target-peers=${CC_PEER_COUNT}
     - --execution-endpoints=${EC_AUTH_URL}
     - --execution-jwt=/tmp/jwt/jwtsecret
-    - --eth1=${EC_API_URL}
+    - --eth1
     - --debug-level=${CC_LOG_LEVEL}
     - --validator-monitor-auto
     - --subscribe-all-subnets

--- a/cli/testdata/run_tests/no_version/docker-compose.yml
+++ b/cli/testdata/run_tests/no_version/docker-compose.yml
@@ -87,7 +87,7 @@ services:
     - --target-peers=${CC_PEER_COUNT}
     - --execution-endpoints=${EC_AUTH_URL}
     - --execution-jwt=/tmp/jwt/jwtsecret
-    - --eth1=${EC_API_URL}
+    - --eth1
     - --debug-level=${CC_LOG_LEVEL}
     - --validator-monitor-auto
     - --subscribe-all-subnets

--- a/cli/testdata/run_tests/valid/docker-compose.yml
+++ b/cli/testdata/run_tests/valid/docker-compose.yml
@@ -87,7 +87,7 @@ services:
     - --target-peers=${CC_PEER_COUNT}
     - --execution-endpoints=${EC_AUTH_URL}
     - --execution-jwt=/tmp/jwt/jwtsecret
-    - --eth1=${EC_API_URL}
+    - --eth1
     - --debug-level=${CC_LOG_LEVEL}
     - --validator-monitor-auto
     - --subscribe-all-subnets

--- a/internal/utils/testdata/validate_compose_tests/no_env/docker-compose.yml
+++ b/internal/utils/testdata/validate_compose_tests/no_env/docker-compose.yml
@@ -88,7 +88,7 @@ services:
     - --target-peers=${CC_PEER_COUNT}
     - --execution-endpoints=${EC_AUTH_URL}
     - --execution-jwt=/tmp/jwt/jwtsecret
-    - --eth1=${EC_API_URL}
+    - --eth1
     - --debug-level=${CC_LOG_LEVEL}
     - --validator-monitor-auto
     - --subscribe-all-subnets

--- a/internal/utils/testdata/validate_compose_tests/no_version/docker-compose.yml
+++ b/internal/utils/testdata/validate_compose_tests/no_version/docker-compose.yml
@@ -87,7 +87,7 @@ services:
     - --target-peers=${CC_PEER_COUNT}
     - --execution-endpoints=${EC_AUTH_URL}
     - --execution-jwt=/tmp/jwt/jwtsecret
-    - --eth1=${EC_API_URL}
+    - --eth1
     - --debug-level=${CC_LOG_LEVEL}
     - --validator-monitor-auto
     - --subscribe-all-subnets

--- a/internal/utils/testdata/validate_compose_tests/valid/docker-compose.yml
+++ b/internal/utils/testdata/validate_compose_tests/valid/docker-compose.yml
@@ -88,7 +88,7 @@ services:
     - --target-peers=${CC_PEER_COUNT}
     - --execution-endpoints=${EC_AUTH_URL}
     - --execution-jwt=/tmp/jwt/jwtsecret
-    - --eth1=${EC_API_URL}
+    - --eth1
     - --debug-level=${CC_LOG_LEVEL}
     - --validator-monitor-auto
     - --subscribe-all-subnets

--- a/templates/services/merge/consensus/lighthouse.tmpl
+++ b/templates/services/merge/consensus/lighthouse.tmpl
@@ -38,7 +38,7 @@
       - --boot-nodes={{.CCBootnodes}}{{end}}
       - --execution-endpoints=${EC_AUTH_URL}
       - --execution-jwt=/tmp/jwt/jwtsecret
-      - --eth1=${EC_API_URL}{{range $url := .FallbackELUrls}},{{$url}}{{end}}
+      - --eth1
       - --debug-level=${CC_LOG_LEVEL}{{with .FeeRecipient}}
       - --suggested-fee-recipient=${FEE_RECIPIENT}{{end}}
       - --validator-monitor-auto


### PR DESCRIPTION
Lighthouse updated the usage of `--eth1` flag in their cli, which was deprecated for some time, but now it just fails to start.

The PR updates it's use in the template as well as some test-related compose files.

Relevant LH doc: https://lighthouse-book.sigmaprime.io/help_bn.html?highlight=eth1#beacon-node


Error example:

```
Usage: lighthouse beacon_node --disable-upnp --datadir <DIR> --port <PORT> --http-address <ADDRESS> --http-port <PORT> --network <network> --target-peers <target-peers> --execution-endpoint <EXECUTION-ENDPOINT> --execution-jwt <EXECUTION-JWT> --eth1 <--http|--gui|--staking>
error: unexpected value ‘http://execution:8545/’ for ‘--eth1’ found; no more were expected
```