### PR TITLE
OP Stack: remove not needed discovery flag

### DIFF
--- a/templates/services/merge/optimism/optimism.tmpl
+++ b/templates/services/merge/optimism/optimism.tmpl
@@ -27,7 +27,6 @@
       - --config={{.NetworkPrefix}}-${NETWORK}
       - --datadir=/nethermind/data
       - --log=${NETHERMIND_OP_LOG_LEVEL}
-      - --Discovery.Discv5Enabled=true
       - --JsonRpc.Enabled=true
       - --JsonRpc.Host=0.0.0.0
       - --JsonRpc.Port={{.ElOPApiPort}}


### PR DESCRIPTION
Removes the not existing Nethermind flag for OP stack. By default, OP configuration already enables `Discovery.Discv5Enabled`