### PR TITLE
fix(cli): Mev-boost not being generated for holesky

### DIFF
--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -40,6 +40,7 @@ func TestCli(t *testing.T) {
 	log.SetOutput(io.Discard)
 
 	mevboostRelayListUris, _ := mevboostrelaylist.RelaysURI("mainnet")
+	holeskyMevboostRelayListUris, _ := mevboostrelaylist.RelaysURI("holesky")
 
 	ETHClients := map[string][]string{
 		"execution": clients.AllClients["execution"],
@@ -585,6 +586,84 @@ func TestCli(t *testing.T) {
 					sedgeActions.EXPECT().ImportValidatorKeys(actions.ImportValidatorKeysOptions{
 						ValidatorClient: "prysm",
 						Network:         NetworkMainnet,
+						GenerationPath:  generationPath,
+						From:            filepath.Join(generationPath, "keystore"),
+						ContainerTag:    "tag",
+					}).Return(nil),
+					prompter.EXPECT().Confirm("Do you want to import slashing protection data?", false).Return(false, nil),
+					prompter.EXPECT().Confirm("Run services now?", false).Return(false, nil),
+				)
+			},
+		},
+		{
+			name: "full node with Lido, holesky",
+			setup: func(t *testing.T, sedgeActions *sedge_mocks.MockSedgeActions, prompter *sedge_mocks.MockPrompter, depsMgr *sedge_mocks.MockDependenciesManager) {
+				generationPath := t.TempDir()
+				genData := generate.GenData{
+					Services: []string{"execution", "consensus", "validator", "mev-boost"},
+					ExecutionClient: &clients.Client{
+						Name:  "nethermind",
+						Type:  "execution",
+						Image: configs.ClientImages.Execution.Nethermind.String(),
+					},
+					ConsensusClient: &clients.Client{
+						Name:  "prysm",
+						Type:  "consensus",
+						Image: configs.ClientImages.Consensus.Prysm.String(),
+					},
+					ValidatorClient: &clients.Client{
+						Name:  "prysm",
+						Type:  "validator",
+						Image: configs.ClientImages.Validator.Prysm.String(),
+					},
+					Network:            "holesky",
+					CheckpointSyncUrl:  "http://checkpoint.sync",
+					FeeRecipient:       "0xE73a3602b99f1f913e72F8bdcBC235e206794Ac8",
+					MapAllPorts:        true,
+					Graffiti:           "test graffiti",
+					VLStartGracePeriod: 840,
+					Mev:                true,
+					MevImage:           "flashbots/mev-boost:latest",
+					RelayURLs:          holeskyMevboostRelayListUris,
+					ContainerTag:       "tag",
+					JWTSecretPath:      filepath.Join(generationPath, "jwtsecret"),
+				}
+				sedgeActions.EXPECT().GetCommandRunner().Return(&test.SimpleCMDRunner{})
+				gomock.InOrder(
+					prompter.EXPECT().Select("Select node setup", "", []string{sedgeOpts.EthereumNode, sedgeOpts.LidoNode}).Return(1, nil),
+					prompter.EXPECT().Select("Select network", "", []string{NetworkMainnet, NetworkHolesky, NetworkSepolia}).Return(1, nil),
+					prompter.EXPECT().Select("Select node type", "", []string{NodeTypeFullNode, NodeTypeExecution, NodeTypeConsensus, NodeTypeValidator}).Return(0, nil),
+					prompter.EXPECT().Input("Generation path", configs.DefaultAbsSedgeDataPath, false, nil).Return(generationPath, nil),
+					prompter.EXPECT().Input("Container tag, sedge will add to each container and the network, a suffix with the tag", "", false, nil).Return("tag", nil),
+					prompter.EXPECT().Confirm("Do you want to set up a validator?", true).Return(true, nil),
+					prompter.EXPECT().Input("Mev-Boost image", "flashbots/mev-boost:latest", false, nil).Return("flashbots/mev-boost:latest", nil),
+					prompter.EXPECT().Select("Select execution client", "", ETHClients["execution"]).Return(0, nil),
+					prompter.EXPECT().Select("Select consensus client", "", ETHClients["consensus"]).Return(1, nil),
+					prompter.EXPECT().Select("Select validator client", "", ETHClients["validator"]).Return(1, nil),
+					prompter.EXPECT().InputInt64("Validator grace period. This is the number of epochs the validator will wait for security reasons before starting", int64(1)).Return(int64(2), nil),
+					prompter.EXPECT().Input("Graffiti to be used by the validator (press enter to skip it)", "", false, gomock.AssignableToTypeOf(ui.GraffitiValidator)).Return("test graffiti", nil),
+					prompter.EXPECT().InputURL("Checkpoint sync URL", configs.NetworksConfigs()[genData.Network].CheckpointSyncURL, false).Return("http://checkpoint.sync", nil),
+					prompter.EXPECT().Confirm("Do you want to expose all ports?", false).Return(true, nil),
+					prompter.EXPECT().Select("Select JWT source", "", []string{SourceTypeCreate, SourceTypeExisting}).Return(0, nil),
+					sedgeActions.EXPECT().Generate(gomock.Eq(actions.GenerateOptions{
+						GenerationPath: generationPath,
+						GenerationData: genData,
+					})).Return(genData, nil),
+					prompter.EXPECT().Select("Select keystore source", "", []string{SourceTypeCreate, SourceTypeExisting, SourceTypeSkip}).Return(0, nil),
+					prompter.EXPECT().Select("Select mnemonic source", "", []string{SourceTypeCreate, SourceTypeExisting}).Return(0, nil),
+					prompter.EXPECT().Select("Select passphrase source", "", []string{SourceTypeRandom, SourceTypeExisting, SourceTypeCreate}).Return(0, nil),
+					prompter.EXPECT().InputInt64("Number of validators", int64(1)).Return(int64(1), nil),
+					prompter.EXPECT().InputInt64("Existing validators. This number will be used as the initial index for the generated keystores.", int64(0)).Return(int64(0), nil),
+					depsMgr.EXPECT().Check([]string{dependencies.Docker}).Return([]string{dependencies.Docker}, nil),
+					depsMgr.EXPECT().DockerEngineIsOn().Return(nil),
+					depsMgr.EXPECT().DockerComposeIsInstalled().Return(nil),
+					sedgeActions.EXPECT().SetupContainers(actions.SetupContainersOptions{
+						GenerationPath: generationPath,
+						Services:       []string{"validator"},
+					}),
+					sedgeActions.EXPECT().ImportValidatorKeys(actions.ImportValidatorKeysOptions{
+						ValidatorClient: "prysm",
+						Network:         NetworkHolesky,
 						GenerationPath:  generationPath,
 						From:            filepath.Join(generationPath, "keystore"),
 						ContainerTag:    "tag",

--- a/internal/pkg/generate/generate_scripts.go
+++ b/internal/pkg/generate/generate_scripts.go
@@ -20,6 +20,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"text/template"
 
@@ -242,6 +243,7 @@ func ComposeFile(gd *GenData, at io.Writer) error {
 			gd.MevBoostEndpoint = fmt.Sprintf("%s:%v", configs.DefaultMevBoostEndpoint, gd.Ports["MevPort"])
 		}
 	}
+	gd.MevBoostService = slices.Contains(gd.Services, "mev-boost")
 
 	data := DockerComposeData{
 		Services:            gd.Services,

--- a/templates/envs/holesky/validator/lighthouse.tmpl
+++ b/templates/envs/holesky/validator/lighthouse.tmpl
@@ -8,4 +8,5 @@ VL_INSTANCE_NAME=LighthouseValidator
 VL_IMAGE_VERSION={{.VlImage}}
 KEYSTORE_DIR={{.KeystoreDir}}
 VL_DATA_DIR={{.VlDataDir}}
+MEV=true
 {{ end }}

--- a/templates/envs/holesky/validator/lodestar.tmpl
+++ b/templates/envs/holesky/validator/lodestar.tmpl
@@ -9,4 +9,5 @@ VL_IMAGE_VERSION={{.VlImage}}
 KEYSTORE_DIR={{.KeystoreDir}}
 VL_DATA_DIR={{.VlDataDir}}
 VL_LODESTAR_PRESET=mainnet
+MEV=true
 {{ end }}

--- a/templates/envs/holesky/validator/prysm.tmpl
+++ b/templates/envs/holesky/validator/prysm.tmpl
@@ -10,4 +10,5 @@ VL_IMAGE_VERSION={{.VlImage}}
 KEYSTORE_DIR={{.KeystoreDir}}
 WALLET_DIR=./wallet
 VL_DATA_DIR={{.VlDataDir}}
+MEV=true
 {{ end }}

--- a/templates/envs/holesky/validator/teku.tmpl
+++ b/templates/envs/holesky/validator/teku.tmpl
@@ -8,4 +8,5 @@ VL_INSTANCE_NAME=TekuValidator
 VL_IMAGE_VERSION={{.VlImage}}
 KEYSTORE_DIR={{.KeystoreDir}}
 VL_DATA_DIR={{.VlDataDir}}
+MEV=true
 {{ end }}


### PR DESCRIPTION
## Changes:
- mev-boost service not being generated for Holesky network when using `sedge cli`.
## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [X] Yes
- [ ] No

**In case you checked yes, did you write tests?**

- [X] Yes
- [ ] No

## Further comments (optional)

I didn't update the changelog because it is supposed we are bringing new support for mev-boost on Holesky.