### PR TITLE
Set golang to 1.21 on release actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.19.0"
+          go-version: "1.21.0"
 
       - run: chmod +x ./scripts/build-go-darwin-binaries.sh && ./scripts/build-go-darwin-binaries.sh
 
@@ -74,7 +74,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.19.0"
+          go-version: "1.21.0"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3


### PR DESCRIPTION
## Changes:
- Update actions to run on golang 1.21 for release

## Types of changes

What types of changes does your code introduce?
- [x] Bugfix (non-breaking change which fixes an issue)
