### PR TITLE
Remove mockgen generation while cloning repo

### DIFF
--- a/.github/workflows/code-generation-checks.yml
+++ b/.github/workflows/code-generation-checks.yml
@@ -1,0 +1,42 @@
+name: Go Code Generation Check
+
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  generate:
+    name: Check Code Generation
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+
+      - name: Set up Go bin in PATH
+        run: echo "${HOME}/go/bin" >> $GITHUB_PATH
+
+      - name: Install Dependencies and Tools
+        run: |
+          make install-deps install-abigen install-mockgen
+
+      - name: Generate Code
+        run: make generate
+
+      - name: Check for Uncommitted Changes
+        run: |
+          if [[ $(git status --porcelain) ]]; then
+            echo '::error::Uncommitted changes detected. Please run `make generate` and commit the generated code.'
+            echo 'Modified files:'
+            git status --porcelain
+            exit 1
+          else
+            echo 'No uncommitted changes. All generated code is up to date.'
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -18,12 +18,4 @@ courtney/
 
 mocks/
 
-internal/lido/contracts/csaccounting/CSAccounting.go
-
-internal/lido/contracts/csfeedistributor/CSFeeDistributor.go
-
-internal/lido/contracts/csmodule/CSModule.go
-
-internal/lido/contracts/mevboostrelaylist/MEVBoostRelayAllowedList.go
-
 build/lido-exporter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update Go version from 1.21 to 1.22.
 - Update documentation versions and dependencies.
 - Update Lido Mainnet Vetted Relays List.
+- Remove the need of users cloning the repository to run `make generate` and `make compile`, rolling back to only `make compile`
 
 ### Fixed
 -  Teku and Lighthouse import keys container error on Windows.

--- a/internal/lido/contracts/csaccounting/CSAccounting.go
+++ b/internal/lido/contracts/csaccounting/CSAccounting.go
@@ -1,0 +1,6362 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package csaccounting
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// ICSAccountingPermitInput is an auto generated low-level Go binding around an user-defined struct.
+type ICSAccountingPermitInput struct {
+	Value    *big.Int
+	Deadline *big.Int
+	V        uint8
+	R        [32]byte
+	S        [32]byte
+}
+
+// ICSBondCurveBondCurve is an auto generated low-level Go binding around an user-defined struct.
+type ICSBondCurveBondCurve struct {
+	Points []*big.Int
+	Trend  *big.Int
+}
+
+// ICSBondLockBondLock is an auto generated low-level Go binding around an user-defined struct.
+type ICSBondLockBondLock struct {
+	Amount         *big.Int
+	RetentionUntil *big.Int
+}
+
+// CsaccountingMetaData contains all meta data concerning the Csaccounting contract.
+var CsaccountingMetaData = &bind.MetaData{
+	ABI: "[{\"inputs\":[{\"internalType\":\"address\",\"name\":\"lidoLocator\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"communityStakingModule\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"maxCurveLength\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"minBondLockRetentionPeriod\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxBondLockRetentionPeriod\",\"type\":\"uint256\"}],\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"},{\"inputs\":[],\"name\":\"AccessControlBadConfirmation\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"},{\"internalType\":\"bytes32\",\"name\":\"neededRole\",\"type\":\"bytes32\"}],\"name\":\"AccessControlUnauthorizedAccount\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"ElRewardsVaultReceiveFailed\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"FailedToSendEther\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidBondCurveId\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidBondCurveLength\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidBondCurveMaxLength\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidBondCurveValues\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidBondLockAmount\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidBondLockRetentionPeriod\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidInitialisationCurveId\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidInitialization\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"NodeOperatorDoesNotExist\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"NotAllowedToRecover\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"NotInitializing\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"NothingToClaim\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"PauseUntilMustBeInFuture\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"PausedExpected\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"ResumedExpected\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint8\",\"name\":\"bits\",\"type\":\"uint8\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"SafeCastOverflowedUintDowncast\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"SenderIsNotCSM\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"ZeroAdminAddress\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"ZeroChargePenaltyRecipientAddress\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"ZeroFeeDistributorAddress\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"ZeroLocatorAddress\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"ZeroModuleAddress\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"ZeroPauseDuration\",\"type\":\"error\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"toBurnAmount\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"burnedAmount\",\"type\":\"uint256\"}],\"name\":\"BondBurned\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"toChargeAmount\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"chargedAmount\",\"type\":\"uint256\"}],\"name\":\"BondCharged\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"BondClaimedStETH\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"requestId\",\"type\":\"uint256\"}],\"name\":\"BondClaimedUnstETH\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"BondClaimedWstETH\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint256[]\",\"name\":\"bondCurve\",\"type\":\"uint256[]\"}],\"name\":\"BondCurveAdded\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"curveId\",\"type\":\"uint256\"}],\"name\":\"BondCurveSet\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"curveId\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256[]\",\"name\":\"bondCurve\",\"type\":\"uint256[]\"}],\"name\":\"BondCurveUpdated\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"address\",\"name\":\"from\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"BondDepositedETH\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"address\",\"name\":\"from\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"BondDepositedStETH\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"address\",\"name\":\"from\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"BondDepositedWstETH\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"newAmount\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"retentionUntil\",\"type\":\"uint256\"}],\"name\":\"BondLockChanged\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"BondLockCompensated\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"}],\"name\":\"BondLockRemoved\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"retentionPeriod\",\"type\":\"uint256\"}],\"name\":\"BondLockRetentionPeriodChanged\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"address\",\"name\":\"chargePenaltyRecipient\",\"type\":\"address\"}],\"name\":\"ChargePenaltyRecipientSet\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"token\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"tokenId\",\"type\":\"uint256\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"recipient\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"ERC1155Recovered\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"token\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"recipient\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"ERC20Recovered\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"token\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"tokenId\",\"type\":\"uint256\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"recipient\",\"type\":\"address\"}],\"name\":\"ERC721Recovered\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"recipient\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"EtherRecovered\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint64\",\"name\":\"version\",\"type\":\"uint64\"}],\"name\":\"Initialized\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"duration\",\"type\":\"uint256\"}],\"name\":\"Paused\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[],\"name\":\"Resumed\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"role\",\"type\":\"bytes32\"},{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"previousAdminRole\",\"type\":\"bytes32\"},{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"newAdminRole\",\"type\":\"bytes32\"}],\"name\":\"RoleAdminChanged\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"role\",\"type\":\"bytes32\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"sender\",\"type\":\"address\"}],\"name\":\"RoleGranted\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"role\",\"type\":\"bytes32\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"sender\",\"type\":\"address\"}],\"name\":\"RoleRevoked\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"recipient\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"shares\",\"type\":\"uint256\"}],\"name\":\"StETHSharesRecovered\",\"type\":\"event\"},{\"inputs\":[],\"name\":\"ACCOUNTING_MANAGER_ROLE\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"CSM\",\"outputs\":[{\"internalType\":\"contractICSModule\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"DEFAULT_ADMIN_ROLE\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"DEFAULT_BOND_CURVE_ID\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"LIDO\",\"outputs\":[{\"internalType\":\"contractILido\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"LIDO_LOCATOR\",\"outputs\":[{\"internalType\":\"contractILidoLocator\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"MANAGE_BOND_CURVES_ROLE\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"MAX_BOND_LOCK_RETENTION_PERIOD\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"MAX_CURVE_LENGTH\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"MIN_BOND_LOCK_RETENTION_PERIOD\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"MIN_CURVE_LENGTH\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"PAUSE_INFINITELY\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"PAUSE_ROLE\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"RECOVERER_ROLE\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"RESET_BOND_CURVE_ROLE\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"RESUME_ROLE\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"SET_BOND_CURVE_ROLE\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"WITHDRAWAL_QUEUE\",\"outputs\":[{\"internalType\":\"contractIWithdrawalQueue\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"WSTETH\",\"outputs\":[{\"internalType\":\"contractIWstETH\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256[]\",\"name\":\"bondCurve\",\"type\":\"uint256[]\"}],\"name\":\"addBondCurve\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"id\",\"type\":\"uint256\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"chargeFee\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"chargePenaltyRecipient\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"stETHAmount\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"rewardAddress\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"cumulativeFeeShares\",\"type\":\"uint256\"},{\"internalType\":\"bytes32[]\",\"name\":\"rewardsProof\",\"type\":\"bytes32[]\"}],\"name\":\"claimRewardsStETH\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"stEthAmount\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"rewardAddress\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"cumulativeFeeShares\",\"type\":\"uint256\"},{\"internalType\":\"bytes32[]\",\"name\":\"rewardsProof\",\"type\":\"bytes32[]\"}],\"name\":\"claimRewardsUnstETH\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"wstETHAmount\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"rewardAddress\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"cumulativeFeeShares\",\"type\":\"uint256\"},{\"internalType\":\"bytes32[]\",\"name\":\"rewardsProof\",\"type\":\"bytes32[]\"}],\"name\":\"claimRewardsWstETH\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"}],\"name\":\"compensateLockedBondETH\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"from\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"}],\"name\":\"depositETH\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"from\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"stETHAmount\",\"type\":\"uint256\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"deadline\",\"type\":\"uint256\"},{\"internalType\":\"uint8\",\"name\":\"v\",\"type\":\"uint8\"},{\"internalType\":\"bytes32\",\"name\":\"r\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"s\",\"type\":\"bytes32\"}],\"internalType\":\"structICSAccounting.PermitInput\",\"name\":\"permit\",\"type\":\"tuple\"}],\"name\":\"depositStETH\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"from\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"wstETHAmount\",\"type\":\"uint256\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"deadline\",\"type\":\"uint256\"},{\"internalType\":\"uint8\",\"name\":\"v\",\"type\":\"uint8\"},{\"internalType\":\"bytes32\",\"name\":\"r\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"s\",\"type\":\"bytes32\"}],\"internalType\":\"structICSAccounting.PermitInput\",\"name\":\"permit\",\"type\":\"tuple\"}],\"name\":\"depositWstETH\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"feeDistributor\",\"outputs\":[{\"internalType\":\"contractICSFeeDistributor\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"}],\"name\":\"getActualLockedBond\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"}],\"name\":\"getBond\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"keys\",\"type\":\"uint256\"},{\"components\":[{\"internalType\":\"uint256[]\",\"name\":\"points\",\"type\":\"uint256[]\"},{\"internalType\":\"uint256\",\"name\":\"trend\",\"type\":\"uint256\"}],\"internalType\":\"structICSBondCurve.BondCurve\",\"name\":\"curve\",\"type\":\"tuple\"}],\"name\":\"getBondAmountByKeysCount\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"pure\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"keys\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"curveId\",\"type\":\"uint256\"}],\"name\":\"getBondAmountByKeysCount\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"keysCount\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"curveId\",\"type\":\"uint256\"}],\"name\":\"getBondAmountByKeysCountWstETH\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"keysCount\",\"type\":\"uint256\"},{\"components\":[{\"internalType\":\"uint256[]\",\"name\":\"points\",\"type\":\"uint256[]\"},{\"internalType\":\"uint256\",\"name\":\"trend\",\"type\":\"uint256\"}],\"internalType\":\"structICSBondCurve.BondCurve\",\"name\":\"curve\",\"type\":\"tuple\"}],\"name\":\"getBondAmountByKeysCountWstETH\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"}],\"name\":\"getBondCurve\",\"outputs\":[{\"components\":[{\"internalType\":\"uint256[]\",\"name\":\"points\",\"type\":\"uint256[]\"},{\"internalType\":\"uint256\",\"name\":\"trend\",\"type\":\"uint256\"}],\"internalType\":\"structICSBondCurve.BondCurve\",\"name\":\"\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"}],\"name\":\"getBondCurveId\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"getBondLockRetentionPeriod\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"}],\"name\":\"getBondShares\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"}],\"name\":\"getBondSummary\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"current\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"required\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"}],\"name\":\"getBondSummaryShares\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"current\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"required\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"curveId\",\"type\":\"uint256\"}],\"name\":\"getCurveInfo\",\"outputs\":[{\"components\":[{\"internalType\":\"uint256[]\",\"name\":\"points\",\"type\":\"uint256[]\"},{\"internalType\":\"uint256\",\"name\":\"trend\",\"type\":\"uint256\"}],\"internalType\":\"structICSBondCurve.BondCurve\",\"name\":\"\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"},{\"components\":[{\"internalType\":\"uint256[]\",\"name\":\"points\",\"type\":\"uint256[]\"},{\"internalType\":\"uint256\",\"name\":\"trend\",\"type\":\"uint256\"}],\"internalType\":\"structICSBondCurve.BondCurve\",\"name\":\"curve\",\"type\":\"tuple\"}],\"name\":\"getKeysCountByBondAmount\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"pure\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"curveId\",\"type\":\"uint256\"}],\"name\":\"getKeysCountByBondAmount\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"}],\"name\":\"getLockedBondInfo\",\"outputs\":[{\"components\":[{\"internalType\":\"uint128\",\"name\":\"amount\",\"type\":\"uint128\"},{\"internalType\":\"uint128\",\"name\":\"retentionUntil\",\"type\":\"uint128\"}],\"internalType\":\"structICSBondLock.BondLock\",\"name\":\"\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"additionalKeys\",\"type\":\"uint256\"}],\"name\":\"getRequiredBondForNextKeys\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"additionalKeys\",\"type\":\"uint256\"}],\"name\":\"getRequiredBondForNextKeysWstETH\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"getResumeSinceTimestamp\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"role\",\"type\":\"bytes32\"}],\"name\":\"getRoleAdmin\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"role\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"index\",\"type\":\"uint256\"}],\"name\":\"getRoleMember\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"role\",\"type\":\"bytes32\"}],\"name\":\"getRoleMemberCount\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"}],\"name\":\"getUnbondedKeysCount\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"}],\"name\":\"getUnbondedKeysCountToEject\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"role\",\"type\":\"bytes32\"},{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"}],\"name\":\"grantRole\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"role\",\"type\":\"bytes32\"},{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"}],\"name\":\"hasRole\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256[]\",\"name\":\"bondCurve\",\"type\":\"uint256[]\"},{\"internalType\":\"address\",\"name\":\"admin\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"_feeDistributor\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"bondLockRetentionPeriod\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"_chargePenaltyRecipient\",\"type\":\"address\"}],\"name\":\"initialize\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"isPaused\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"lockBondETH\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"duration\",\"type\":\"uint256\"}],\"name\":\"pauseFor\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"penalize\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"cumulativeFeeShares\",\"type\":\"uint256\"},{\"internalType\":\"bytes32[]\",\"name\":\"rewardsProof\",\"type\":\"bytes32[]\"}],\"name\":\"pullFeeRewards\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"token\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"tokenId\",\"type\":\"uint256\"}],\"name\":\"recoverERC1155\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"token\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"recoverERC20\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"token\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"tokenId\",\"type\":\"uint256\"}],\"name\":\"recoverERC721\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"recoverEther\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"recoverStETHShares\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"releaseLockedBondETH\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"renewBurnerAllowance\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"role\",\"type\":\"bytes32\"},{\"internalType\":\"address\",\"name\":\"callerConfirmation\",\"type\":\"address\"}],\"name\":\"renounceRole\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"}],\"name\":\"resetBondCurve\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"resume\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"role\",\"type\":\"bytes32\"},{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"}],\"name\":\"revokeRole\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"curveId\",\"type\":\"uint256\"}],\"name\":\"setBondCurve\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_chargePenaltyRecipient\",\"type\":\"address\"}],\"name\":\"setChargePenaltyRecipient\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"retention\",\"type\":\"uint256\"}],\"name\":\"setLockedBondRetentionPeriod\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"}],\"name\":\"settleLockedBondETH\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"settledAmount\",\"type\":\"uint256\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes4\",\"name\":\"interfaceId\",\"type\":\"bytes4\"}],\"name\":\"supportsInterface\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"totalBondShares\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"curveId\",\"type\":\"uint256\"},{\"internalType\":\"uint256[]\",\"name\":\"bondCurve\",\"type\":\"uint256[]\"}],\"name\":\"updateBondCurve\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}]",
+	Bin: "0x608060405260043610610463575f3560e01c80638980f11f11610241578063cb11c52711610134578063dcab7f83116100b3578063f3f449c711610078578063f3f449c714610f3c578063f7966efe14610f5b578063f939122314610f7a578063fab382f114610f99578063fee6380514610fb8575f80fd5b8063dcab7f8314610e98578063def82d0214610eb7578063e5220e3f14610eea578063ead42a6914610f09578063f3efecc414610f28575f80fd5b8063d8fe7642116100f9578063d8fe764214610dd5578063d963ae5514610df4578063d9fb643a14610e13578063dbba4b4814610e46578063dc38ea3d14610e79575f80fd5b8063cb11c52714610d45578063cc810cb914610d59578063ce19793f14610d78578063d2fa16a614610d97578063d547741f14610db6575f80fd5b80639c516102116101c0578063b148db6a11610185578063b148db6a14610cb5578063b187bd2614610cd4578063b2d03e4d14610ce8578063b5b624bf14610d07578063ca15c87314610d26575f80fd5b80639c51610214610c1c578063a217fddf146107a1578063a302ee3814610c3b578063acf1c94814610c4f578063ae84975614610c82575f80fd5b80639010d07c116102065780639010d07c14610b8157806391d1485414610ba05780639996522514610bbf5780639a4df8f014610bde5780639b4c6c2714610bfd575f80fd5b80638980f11f14610a955780638b21f17014610ab45780638de2b27214610ae75780638ed5c5d714610b1a5780638f6549ae14610b4d575f80fd5b80634342b3c111610359578063589ff76c116102d857806370903eb91161029d57806370903eb91461096f57806374d70aea1461098e578063819d4cc6146109c157806383316184146109e0578063881fa03c14610a76575f80fd5b8063589ff76c146108c95780635a73bdc8146108dd5780635c654ad9146108f1578063699340f4146109105780636e13f09914610943575f80fd5b80634c7ed3d21161031e5780634c7ed3d214610825578063526352fc1461084457806352d8bfc214610877578063546da24f1461088b578063573b6245146108aa575f80fd5b80634342b3c11461076e578063443fbfef146107a1578063449add1b146107b45780634b2ce9fe146107d35780634bb22a7214610806575f80fd5b8063165123dd116103e55780632e599054116103aa5780632e599054146106cb5780632f2ff15d146106de57806336568abe146106fd578063389ed2671461071c578063433cd6c31461074f575f80fd5b8063165123dd146105ed57806321d439d51461060c578063248a9ca31461063f57806328846981146106795780632de03aa114610698575f80fd5b806306cd0e901161042b57806306cd0e90146105475780630d43e8ad146105665780630f23e7421461059c57806313d1234b146105bb57806315b5c477146105da575f80fd5b8063019c1a4f1461046757806301a5e9e31461048857806301ffc9a7146104ba578063046f7da2146104e95780630569b947146104fd575b5f80fd5b348015610472575f80fd5b50610486610481366004614c69565b610feb565b005b348015610493575f80fd5b506104a76104a2366004614cb1565b611026565b6040519081526020015b60405180910390f35b3480156104c5575f80fd5b506104d96104d4366004614cc8565b611038565b60405190151581526020016104b1565b3480156104f4575f80fd5b5061048661105c565b348015610508575f80fd5b506104a7610517366004614cb1565b5f9081527f8f22e270e477f5becb8793b61d439ab7ae990ed8eba045eb72061c0e6cfe1501602052604090205490565b348015610552575f80fd5b506104a7610561366004614cb1565b611091565b348015610571575f80fd5b505f54610584906001600160a01b031681565b6040516001600160a01b0390911681526020016104b1565b3480156105a7575f80fd5b506104a76105b6366004614d80565b6110c1565b3480156105c6575f80fd5b506104a76105d5366004614e55565b611140565b6104866105e8366004614cb1565b6111de565b3480156105f8575f80fd5b50600154610584906001600160a01b031681565b348015610617575f80fd5b506104a77fb5dffea014b759c493d63b1edaceb942631d6468998125e1b4fe427c9908213481565b34801561064a575f80fd5b506104a7610659366004614cb1565b5f9081525f80516020615385833981519152602052604090206001015490565b348015610684575f80fd5b506104a7610693366004614e55565b61135e565b3480156106a3575f80fd5b506104a77f2fc10cc8ae19568712f7a176fb4978616a610650813c9d05326c34abb62749c781565b6104866106d9366004614e89565b611398565b3480156106e9575f80fd5b506104866106f8366004614eb3565b6113f7565b348015610708575f80fd5b50610486610717366004614eb3565b611427565b348015610727575f80fd5b506104a77f139c2898040ef16910dc9f44dc697df79363da767d8bc92f2e310312b816e46d81565b34801561075a575f80fd5b50610486610769366004614ee1565b61145f565b348015610779575f80fd5b506104a77f645c9e6d2a86805cb5a28b1e4751c0dab493df7cf935070ce405489ba1a7bf7281565b3480156107ac575f80fd5b506104a75f81565b3480156107bf575f80fd5b506104866107ce366004614cb1565b611492565b3480156107de575f80fd5b506104a77f000000000000000000000000000000000000000000000000000000000000000a81565b348015610811575f80fd5b506104a7610820366004614cb1565b6114ce565b348015610830575f80fd5b5061048661083f366004614efc565b611546565b34801561084f575f80fd5b506104a77f0000000000000000000000000000000000000000000000000000000001e1338081565b348015610882575f80fd5b50610486611716565b348015610896575f80fd5b506104a76108a5366004614e55565b611772565b3480156108b5575f80fd5b506104a76108c4366004614f4b565b611780565b3480156108d4575f80fd5b506104a76117b5565b3480156108e8575f80fd5b506104866117e3565b3480156108fc575f80fd5b5061048661090b366004614e89565b611938565b34801561091b575f80fd5b506105847f000000000000000000000000c7cc160b58f8bb0bac94b80847e2cf2800565c5081565b34801561094e575f80fd5b5061096261095d366004614cb1565b6119b3565b6040516104b19190614f8a565b34801561097a575f80fd5b50610486610989366004614fe5565b6119fe565b348015610999575f80fd5b507f23f334b9eb5378c2a1573857b8f9d9ca79959360a69e73d3f16848e56ec92101546104a7565b3480156109cc575f80fd5b506104866109db366004614e89565b611a6c565b3480156109eb575f80fd5b50610a4f6109fa366004614cb1565b6040805180820182525f80825260209182018190529283525f805160206153658339815191528152918190208151808301909252546001600160801b038082168352600160801b909104169181019190915290565b6040805182516001600160801b0390811682526020938401511692810192909252016104b1565b348015610a81575f80fd5b50610486610a90366004614e55565b611abb565b348015610aa0575f80fd5b50610486610aaf366004614e89565b611b1d565b348015610abf575f80fd5b506105847f0000000000000000000000003f1c547b21f65e10480de3ad8e19faac46c9503481565b348015610af2575f80fd5b506105847f0000000000000000000000004562c3e63c2e586cd1651b958c22f88135acad4f81565b348015610b25575f80fd5b506104a77f40579467dba486691cc62fd8536d22c6d4dc9cdc7bc716ef2518422aa554c09881565b348015610b58575f80fd5b50610b6c610b67366004614cb1565b611bbe565b604080519283526020830191909152016104b1565b348015610b8c575f80fd5b50610584610b9b366004614e55565b611c78565b348015610bab575f80fd5b506104d9610bba366004614eb3565b611cb0565b348015610bca575f80fd5b50610486610bd9366004614cb1565b611ce6565b348015610be9575f80fd5b506104a7610bf8366004614d80565b611d19565b348015610c08575f80fd5b50610486610c17366004615053565b611d53565b348015610c27575f80fd5b506104a7610c36366004614cb1565b611d68565b348015610c46575f80fd5b506104a75f1981565b348015610c5a575f80fd5b506104a77fb3e25b5404b87e5a838579cb5d7481d61ad96ee284d38ec1e97c07ba64e7f6fc81565b348015610c8d575f80fd5b506104a77f000000000000000000000000000000000000000000000000000000000000000081565b348015610cc0575f80fd5b506104a7610ccf366004614e55565b611d73565b348015610cdf575f80fd5b506104d9611e4f565b348015610cf3575f80fd5b50610486610d02366004614e55565b611e7f565b348015610d12575f80fd5b50610962610d21366004614cb1565b611ebc565b348015610d31575f80fd5b506104a7610d40366004614cb1565b611f80565b348015610d50575f80fd5b506104a7600181565b348015610d64575f80fd5b50610486610d73366004614fe5565b611fb7565b348015610d83575f80fd5b50610b6c610d92366004614cb1565b612025565b348015610da2575f80fd5b506104a7610db1366004614d80565b6120d7565b348015610dc1575f80fd5b50610486610dd0366004614eb3565b61213b565b348015610de0575f80fd5b506104a7610def366004614cb1565b61216b565b348015610dff575f80fd5b50610486610e0e366004614e55565b61217d565b348015610e1e575f80fd5b506105847f0000000000000000000000008d09a4502cc8cf1547ad300e066060d043f6982d81565b348015610e51575f80fd5b506105847f00000000000000000000000028fab2059c713a7f9d8c86db49f9bb0e96af1ef881565b348015610e84575f80fd5b506104a7610e93366004614e55565b6121d0565b348015610ea3575f80fd5b50610486610eb2366004614e55565b6121de565b348015610ec2575f80fd5b507f78c5a36767279da056404c09083fca30cf3ea61c442cfaba6669f76a37393f00546104a7565b348015610ef5575f80fd5b50610486610f04366004614e55565b612231565b348015610f14575f80fd5b506104a7610f23366004614cb1565b612284565b348015610f33575f80fd5b506104866122d8565b348015610f47575f80fd5b50610486610f56366004614cb1565b6123f5565b348015610f66575f80fd5b50610486610f75366004614efc565b612428565b348015610f85575f80fd5b50610486610f94366004614fe5565b6125f8565b348015610fa4575f80fd5b50610486610fb33660046150a2565b612666565b348015610fc3575f80fd5b506104a77fd35e4a788498271198ec69c34f1dc762a1eee8200c111f598da1b3dde946783d81565b7fd35e4a788498271198ec69c34f1dc762a1eee8200c111f598da1b3dde946783d61101581612b1d565b611020848484612b27565b50505050565b5f611032826001612c92565b92915050565b5f6001600160e01b03198216635a05180f60e01b1480611032575061103282612d80565b7f2fc10cc8ae19568712f7a176fb4978616a610650813c9d05326c34abb62749c761108681612b1d565b61108e612db4565b50565b5f9081527f23f334b9eb5378c2a1573857b8f9d9ca79959360a69e73d3f16848e56ec92100602052604090205490565b5f825f036110d057505f611032565b8151518084116110fa576110f56110e8600186615136565b8451602091820201015190565b611138565b60208301516111098286615136565b6111139190615149565b61112e611121600184615136565b8551602091820201015190565b6111389190615160565b949350505050565b5f7f0000000000000000000000008d09a4502cc8cf1547ad300e066060d043f6982d6001600160a01b031663b0e3890061117a8585611772565b6040518263ffffffff1660e01b815260040161119891815260200190565b602060405180830381865afa1580156111b3573d5f803e3d5ffd5b505050506040513d601f19601f820116820180604052508101906111d79190615173565b9392505050565b336001600160a01b037f0000000000000000000000004562c3e63c2e586cd1651b958c22f88135acad4f161461122757604051633bebb4c160e11b815260040160405180910390fd5b5f7f00000000000000000000000028fab2059c713a7f9d8c86db49f9bb0e96af1ef86001600160a01b031663e441d25f6040518163ffffffff1660e01b8152600401602060405180830381865afa158015611284573d5f803e3d5ffd5b505050506040513d601f19601f820116820180604052508101906112a8919061518a565b6001600160a01b0316346040515f6040518083038185875af1925050503d805f81146112ef576040519150601f19603f3d011682016040523d82523d5f602084013e6112f4565b606091505b5050905080611316576040516324f09be760e21b815260040160405180910390fd5b6113208234612e09565b817fb6ee6e3aae6776519627b46786a622b642c38cabfe4c97cb34054fd63fc11a233460405161135291815260200190565b60405180910390a25050565b5f7f0000000000000000000000008d09a4502cc8cf1547ad300e066060d043f6982d6001600160a01b031663b0e3890061117a8585611d73565b6113a0612e8f565b336001600160a01b037f0000000000000000000000004562c3e63c2e586cd1651b958c22f88135acad4f16146113e957604051633bebb4c160e11b815260040160405180910390fd5b6113f38282612eb7565b5050565b5f8281525f80516020615385833981519152602052604090206001015461141d81612b1d565b6110208383612fa4565b6001600160a01b03811633146114505760405163334bd91960e11b815260040160405180910390fd5b61145a8282612ff9565b505050565b7f40579467dba486691cc62fd8536d22c6d4dc9cdc7bc716ef2518422aa554c09861148981612b1d565b6113f382613045565b7fb5dffea014b759c493d63b1edaceb942631d6468998125e1b4fe427c990821346114bc81612b1d565b6114c5826130c1565b6113f382613164565b5f336001600160a01b037f0000000000000000000000004562c3e63c2e586cd1651b958c22f88135acad4f161461151857604051633bebb4c160e11b815260040160405180910390fd5b5f61152283612284565b905080156115375761153483826131ca565b91505b61154083613316565b50919050565b61154e612e8f565b336001600160a01b037f0000000000000000000000004562c3e63c2e586cd1651b958c22f88135acad4f161461159757604051633bebb4c160e11b815260040160405180910390fd5b8035158015906116375750604051636eb1769f60e11b81526001600160a01b0385811660048301523060248301528235917f0000000000000000000000003f1c547b21f65e10480de3ad8e19faac46c950349091169063dd62ed3e90604401602060405180830381865afa158015611611573d5f803e3d5ffd5b505050506040513d601f19601f820116820180604052508101906116359190615173565b105b1561170b576001600160a01b037f0000000000000000000000003f1c547b21f65e10480de3ad8e19faac46c950341663d505accf85308435602086013561168460608801604089016151a5565b6040516001600160e01b031960e088901b1681526001600160a01b0395861660048201529490931660248501526044840191909152606483015260ff166084820152606084013560a4820152608084013560c482015260e4015f604051808303815f87803b1580156116f4575f80fd5b505af1158015611706573d5f803e3d5ffd5b505050505b61102084848461335c565b61171e613459565b73a74528edc289b1a597faf83fcff7eff871cc01d96352d8bfc26040518163ffffffff1660e01b81526004015f6040518083038186803b158015611760575f80fd5b505af4158015611020573d5f803e3d5ffd5b5f6111d7836105b684611ebc565b5f7fd35e4a788498271198ec69c34f1dc762a1eee8200c111f598da1b3dde946783d6117ab81612b1d565b6111388484613482565b5f6117de7fe8b012900cb200ee5dfc3b895a32791b67d12891b09f117814f167a237783a025490565b905090565b6117eb613459565b5f6118147f23f334b9eb5378c2a1573857b8f9d9ca79959360a69e73d3f16848e56ec921015490565b604051633d7ad0b760e21b81523060048201527f0000000000000000000000003f1c547b21f65e10480de3ad8e19faac46c950346001600160a01b03169063f5eb42dc90602401602060405180830381865afa158015611876573d5f803e3d5ffd5b505050506040513d601f19601f8201168201806040525081019061189a9190615173565b6118a49190615136565b6040516389ad944360e01b81526001600160a01b037f0000000000000000000000003f1c547b21f65e10480de3ad8e19faac46c950341660048201526024810182905290915073a74528edc289b1a597faf83fcff7eff871cc01d9906389ad9443906044015f6040518083038186803b15801561191f575f80fd5b505af4158015611931573d5f803e3d5ffd5b5050505050565b611940613459565b604051635c654ad960e01b81526001600160a01b03831660048201526024810182905273a74528edc289b1a597faf83fcff7eff871cc01d990635c654ad9906044015b5f6040518083038186803b158015611999575f80fd5b505af41580156119ab573d5f803e3d5ffd5b505050505050565b60408051808201909152606081525f6020820152611032610d21835f9081527f8f22e270e477f5becb8793b61d439ab7ae990ed8eba045eb72061c0e6cfe1501602052604090205490565b611a06612e8f565b336001600160a01b037f0000000000000000000000004562c3e63c2e586cd1651b958c22f88135acad4f1614611a4f57604051633bebb4c160e11b815260040160405180910390fd5b8015611a6157611a61868484846135be565b6119ab868686613640565b611a74613459565b6040516340cea66360e11b81526001600160a01b03831660048201526024810182905273a74528edc289b1a597faf83fcff7eff871cc01d99063819d4cc690604401611983565b336001600160a01b037f0000000000000000000000004562c3e63c2e586cd1651b958c22f88135acad4f1614611b0457604051633bebb4c160e11b815260040160405180910390fd5b60015461145a90839083906001600160a01b0316613903565b611b25613459565b7f0000000000000000000000003f1c547b21f65e10480de3ad8e19faac46c950346001600160a01b0316826001600160a01b031603611b77576040516319efe5d760e21b815260040160405180910390fd5b604051638980f11f60e01b81526001600160a01b03831660048201526024810182905273a74528edc289b1a597faf83fcff7eff871cc01d990638980f11f90604401611983565b5f80611bc983611091565b9150611c71611bd784612284565b6040516311d8d20560e31b815260048101869052611c6b907f0000000000000000000000004562c3e63c2e586cd1651b958c22f88135acad4f6001600160a01b031690638ec6902890602401602060405180830381865afa158015611c3e573d5f803e3d5ffd5b505050506040513d601f19601f82011682018060405250810190611c629190615173565b6105b6876119b3565b01613a04565b9050915091565b5f8281527fc1f6fe24621ce81ec5827caf0253cadb74709b061630e6b55e823717059320006020819052604082206111389084613a8e565b5f9182525f80516020615385833981519152602090815260408084206001600160a01b0393909316845291905290205460ff1690565b7f40579467dba486691cc62fd8536d22c6d4dc9cdc7bc716ef2518422aa554c098611d1081612b1d565b6113f382613a99565b5f7f0000000000000000000000008d09a4502cc8cf1547ad300e066060d043f6982d6001600160a01b031663b0e3890061117a85856110c1565b611d5c846130c1565b611020848484846135be565b5f611032825f612c92565b5f80611d7e8461216b565b90505f611e1c847f0000000000000000000000004562c3e63c2e586cd1651b958c22f88135acad4f6001600160a01b0316638ec69028886040518263ffffffff1660e01b8152600401611dd391815260200190565b602060405180830381865afa158015611dee573d5f803e3d5ffd5b505050506040513d601f19601f82011682018060405250810190611e129190615173565b611c629190615160565b90505f611e2886612284565b611e329083615160565b9050828111611e41575f611e45565b8281035b9695505050505050565b5f611e787fe8b012900cb200ee5dfc3b895a32791b67d12891b09f117814f167a237783a025490565b4210905090565b7f645c9e6d2a86805cb5a28b1e4751c0dab493df7cf935070ce405489ba1a7bf72611ea981612b1d565b611eb2836130c1565b61145a8383613b57565b60408051808201909152606081525f60208201527f8f22e270e477f5becb8793b61d439ab7ae990ed8eba045eb72061c0e6cfe1500805483908110611f0357611f036151c5565b905f5260205f2090600202016040518060400160405290815f8201805480602002602001604051908101604052809291908181526020018280548015611f6657602002820191905f5260205f20905b815481526020019060010190808311611f52575b505050505081526020016001820154815250509050919050565b5f8181527fc1f6fe24621ce81ec5827caf0253cadb74709b061630e6b55e823717059320006020819052604082206111d790613be3565b611fbf612e8f565b336001600160a01b037f0000000000000000000000004562c3e63c2e586cd1651b958c22f88135acad4f161461200857604051633bebb4c160e11b815260040160405180910390fd5b801561201a5761201a868484846135be565b6119ab868686613bec565b5f806120308361216b565b915061203b83612284565b6040516311d8d20560e31b8152600481018590526120cf907f0000000000000000000000004562c3e63c2e586cd1651b958c22f88135acad4f6001600160a01b031690638ec6902890602401602060405180830381865afa1580156120a2573d5f803e3d5ffd5b505050506040513d601f19601f820116820180604052508101906120c69190615173565b6105b6866119b3565b019050915091565b8051602001515f908310156120ed57505f611032565b8151515f6120ff611121600184615136565b90508085106121255783602001518186038161211d5761211d6151d9565b048201612132565b61213285855f0151613ec0565b95945050505050565b5f8281525f80516020615385833981519152602052604090206001015461216181612b1d565b6110208383612ff9565b5f61103261217883611091565b613f2c565b336001600160a01b037f0000000000000000000000004562c3e63c2e586cd1651b958c22f88135acad4f16146121c657604051633bebb4c160e11b815260040160405180910390fd5b6113f38282612e09565b5f6111d783610db184611ebc565b336001600160a01b037f0000000000000000000000004562c3e63c2e586cd1651b958c22f88135acad4f161461222757604051633bebb4c160e11b815260040160405180910390fd5b6113f38282613f7b565b336001600160a01b037f0000000000000000000000004562c3e63c2e586cd1651b958c22f88135acad4f161461227a57604051633bebb4c160e11b815260040160405180910390fd5b61145a82826131ca565b5f8181525f8051602061536583398151915260205260408120805442600160801b9091046001600160801b0316116122bc575f6122c8565b80546001600160801b03165b6001600160801b03169392505050565b7f0000000000000000000000003f1c547b21f65e10480de3ad8e19faac46c950346001600160a01b031663095ea7b37f00000000000000000000000028fab2059c713a7f9d8c86db49f9bb0e96af1ef86001600160a01b03166327810b6e6040518163ffffffff1660e01b8152600401602060405180830381865afa158015612363573d5f803e3d5ffd5b505050506040513d601f19601f82011682018060405250810190612387919061518a565b6040516001600160e01b031960e084901b1681526001600160a01b0390911660048201525f1960248201526044016020604051808303815f875af11580156123d1573d5f803e3d5ffd5b505050506040513d601f19601f8201168201806040525081019061108e91906151ed565b7f139c2898040ef16910dc9f44dc697df79363da767d8bc92f2e310312b816e46d61241f81612b1d565b6113f382614014565b612430612e8f565b336001600160a01b037f0000000000000000000000004562c3e63c2e586cd1651b958c22f88135acad4f161461247957604051633bebb4c160e11b815260040160405180910390fd5b8035158015906125195750604051636eb1769f60e11b81526001600160a01b0385811660048301523060248301528235917f0000000000000000000000008d09a4502cc8cf1547ad300e066060d043f6982d9091169063dd62ed3e90604401602060405180830381865afa1580156124f3573d5f803e3d5ffd5b505050506040513d601f19601f820116820180604052508101906125179190615173565b105b156125ed576001600160a01b037f0000000000000000000000008d09a4502cc8cf1547ad300e066060d043f6982d1663d505accf85308435602086013561256660608801604089016151a5565b6040516001600160e01b031960e088901b1681526001600160a01b0395861660048201529490931660248501526044840191909152606483015260ff166084820152606084013560a4820152608084013560c482015260e4015f604051808303815f87803b1580156125d6575f80fd5b505af11580156125e8573d5f803e3d5ffd5b505050505b611020848484614063565b612600612e8f565b336001600160a01b037f0000000000000000000000004562c3e63c2e586cd1651b958c22f88135acad4f161461264957604051633bebb4c160e11b815260040160405180910390fd5b801561265b5761265b868484846135be565b6119ab8686866142e8565b7ff0c57e16840df040f15088dc2f81fe391c3923bec73e23a9662efc9c229c6a008054600160401b810460ff16159067ffffffffffffffff165f811580156126ab5750825b90505f8267ffffffffffffffff1660011480156126c75750303b155b9050811580156126d5575080155b156126f35760405163f92ee8a960e01b815260040160405180910390fd5b845467ffffffffffffffff19166001178555831561271d57845460ff60401b1916600160401b1785555b61272561441b565b61272f8b8b614423565b61273887614457565b6001600160a01b03891661275f57604051633ef39b8160e01b815260040160405180910390fd5b6001600160a01b0388166127865760405163658b92ad60e11b815260040160405180910390fd5b6127905f8a612fa4565b506127db7f645c9e6d2a86805cb5a28b1e4751c0dab493df7cf935070ce405489ba1a7bf727f0000000000000000000000004562c3e63c2e586cd1651b958c22f88135acad4f612fa4565b506128267fb5dffea014b759c493d63b1edaceb942631d6468998125e1b4fe427c990821347f0000000000000000000000004562c3e63c2e586cd1651b958c22f88135acad4f612fa4565b505f80546001600160a01b0319166001600160a01b038a1617905561284a86613045565b60405163095ea7b360e01b81526001600160a01b037f0000000000000000000000008d09a4502cc8cf1547ad300e066060d043f6982d811660048301525f1960248301527f0000000000000000000000003f1c547b21f65e10480de3ad8e19faac46c95034169063095ea7b3906044016020604051808303815f875af11580156128d6573d5f803e3d5ffd5b505050506040513d601f19601f820116820180604052508101906128fa91906151ed565b5060405163095ea7b360e01b81526001600160a01b037f000000000000000000000000c7cc160b58f8bb0bac94b80847e2cf2800565c50811660048301525f1960248301527f0000000000000000000000003f1c547b21f65e10480de3ad8e19faac46c95034169063095ea7b3906044016020604051808303815f875af1158015612987573d5f803e3d5ffd5b505050506040513d601f19601f820116820180604052508101906129ab91906151ed565b507f0000000000000000000000003f1c547b21f65e10480de3ad8e19faac46c950346001600160a01b031663095ea7b37f00000000000000000000000028fab2059c713a7f9d8c86db49f9bb0e96af1ef86001600160a01b03166327810b6e6040518163ffffffff1660e01b8152600401602060405180830381865afa158015612a37573d5f803e3d5ffd5b505050506040513d601f19601f82011682018060405250810190612a5b919061518a565b6040516001600160e01b031960e084901b1681526001600160a01b0390911660048201525f1960248201526044016020604051808303815f875af1158015612aa5573d5f803e3d5ffd5b505050506040513d601f19601f82011682018060405250810190612ac991906151ed565b508315612b1057845460ff60401b19168555604051600181527fc7f505b2f371ae2175ee4913f4499e1f2633a7b5936321eed1cdaeb6115181d29060200160405180910390a15b5050505050505050505050565b61108e8133614468565b7f8f22e270e477f5becb8793b61d439ab7ae990ed8eba045eb72061c0e6cfe150080545f1901841115612b6d576040516331e784e960e11b815260040160405180910390fd5b612b7783836144a6565b5f60018311612b86575f612ba4565b83836001198101818110612b9c57612b9c6151c5565b905060200201355b84845f198101818110612bb957612bb96151c5565b9050602002013503905060405180604001604052808585808060200260200160405190810160405280939291908181526020018383602002808284375f920191909152505050908252506020018290528254839087908110612c1d57612c1d6151c5565b905f5260205f2090600202015f820151815f019080519060200190612c43929190614bcd565b506020820151816001015590505050837f53da7af401538204fd91f2946f2fe85d05224d2cc766fd7aa9fbd8bf4fb4ce9f8484604051612c8492919061523c565b60405180910390a250505050565b6040516311d8d20560e31b8152600481018390525f9081906001600160a01b037f0000000000000000000000004562c3e63c2e586cd1651b958c22f88135acad4f1690638ec6902890602401602060405180830381865afa158015612cf9573d5f803e3d5ffd5b505050506040513d601f19601f82011682018060405250810190612d1d9190615173565b90505f612d2c61217886611091565b600a0190508315612d58575f612d4186612284565b9050808211612d5557829350505050611032565b90035b5f612d6682610db1886119b3565b9050808311612d75575f611e45565b909103949350505050565b5f6001600160e01b03198216637965db0b60e01b148061103257506301ffc9a760e01b6001600160e01b0319831614611032565b612dbc614590565b427fe8b012900cb200ee5dfc3b895a32791b67d12891b09f117814f167a237783a02556040517f62451d457bc659158be6e6247f56ec1df424a5c7597f71c20c2bc44e0965c8f9905f90a1565b5f612e1383612284565b9050815f03612e3557604051633649e09760e11b815260040160405180910390fd5b81811015612e5657604051633649e09760e11b815260040160405180910390fd5b5f8381525f80516020615365833981519152602052604090205461145a90849084840390600160801b90046001600160801b03166145b5565b612e97611e4f565b15612eb557604051630286f07360e31b815260040160405180910390fd5b565b345f03612ec2575050565b60405163a1903eab60e01b81525f60048201819052906001600160a01b037f0000000000000000000000003f1c547b21f65e10480de3ad8e19faac46c95034169063a1903eab90349060240160206040518083038185885af1158015612f2a573d5f803e3d5ffd5b50505050506040513d601f19601f82011682018060405250810190612f4f9190615173565b9050612f5b8282614669565b604080516001600160a01b038516815234602082015283917f16ec5116295424dec7fd52c87d9971a963ea7f59f741ad9ad468f0312055dc4991015b60405180910390a2505050565b5f7fc1f6fe24621ce81ec5827caf0253cadb74709b061630e6b55e8237170593200081612fd185856146d1565b90508015611138575f858152602083905260409020612ff09085614779565b50949350505050565b5f7fc1f6fe24621ce81ec5827caf0253cadb74709b061630e6b55e8237170593200081613026858561478d565b90508015611138575f858152602083905260409020612ff09085614806565b6001600160a01b03811661306c57604051631279f7c160e21b815260040160405180910390fd5b600180546001600160a01b0319166001600160a01b0383169081179091556040519081527f4beaaee83871b066b675515d6a53567e76411f60266703cef934a01905a4d832906020015b60405180910390a150565b7f0000000000000000000000004562c3e63c2e586cd1651b958c22f88135acad4f6001600160a01b031663a70c70e46040518163ffffffff1660e01b8152600401602060405180830381865afa15801561311d573d5f803e3d5ffd5b505050506040513d601f19601f820116820180604052508101906131419190615173565b81101561314b5750565b604051633ed893db60e21b815260040160405180910390fd5b5f8181527f8f22e270e477f5becb8793b61d439ab7ae990ed8eba045eb72061c0e6cfe1501602090815260408083208390555191825282917f4642db1736894887bc907d721f20af84d3e585a0a3cea90f41b78b2aa906541b910160405180910390a250565b5f806131d583613a04565b90505f6131e2858361481a565b90507f00000000000000000000000028fab2059c713a7f9d8c86db49f9bb0e96af1ef86001600160a01b03166327810b6e6040518163ffffffff1660e01b8152600401602060405180830381865afa158015613240573d5f803e3d5ffd5b505050506040513d601f19601f82011682018060405250810190613264919061518a565b6040516308c2292560e31b8152306004820152602481018390526001600160a01b0391909116906346114928906044015f604051808303815f87803b1580156132ab575f80fd5b505af11580156132bd573d5f803e3d5ffd5b505050506132ca81613f2c565b9250847f4da924ae7845fe96897faab524b536685b8bbc4d82fbb45c10d941e0f86ade0f6132f784613f2c565b60408051918252602082018790520160405180910390a2505092915050565b5f8181525f8051602061536583398151915260205260408082208290555182917f844ae6b00e8a437dcdde1a634feab3273e08bb5c274a4be3b195b308ae0ba20a91a250565b805f0361336857505050565b5f61337282613a04565b604051636d78045960e01b81526001600160a01b038681166004830152306024830152604482018390529192507f0000000000000000000000003f1c547b21f65e10480de3ad8e19faac46c9503490911690636d780459906064016020604051808303815f875af11580156133e9573d5f803e3d5ffd5b505050506040513d601f19601f8201168201806040525081019061340d9190615173565b506134188382614669565b604080516001600160a01b03861681526020810184905284917fee31ebba29fd5471227e42fd8ca621a892d689901892cb8febb03fe802c3214b9101612c84565b612eb57fb3e25b5404b87e5a838579cb5d7481d61ad96ee284d38ec1e97c07ba64e7f6fc612b1d565b5f7f8f22e270e477f5becb8793b61d439ab7ae990ed8eba045eb72061c0e6cfe15006134ae84846144a6565b5f600184116134bd575f6134db565b848460011981018181106134d3576134d36151c5565b905060200201355b85855f1981018181106134f0576134f06151c5565b90506020020135039050815f0160405180604001604052808787808060200260200160405190810160405280939291908181526020018383602002808284375f920182905250938552505050602091820185905283546001810185559381528190208251805193946002029091019261356c9284920190614bcd565b506020820151816001015550507f1fb1d9b944dd7015e95b7b7a9623c45792e4532badcf9c6e7a284d7d4d0570f085856040516135aa92919061523c565b60405180910390a150545f19019392505050565b5f80546040516321893f7b60e01b81526001600160a01b03909116906321893f7b906135f490889088908890889060040161524f565b6020604051808303815f875af1158015613610573d5f803e3d5ffd5b505050506040513d601f19601f820116820180604052508101906136349190615173565b90506119318582614669565b5f61364a84614842565b90505f81841061365a578161365c565b835b9050805f0361367e576040516312d37ee560e31b815260040160405180910390fd5b604051633d7ad0b760e21b81523060048201525f907f0000000000000000000000003f1c547b21f65e10480de3ad8e19faac46c950346001600160a01b03169063f5eb42dc90602401602060405180830381865afa1580156136e2573d5f803e3d5ffd5b505050506040513d601f19601f820116820180604052508101906137069190615173565b90505f7f0000000000000000000000008d09a4502cc8cf1547ad300e066060d043f6982d6001600160a01b031663ea598cb061374185613f2c565b6040518263ffffffff1660e01b815260040161375f91815260200190565b6020604051808303815f875af115801561377b573d5f803e3d5ffd5b505050506040513d601f19601f8201168201806040525081019061379f9190615173565b604051633d7ad0b760e21b81523060048201529091505f906001600160a01b037f0000000000000000000000003f1c547b21f65e10480de3ad8e19faac46c95034169063f5eb42dc90602401602060405180830381865afa158015613806573d5f803e3d5ffd5b505050506040513d601f19601f8201168201806040525081019061382a9190615173565b905061383888828503614907565b60405163a9059cbb60e01b81526001600160a01b038781166004830152602482018490527f0000000000000000000000008d09a4502cc8cf1547ad300e066060d043f6982d169063a9059cbb906044015f604051808303815f87803b15801561389f575f80fd5b505af11580156138b1573d5f803e3d5ffd5b5050604080516001600160a01b038a168152602081018690528b93507fe6a8c06447e05a412e5e9581e088941f3994db3d8a9bfd3275b38d77acacafac92500160405180910390a25050505050505050565b5f8061390e84613a04565b905061391a858261481a565b604051638fcb4e5b60e01b81526001600160a01b038581166004830152602482018390529193507f0000000000000000000000003f1c547b21f65e10480de3ad8e19faac46c9503490911690638fcb4e5b906044016020604051808303815f875af115801561398b573d5f803e3d5ffd5b505050506040513d601f19601f820116820180604052508101906139af9190615173565b50847f8615528474a7bb3a28d9971535d956b79242b8e8fcfb27f3e331270fff088afd6139db83613f2c565b6139e485613f2c565b6040805192835260208301919091520160405180910390a2509392505050565b604051631920845160e01b8152600481018290525f907f0000000000000000000000003f1c547b21f65e10480de3ad8e19faac46c950346001600160a01b0316906319208451906024015b602060405180830381865afa158015613a6a573d5f803e3d5ffd5b505050506040513d601f19601f820116820180604052508101906110329190615173565b5f6111d78383614966565b7f0000000000000000000000000000000000000000000000000000000000000000811080613ae657507f0000000000000000000000000000000000000000000000000000000001e1338081115b15613b045760405163dee7108760e01b815260040160405180910390fd5b807f78c5a36767279da056404c09083fca30cf3ea61c442cfaba6669f76a37393f00556040518181527fdaf5eddbe9ed0768e54cc8f739a9cb86c57fc70da07eff01d9ba886f21a7a4b3906020016130b6565b7f8f22e270e477f5becb8793b61d439ab7ae990ed8eba045eb72061c0e6cfe150080545f1901821115613b9d576040516331e784e960e11b815260040160405180910390fd5b5f838152600182016020526040908190208390555183907f4642db1736894887bc907d721f20af84d3e585a0a3cea90f41b78b2aa906541b90612f979085815260200190565b5f611032825490565b5f613bf684614842565b90505f613c0282613f2c565b8410613c0e5781613c17565b613c1784613a04565b9050805f03613c39576040516312d37ee560e31b815260040160405180910390fd5b6040805160018082528183019092525f9160208083019080368337019050509050613c6382613f2c565b815f81518110613c7557613c756151c5565b6020908102919091010152604051633d7ad0b760e21b81523060048201525f907f0000000000000000000000003f1c547b21f65e10480de3ad8e19faac46c950346001600160a01b03169063f5eb42dc90602401602060405180830381865afa158015613ce4573d5f803e3d5ffd5b505050506040513d601f19601f82011682018060405250810190613d089190615173565b90505f7f000000000000000000000000c7cc160b58f8bb0bac94b80847e2cf2800565c506001600160a01b031663d668104284886040518363ffffffff1660e01b8152600401613d5992919061526e565b5f604051808303815f875af1158015613d74573d5f803e3d5ffd5b505050506040513d5f823e601f3d908101601f19168201604052613d9b91908101906152c4565b604051633d7ad0b760e21b81523060048201529091505f906001600160a01b037f0000000000000000000000003f1c547b21f65e10480de3ad8e19faac46c95034169063f5eb42dc90602401602060405180830381865afa158015613e02573d5f803e3d5ffd5b505050506040513d601f19601f82011682018060405250810190613e269190615173565b9050613e3489828503614907565b887f26673a9d018b21192d08ee14377b798f11b9e5b15ea1559c110265716b8985b588865f81518110613e6957613e696151c5565b6020026020010151855f81518110613e8357613e836151c5565b602090810291909101810151604080516001600160a01b0390951685529184019290925282015260600160405180910390a2505050505050505050565b80515f9081906001190181805b828411613f21575050600282820104602081810286010151808703613efa57506001019250611032915050565b80871015613f0d57600182039250613ecd565b80871115613f1c578160010193505b613ecd565b509195945050505050565b604051630f451f7160e31b8152600481018290525f907f0000000000000000000000003f1c547b21f65e10480de3ad8e19faac46c950346001600160a01b031690637a28fb8890602401613a4f565b7f78c5a36767279da056404c09083fca30cf3ea61c442cfaba6669f76a37393f005f829003613fbd57604051633649e09760e11b815260040160405180910390fd5b5f83815260018201602052604090205442600160801b9091046001600160801b03161115614004575f8381526001820160205260409020546001600160801b031691909101905b61145a8383835f015442016145b5565b61401c612e8f565b805f0361403c5760405163ad58bfc760e01b815260040160405180910390fd5b5f5f19820361404d57505f1961405a565b6140578242615160565b90505b6113f38161498c565b805f0361406f57505050565b6040516323b872dd60e01b81526001600160a01b038481166004830152306024830152604482018390527f0000000000000000000000008d09a4502cc8cf1547ad300e066060d043f6982d16906323b872dd906064015f604051808303815f87803b1580156140dc575f80fd5b505af11580156140ee573d5f803e3d5ffd5b5050604051633d7ad0b760e21b81523060048201525f92507f0000000000000000000000003f1c547b21f65e10480de3ad8e19faac46c950346001600160a01b0316915063f5eb42dc90602401602060405180830381865afa158015614156573d5f803e3d5ffd5b505050506040513d601f19601f8201168201806040525081019061417a9190615173565b604051636f074d1f60e11b8152600481018490529091507f0000000000000000000000008d09a4502cc8cf1547ad300e066060d043f6982d6001600160a01b03169063de0e9a3e906024016020604051808303815f875af11580156141e1573d5f803e3d5ffd5b505050506040513d601f19601f820116820180604052508101906142059190615173565b50604051633d7ad0b760e21b81523060048201525f907f0000000000000000000000003f1c547b21f65e10480de3ad8e19faac46c950346001600160a01b03169063f5eb42dc90602401602060405180830381865afa15801561426a573d5f803e3d5ffd5b505050506040513d601f19601f8201168201806040525081019061428e9190615173565b905061429c84838303614669565b604080516001600160a01b03871681526020810185905285917f6576bbc9c5b478bf9717dc3d2bcb485e5ff0727df77c72558727597f3609d3f191015b60405180910390a25050505050565b5f6142f284614842565b90505f6142fe82613f2c565b841061430a5781614313565b61431384613a04565b9050805f03614335576040516312d37ee560e31b815260040160405180910390fd5b61433f8582614907565b604051638fcb4e5b60e01b81526001600160a01b038481166004830152602482018390527f0000000000000000000000003f1c547b21f65e10480de3ad8e19faac46c950341690638fcb4e5b906044016020604051808303815f875af11580156143ab573d5f803e3d5ffd5b505050506040513d601f19601f820116820180604052508101906143cf9190615173565b50847f3e3a1398fe71575ed0c17a80cd9d46ad684c2c75c2fad7b0e7dde15e78ab22d3846143fc84613f2c565b604080516001600160a01b0390931683526020830191909152016142d9565b612eb5614a27565b61442b614a27565b5f6144368383613482565b9050801561145a57604051634273eaaf60e11b815260040160405180910390fd5b61445f614a27565b61108e81613a99565b6144728282611cb0565b6113f35760405163e2517d3f60e01b81526001600160a01b0382166004820152602481018390526044015b60405180910390fd5b60018110806144d457507f000000000000000000000000000000000000000000000000000000000000000a81115b156144f257604051638326bf5360e01b815260040160405180910390fd5b81815f818110614504576145046151c5565b905060200201355f0361452a576040516302527aef60e21b815260040160405180910390fd5b60015b8181101561145a5782826001830381811061454a5761454a6151c5565b90506020020135838383818110614563576145636151c5565b9050602002013511614588576040516302527aef60e21b815260040160405180910390fd5b60010161452d565b614598611e4f565b612eb55760405163b047186b60e01b815260040160405180910390fd5b815f036145c55761145a83613316565b60405180604001604052806145d984614a70565b6001600160801b031681526020016145f083614a70565b6001600160801b039081169091525f8581525f8051602061536583398151915260209081526040918290208451948201518416600160801b029490931693909317909155805184815291820183905284917f69a153d448f54b17f05cf3b268a2efab87c94a4727d108c4ca4aa3e5d65113de9101612f97565b805f03614674575050565b5f9182527f23f334b9eb5378c2a1573857b8f9d9ca79959360a69e73d3f16848e56ec9210060205260409091208054820190557f23f334b9eb5378c2a1573857b8f9d9ca79959360a69e73d3f16848e56ec9210180549091019055565b5f5f805160206153858339815191526146ea8484611cb0565b614769575f848152602082815260408083206001600160a01b03871684529091529020805460ff1916600117905561471f3390565b6001600160a01b0316836001600160a01b0316857f2f8788117e7eff1d82e926ec794901d17c78024a50270940304540a733656f0d60405160405180910390a46001915050611032565b5f915050611032565b5092915050565b5f6111d7836001600160a01b038416614aa7565b5f5f805160206153858339815191526147a68484611cb0565b15614769575f848152602082815260408083206001600160a01b0387168085529252808320805460ff1916905551339287917ff6391f5c32d9c69d2a47ea670b442974b53935d1edc7fd64eb21e047a839171b9190a46001915050611032565b5f6111d7836001600160a01b038416614af3565b5f8061482584611091565b90508083106148345780614836565b825b91506147728483614907565b5f8061484d83611091565b90505f6148f061485c85612284565b6040516311d8d20560e31b815260048101879052611c6b907f0000000000000000000000004562c3e63c2e586cd1651b958c22f88135acad4f6001600160a01b031690638ec6902890602401602060405180830381865afa1580156148c3573d5f803e3d5ffd5b505050506040513d601f19601f820116820180604052508101906148e79190615173565b6105b6886119b3565b90508082116148ff575f611138565b900392915050565b5f9182527f23f334b9eb5378c2a1573857b8f9d9ca79959360a69e73d3f16848e56ec921006020526040909120805482900390557f23f334b9eb5378c2a1573857b8f9d9ca79959360a69e73d3f16848e56ec921018054919091039055565b5f825f01828154811061497b5761497b6151c5565b905f5260205f200154905092915050565b6149b57fe8b012900cb200ee5dfc3b895a32791b67d12891b09f117814f167a237783a02829055565b5f1981036149ee576040515f1981527f32fb7c9891bc4f963c7de9f1186d2a7755c7d6e9f4604dabe1d8bb3027c2f49e906020016130b6565b7f32fb7c9891bc4f963c7de9f1186d2a7755c7d6e9f4604dabe1d8bb3027c2f49e614a194283615136565b6040519081526020016130b6565b7ff0c57e16840df040f15088dc2f81fe391c3923bec73e23a9662efc9c229c6a0054600160401b900460ff16612eb557604051631afcd79f60e31b815260040160405180910390fd5b5f6001600160801b03821115614aa3576040516306dfcc6560e41b8152608060048201526024810183905260440161449d565b5090565b5f818152600183016020526040812054614aec57508154600181810184555f848152602080822090930184905584548482528286019093526040902091909155611032565b505f611032565b5f8181526001830160205260408120548015614769575f614b15600183615136565b85549091505f90614b2890600190615136565b9050808214614b87575f865f018281548110614b4657614b466151c5565b905f5260205f200154905080875f018481548110614b6657614b666151c5565b5f918252602080832090910192909255918252600188019052604090208390555b8554869080614b9857614b98615350565b600190038181905f5260205f20015f90559055856001015f8681526020019081526020015f205f905560019350505050611032565b828054828255905f5260205f20908101928215614c06579160200282015b82811115614c06578251825591602001919060010190614beb565b50614aa39291505b80821115614aa3575f8155600101614c0e565b5f8083601f840112614c31575f80fd5b50813567ffffffffffffffff811115614c48575f80fd5b6020830191508360208260051b8501011115614c62575f80fd5b9250929050565b5f805f60408486031215614c7b575f80fd5b83359250602084013567ffffffffffffffff811115614c98575f80fd5b614ca486828701614c21565b9497909650939450505050565b5f60208284031215614cc1575f80fd5b5035919050565b5f60208284031215614cd8575f80fd5b81356001600160e01b0319811681146111d7575f80fd5b634e487b7160e01b5f52604160045260245ffd5b6040805190810167ffffffffffffffff81118282101715614d2657614d26614cef565b60405290565b604051601f8201601f1916810167ffffffffffffffff81118282101715614d5557614d55614cef565b604052919050565b5f67ffffffffffffffff821115614d7657614d76614cef565b5060051b60200190565b5f8060408385031215614d91575f80fd5b8235915060208084013567ffffffffffffffff80821115614db0575f80fd5b9085019060408288031215614dc3575f80fd5b614dcb614d03565b823582811115614dd9575f80fd5b83019150601f82018813614deb575f80fd5b8135614dfe614df982614d5d565b614d2c565b81815260059190911b8301850190858101908a831115614e1c575f80fd5b938601935b82851015614e3a57843582529386019390860190614e21565b83525050918301359282019290925292959294509192505050565b5f8060408385031215614e66575f80fd5b50508035926020909101359150565b6001600160a01b038116811461108e575f80fd5b5f8060408385031215614e9a575f80fd5b8235614ea581614e75565b946020939093013593505050565b5f8060408385031215614ec4575f80fd5b823591506020830135614ed681614e75565b809150509250929050565b5f60208284031215614ef1575f80fd5b81356111d781614e75565b5f805f80848603610100811215614f11575f80fd5b8535614f1c81614e75565b9450602086013593506040860135925060a0605f1982011215614f3d575f80fd5b509295919450926060019150565b5f8060208385031215614f5c575f80fd5b823567ffffffffffffffff811115614f72575f80fd5b614f7e85828601614c21565b90969095509350505050565b602080825282516040838301528051606084018190525f9291820190839060808601905b80831015614fce5783518252928401926001929092019190840190614fae565b508387015160408701528094505050505092915050565b5f805f805f8060a08789031215614ffa575f80fd5b8635955060208701359450604087013561501381614e75565b935060608701359250608087013567ffffffffffffffff811115615035575f80fd5b61504189828a01614c21565b979a9699509497509295939492505050565b5f805f8060608587031215615066575f80fd5b8435935060208501359250604085013567ffffffffffffffff81111561508a575f80fd5b61509687828801614c21565b95989497509550505050565b5f805f805f8060a087890312156150b7575f80fd5b863567ffffffffffffffff8111156150cd575f80fd5b6150d989828a01614c21565b90975095505060208701356150ed81614e75565b935060408701356150fd81614e75565b925060608701359150608087013561511481614e75565b809150509295509295509295565b634e487b7160e01b5f52601160045260245ffd5b8181038181111561103257611032615122565b808202811582820484141761103257611032615122565b8082018082111561103257611032615122565b5f60208284031215615183575f80fd5b5051919050565b5f6020828403121561519a575f80fd5b81516111d781614e75565b5f602082840312156151b5575f80fd5b813560ff811681146111d7575f80fd5b634e487b7160e01b5f52603260045260245ffd5b634e487b7160e01b5f52601260045260245ffd5b5f602082840312156151fd575f80fd5b815180151581146111d7575f80fd5b8183525f6001600160fb1b03831115615223575f80fd5b8260051b80836020870137939093016020019392505050565b602081525f61113860208301848661520c565b848152836020820152606060408201525f611e4560608301848661520c565b604080825283519082018190525f906020906060840190828701845b828110156152a65781518452928401929084019060010161528a565b50505080925050506001600160a01b03831660208301529392505050565b5f60208083850312156152d5575f80fd5b825167ffffffffffffffff8111156152eb575f80fd5b8301601f810185136152fb575f80fd5b8051615309614df982614d5d565b81815260059190911b82018301908381019087831115615327575f80fd5b928401925b828410156153455783518252928401929084019061532c565b979650505050505050565b634e487b7160e01b5f52603160045260245ffdfe78c5a36767279da056404c09083fca30cf3ea61c442cfaba6669f76a37393f0102dd7bc7dec4dceedda775e58dd541e08a116c6c53815c0bd028192f7b626800a164736f6c6343000818000a",
+}
+
+// CsaccountingABI is the input ABI used to generate the binding from.
+// Deprecated: Use CsaccountingMetaData.ABI instead.
+var CsaccountingABI = CsaccountingMetaData.ABI
+
+// CsaccountingBin is the compiled bytecode used for deploying new contracts.
+// Deprecated: Use CsaccountingMetaData.Bin instead.
+var CsaccountingBin = CsaccountingMetaData.Bin
+
+// DeployCsaccounting deploys a new Ethereum contract, binding an instance of Csaccounting to it.
+func DeployCsaccounting(auth *bind.TransactOpts, backend bind.ContractBackend, lidoLocator common.Address, communityStakingModule common.Address, maxCurveLength *big.Int, minBondLockRetentionPeriod *big.Int, maxBondLockRetentionPeriod *big.Int) (common.Address, *types.Transaction, *Csaccounting, error) {
+	parsed, err := CsaccountingMetaData.GetAbi()
+	if err != nil {
+		return common.Address{}, nil, nil, err
+	}
+	if parsed == nil {
+		return common.Address{}, nil, nil, errors.New("GetABI returned nil")
+	}
+
+	address, tx, contract, err := bind.DeployContract(auth, *parsed, common.FromHex(CsaccountingBin), backend, lidoLocator, communityStakingModule, maxCurveLength, minBondLockRetentionPeriod, maxBondLockRetentionPeriod)
+	if err != nil {
+		return common.Address{}, nil, nil, err
+	}
+	return address, tx, &Csaccounting{CsaccountingCaller: CsaccountingCaller{contract: contract}, CsaccountingTransactor: CsaccountingTransactor{contract: contract}, CsaccountingFilterer: CsaccountingFilterer{contract: contract}}, nil
+}
+
+// Csaccounting is an auto generated Go binding around an Ethereum contract.
+type Csaccounting struct {
+	CsaccountingCaller     // Read-only binding to the contract
+	CsaccountingTransactor // Write-only binding to the contract
+	CsaccountingFilterer   // Log filterer for contract events
+}
+
+// CsaccountingCaller is an auto generated read-only Go binding around an Ethereum contract.
+type CsaccountingCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// CsaccountingTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type CsaccountingTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// CsaccountingFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type CsaccountingFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// CsaccountingSession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type CsaccountingSession struct {
+	Contract     *Csaccounting     // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// CsaccountingCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type CsaccountingCallerSession struct {
+	Contract *CsaccountingCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts       // Call options to use throughout this session
+}
+
+// CsaccountingTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type CsaccountingTransactorSession struct {
+	Contract     *CsaccountingTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts       // Transaction auth options to use throughout this session
+}
+
+// CsaccountingRaw is an auto generated low-level Go binding around an Ethereum contract.
+type CsaccountingRaw struct {
+	Contract *Csaccounting // Generic contract binding to access the raw methods on
+}
+
+// CsaccountingCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type CsaccountingCallerRaw struct {
+	Contract *CsaccountingCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// CsaccountingTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type CsaccountingTransactorRaw struct {
+	Contract *CsaccountingTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewCsaccounting creates a new instance of Csaccounting, bound to a specific deployed contract.
+func NewCsaccounting(address common.Address, backend bind.ContractBackend) (*Csaccounting, error) {
+	contract, err := bindCsaccounting(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &Csaccounting{CsaccountingCaller: CsaccountingCaller{contract: contract}, CsaccountingTransactor: CsaccountingTransactor{contract: contract}, CsaccountingFilterer: CsaccountingFilterer{contract: contract}}, nil
+}
+
+// NewCsaccountingCaller creates a new read-only instance of Csaccounting, bound to a specific deployed contract.
+func NewCsaccountingCaller(address common.Address, caller bind.ContractCaller) (*CsaccountingCaller, error) {
+	contract, err := bindCsaccounting(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &CsaccountingCaller{contract: contract}, nil
+}
+
+// NewCsaccountingTransactor creates a new write-only instance of Csaccounting, bound to a specific deployed contract.
+func NewCsaccountingTransactor(address common.Address, transactor bind.ContractTransactor) (*CsaccountingTransactor, error) {
+	contract, err := bindCsaccounting(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &CsaccountingTransactor{contract: contract}, nil
+}
+
+// NewCsaccountingFilterer creates a new log filterer instance of Csaccounting, bound to a specific deployed contract.
+func NewCsaccountingFilterer(address common.Address, filterer bind.ContractFilterer) (*CsaccountingFilterer, error) {
+	contract, err := bindCsaccounting(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &CsaccountingFilterer{contract: contract}, nil
+}
+
+// bindCsaccounting binds a generic wrapper to an already deployed contract.
+func bindCsaccounting(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := CsaccountingMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_Csaccounting *CsaccountingRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _Csaccounting.Contract.CsaccountingCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_Csaccounting *CsaccountingRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Csaccounting.Contract.CsaccountingTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_Csaccounting *CsaccountingRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _Csaccounting.Contract.CsaccountingTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_Csaccounting *CsaccountingCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _Csaccounting.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_Csaccounting *CsaccountingTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Csaccounting.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_Csaccounting *CsaccountingTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _Csaccounting.Contract.contract.Transact(opts, method, params...)
+}
+
+// ACCOUNTINGMANAGERROLE is a free data retrieval call binding the contract method 0x8ed5c5d7.
+//
+// Solidity: function ACCOUNTING_MANAGER_ROLE() view returns(bytes32)
+func (_Csaccounting *CsaccountingCaller) ACCOUNTINGMANAGERROLE(opts *bind.CallOpts) ([32]byte, error) {
+	var out []interface{}
+	err := _Csaccounting.contract.Call(opts, &out, "ACCOUNTING_MANAGER_ROLE")
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// ACCOUNTINGMANAGERROLE is a free data retrieval call binding the contract method 0x8ed5c5d7.
+//
+// Solidity: function ACCOUNTING_MANAGER_ROLE() view returns(bytes32)
+func (_Csaccounting *CsaccountingSession) ACCOUNTINGMANAGERROLE() ([32]byte, error) {
+	return _Csaccounting.Contract.ACCOUNTINGMANAGERROLE(&_Csaccounting.CallOpts)
+}
+
+// ACCOUNTINGMANAGERROLE is a free data retrieval call binding the contract method 0x8ed5c5d7.
+//
+// Solidity: function ACCOUNTING_MANAGER_ROLE() view returns(bytes32)
+func (_Csaccounting *CsaccountingCallerSession) ACCOUNTINGMANAGERROLE() ([32]byte, error) {
+	return _Csaccounting.Contract.ACCOUNTINGMANAGERROLE(&_Csaccounting.CallOpts)
+}
+
+// CSM is a free data retrieval call binding the contract method 0x8de2b272.
+//
+// Solidity: function CSM() view returns(address)
+func (_Csaccounting *CsaccountingCaller) CSM(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _Csaccounting.contract.Call(opts, &out, "CSM")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// CSM is a free data retrieval call binding the contract method 0x8de2b272.
+//
+// Solidity: function CSM() view returns(address)
+func (_Csaccounting *CsaccountingSession) CSM() (common.Address, error) {
+	return _Csaccounting.Contract.CSM(&_Csaccounting.CallOpts)
+}
+
+// CSM is a free data retrieval call binding the contract method 0x8de2b272.
+//
+// Solidity: function CSM() view returns(address)
+func (_Csaccounting *CsaccountingCallerSession) CSM() (common.Address, error) {
+	return _Csaccounting.Contract.CSM(&_Csaccounting.CallOpts)
+}
+
+// DEFAULTADMINROLE is a free data retrieval call binding the contract method 0xa217fddf.
+//
+// Solidity: function DEFAULT_ADMIN_ROLE() view returns(bytes32)
+func (_Csaccounting *CsaccountingCaller) DEFAULTADMINROLE(opts *bind.CallOpts) ([32]byte, error) {
+	var out []interface{}
+	err := _Csaccounting.contract.Call(opts, &out, "DEFAULT_ADMIN_ROLE")
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// DEFAULTADMINROLE is a free data retrieval call binding the contract method 0xa217fddf.
+//
+// Solidity: function DEFAULT_ADMIN_ROLE() view returns(bytes32)
+func (_Csaccounting *CsaccountingSession) DEFAULTADMINROLE() ([32]byte, error) {
+	return _Csaccounting.Contract.DEFAULTADMINROLE(&_Csaccounting.CallOpts)
+}
+
+// DEFAULTADMINROLE is a free data retrieval call binding the contract method 0xa217fddf.
+//
+// Solidity: function DEFAULT_ADMIN_ROLE() view returns(bytes32)
+func (_Csaccounting *CsaccountingCallerSession) DEFAULTADMINROLE() ([32]byte, error) {
+	return _Csaccounting.Contract.DEFAULTADMINROLE(&_Csaccounting.CallOpts)
+}
+
+// DEFAULTBONDCURVEID is a free data retrieval call binding the contract method 0x443fbfef.
+//
+// Solidity: function DEFAULT_BOND_CURVE_ID() view returns(uint256)
+func (_Csaccounting *CsaccountingCaller) DEFAULTBONDCURVEID(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _Csaccounting.contract.Call(opts, &out, "DEFAULT_BOND_CURVE_ID")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// DEFAULTBONDCURVEID is a free data retrieval call binding the contract method 0x443fbfef.
+//
+// Solidity: function DEFAULT_BOND_CURVE_ID() view returns(uint256)
+func (_Csaccounting *CsaccountingSession) DEFAULTBONDCURVEID() (*big.Int, error) {
+	return _Csaccounting.Contract.DEFAULTBONDCURVEID(&_Csaccounting.CallOpts)
+}
+
+// DEFAULTBONDCURVEID is a free data retrieval call binding the contract method 0x443fbfef.
+//
+// Solidity: function DEFAULT_BOND_CURVE_ID() view returns(uint256)
+func (_Csaccounting *CsaccountingCallerSession) DEFAULTBONDCURVEID() (*big.Int, error) {
+	return _Csaccounting.Contract.DEFAULTBONDCURVEID(&_Csaccounting.CallOpts)
+}
+
+// LIDO is a free data retrieval call binding the contract method 0x8b21f170.
+//
+// Solidity: function LIDO() view returns(address)
+func (_Csaccounting *CsaccountingCaller) LIDO(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _Csaccounting.contract.Call(opts, &out, "LIDO")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// LIDO is a free data retrieval call binding the contract method 0x8b21f170.
+//
+// Solidity: function LIDO() view returns(address)
+func (_Csaccounting *CsaccountingSession) LIDO() (common.Address, error) {
+	return _Csaccounting.Contract.LIDO(&_Csaccounting.CallOpts)
+}
+
+// LIDO is a free data retrieval call binding the contract method 0x8b21f170.
+//
+// Solidity: function LIDO() view returns(address)
+func (_Csaccounting *CsaccountingCallerSession) LIDO() (common.Address, error) {
+	return _Csaccounting.Contract.LIDO(&_Csaccounting.CallOpts)
+}
+
+// LIDOLOCATOR is a free data retrieval call binding the contract method 0xdbba4b48.
+//
+// Solidity: function LIDO_LOCATOR() view returns(address)
+func (_Csaccounting *CsaccountingCaller) LIDOLOCATOR(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _Csaccounting.contract.Call(opts, &out, "LIDO_LOCATOR")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// LIDOLOCATOR is a free data retrieval call binding the contract method 0xdbba4b48.
+//
+// Solidity: function LIDO_LOCATOR() view returns(address)
+func (_Csaccounting *CsaccountingSession) LIDOLOCATOR() (common.Address, error) {
+	return _Csaccounting.Contract.LIDOLOCATOR(&_Csaccounting.CallOpts)
+}
+
+// LIDOLOCATOR is a free data retrieval call binding the contract method 0xdbba4b48.
+//
+// Solidity: function LIDO_LOCATOR() view returns(address)
+func (_Csaccounting *CsaccountingCallerSession) LIDOLOCATOR() (common.Address, error) {
+	return _Csaccounting.Contract.LIDOLOCATOR(&_Csaccounting.CallOpts)
+}
+
+// MANAGEBONDCURVESROLE is a free data retrieval call binding the contract method 0xfee63805.
+//
+// Solidity: function MANAGE_BOND_CURVES_ROLE() view returns(bytes32)
+func (_Csaccounting *CsaccountingCaller) MANAGEBONDCURVESROLE(opts *bind.CallOpts) ([32]byte, error) {
+	var out []interface{}
+	err := _Csaccounting.contract.Call(opts, &out, "MANAGE_BOND_CURVES_ROLE")
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// MANAGEBONDCURVESROLE is a free data retrieval call binding the contract method 0xfee63805.
+//
+// Solidity: function MANAGE_BOND_CURVES_ROLE() view returns(bytes32)
+func (_Csaccounting *CsaccountingSession) MANAGEBONDCURVESROLE() ([32]byte, error) {
+	return _Csaccounting.Contract.MANAGEBONDCURVESROLE(&_Csaccounting.CallOpts)
+}
+
+// MANAGEBONDCURVESROLE is a free data retrieval call binding the contract method 0xfee63805.
+//
+// Solidity: function MANAGE_BOND_CURVES_ROLE() view returns(bytes32)
+func (_Csaccounting *CsaccountingCallerSession) MANAGEBONDCURVESROLE() ([32]byte, error) {
+	return _Csaccounting.Contract.MANAGEBONDCURVESROLE(&_Csaccounting.CallOpts)
+}
+
+// MAXBONDLOCKRETENTIONPERIOD is a free data retrieval call binding the contract method 0x526352fc.
+//
+// Solidity: function MAX_BOND_LOCK_RETENTION_PERIOD() view returns(uint256)
+func (_Csaccounting *CsaccountingCaller) MAXBONDLOCKRETENTIONPERIOD(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _Csaccounting.contract.Call(opts, &out, "MAX_BOND_LOCK_RETENTION_PERIOD")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// MAXBONDLOCKRETENTIONPERIOD is a free data retrieval call binding the contract method 0x526352fc.
+//
+// Solidity: function MAX_BOND_LOCK_RETENTION_PERIOD() view returns(uint256)
+func (_Csaccounting *CsaccountingSession) MAXBONDLOCKRETENTIONPERIOD() (*big.Int, error) {
+	return _Csaccounting.Contract.MAXBONDLOCKRETENTIONPERIOD(&_Csaccounting.CallOpts)
+}
+
+// MAXBONDLOCKRETENTIONPERIOD is a free data retrieval call binding the contract method 0x526352fc.
+//
+// Solidity: function MAX_BOND_LOCK_RETENTION_PERIOD() view returns(uint256)
+func (_Csaccounting *CsaccountingCallerSession) MAXBONDLOCKRETENTIONPERIOD() (*big.Int, error) {
+	return _Csaccounting.Contract.MAXBONDLOCKRETENTIONPERIOD(&_Csaccounting.CallOpts)
+}
+
+// MAXCURVELENGTH is a free data retrieval call binding the contract method 0x4b2ce9fe.
+//
+// Solidity: function MAX_CURVE_LENGTH() view returns(uint256)
+func (_Csaccounting *CsaccountingCaller) MAXCURVELENGTH(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _Csaccounting.contract.Call(opts, &out, "MAX_CURVE_LENGTH")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// MAXCURVELENGTH is a free data retrieval call binding the contract method 0x4b2ce9fe.
+//
+// Solidity: function MAX_CURVE_LENGTH() view returns(uint256)
+func (_Csaccounting *CsaccountingSession) MAXCURVELENGTH() (*big.Int, error) {
+	return _Csaccounting.Contract.MAXCURVELENGTH(&_Csaccounting.CallOpts)
+}
+
+// MAXCURVELENGTH is a free data retrieval call binding the contract method 0x4b2ce9fe.
+//
+// Solidity: function MAX_CURVE_LENGTH() view returns(uint256)
+func (_Csaccounting *CsaccountingCallerSession) MAXCURVELENGTH() (*big.Int, error) {
+	return _Csaccounting.Contract.MAXCURVELENGTH(&_Csaccounting.CallOpts)
+}
+
+// MINBONDLOCKRETENTIONPERIOD is a free data retrieval call binding the contract method 0xae849756.
+//
+// Solidity: function MIN_BOND_LOCK_RETENTION_PERIOD() view returns(uint256)
+func (_Csaccounting *CsaccountingCaller) MINBONDLOCKRETENTIONPERIOD(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _Csaccounting.contract.Call(opts, &out, "MIN_BOND_LOCK_RETENTION_PERIOD")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// MINBONDLOCKRETENTIONPERIOD is a free data retrieval call binding the contract method 0xae849756.
+//
+// Solidity: function MIN_BOND_LOCK_RETENTION_PERIOD() view returns(uint256)
+func (_Csaccounting *CsaccountingSession) MINBONDLOCKRETENTIONPERIOD() (*big.Int, error) {
+	return _Csaccounting.Contract.MINBONDLOCKRETENTIONPERIOD(&_Csaccounting.CallOpts)
+}
+
+// MINBONDLOCKRETENTIONPERIOD is a free data retrieval call binding the contract method 0xae849756.
+//
+// Solidity: function MIN_BOND_LOCK_RETENTION_PERIOD() view returns(uint256)
+func (_Csaccounting *CsaccountingCallerSession) MINBONDLOCKRETENTIONPERIOD() (*big.Int, error) {
+	return _Csaccounting.Contract.MINBONDLOCKRETENTIONPERIOD(&_Csaccounting.CallOpts)
+}
+
+// MINCURVELENGTH is a free data retrieval call binding the contract method 0xcb11c527.
+//
+// Solidity: function MIN_CURVE_LENGTH() view returns(uint256)
+func (_Csaccounting *CsaccountingCaller) MINCURVELENGTH(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _Csaccounting.contract.Call(opts, &out, "MIN_CURVE_LENGTH")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// MINCURVELENGTH is a free data retrieval call binding the contract method 0xcb11c527.
+//
+// Solidity: function MIN_CURVE_LENGTH() view returns(uint256)
+func (_Csaccounting *CsaccountingSession) MINCURVELENGTH() (*big.Int, error) {
+	return _Csaccounting.Contract.MINCURVELENGTH(&_Csaccounting.CallOpts)
+}
+
+// MINCURVELENGTH is a free data retrieval call binding the contract method 0xcb11c527.
+//
+// Solidity: function MIN_CURVE_LENGTH() view returns(uint256)
+func (_Csaccounting *CsaccountingCallerSession) MINCURVELENGTH() (*big.Int, error) {
+	return _Csaccounting.Contract.MINCURVELENGTH(&_Csaccounting.CallOpts)
+}
+
+// PAUSEINFINITELY is a free data retrieval call binding the contract method 0xa302ee38.
+//
+// Solidity: function PAUSE_INFINITELY() view returns(uint256)
+func (_Csaccounting *CsaccountingCaller) PAUSEINFINITELY(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _Csaccounting.contract.Call(opts, &out, "PAUSE_INFINITELY")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// PAUSEINFINITELY is a free data retrieval call binding the contract method 0xa302ee38.
+//
+// Solidity: function PAUSE_INFINITELY() view returns(uint256)
+func (_Csaccounting *CsaccountingSession) PAUSEINFINITELY() (*big.Int, error) {
+	return _Csaccounting.Contract.PAUSEINFINITELY(&_Csaccounting.CallOpts)
+}
+
+// PAUSEINFINITELY is a free data retrieval call binding the contract method 0xa302ee38.
+//
+// Solidity: function PAUSE_INFINITELY() view returns(uint256)
+func (_Csaccounting *CsaccountingCallerSession) PAUSEINFINITELY() (*big.Int, error) {
+	return _Csaccounting.Contract.PAUSEINFINITELY(&_Csaccounting.CallOpts)
+}
+
+// PAUSEROLE is a free data retrieval call binding the contract method 0x389ed267.
+//
+// Solidity: function PAUSE_ROLE() view returns(bytes32)
+func (_Csaccounting *CsaccountingCaller) PAUSEROLE(opts *bind.CallOpts) ([32]byte, error) {
+	var out []interface{}
+	err := _Csaccounting.contract.Call(opts, &out, "PAUSE_ROLE")
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// PAUSEROLE is a free data retrieval call binding the contract method 0x389ed267.
+//
+// Solidity: function PAUSE_ROLE() view returns(bytes32)
+func (_Csaccounting *CsaccountingSession) PAUSEROLE() ([32]byte, error) {
+	return _Csaccounting.Contract.PAUSEROLE(&_Csaccounting.CallOpts)
+}
+
+// PAUSEROLE is a free data retrieval call binding the contract method 0x389ed267.
+//
+// Solidity: function PAUSE_ROLE() view returns(bytes32)
+func (_Csaccounting *CsaccountingCallerSession) PAUSEROLE() ([32]byte, error) {
+	return _Csaccounting.Contract.PAUSEROLE(&_Csaccounting.CallOpts)
+}
+
+// RECOVERERROLE is a free data retrieval call binding the contract method 0xacf1c948.
+//
+// Solidity: function RECOVERER_ROLE() view returns(bytes32)
+func (_Csaccounting *CsaccountingCaller) RECOVERERROLE(opts *bind.CallOpts) ([32]byte, error) {
+	var out []interface{}
+	err := _Csaccounting.contract.Call(opts, &out, "RECOVERER_ROLE")
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// RECOVERERROLE is a free data retrieval call binding the contract method 0xacf1c948.
+//
+// Solidity: function RECOVERER_ROLE() view returns(bytes32)
+func (_Csaccounting *CsaccountingSession) RECOVERERROLE() ([32]byte, error) {
+	return _Csaccounting.Contract.RECOVERERROLE(&_Csaccounting.CallOpts)
+}
+
+// RECOVERERROLE is a free data retrieval call binding the contract method 0xacf1c948.
+//
+// Solidity: function RECOVERER_ROLE() view returns(bytes32)
+func (_Csaccounting *CsaccountingCallerSession) RECOVERERROLE() ([32]byte, error) {
+	return _Csaccounting.Contract.RECOVERERROLE(&_Csaccounting.CallOpts)
+}
+
+// RESETBONDCURVEROLE is a free data retrieval call binding the contract method 0x21d439d5.
+//
+// Solidity: function RESET_BOND_CURVE_ROLE() view returns(bytes32)
+func (_Csaccounting *CsaccountingCaller) RESETBONDCURVEROLE(opts *bind.CallOpts) ([32]byte, error) {
+	var out []interface{}
+	err := _Csaccounting.contract.Call(opts, &out, "RESET_BOND_CURVE_ROLE")
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// RESETBONDCURVEROLE is a free data retrieval call binding the contract method 0x21d439d5.
+//
+// Solidity: function RESET_BOND_CURVE_ROLE() view returns(bytes32)
+func (_Csaccounting *CsaccountingSession) RESETBONDCURVEROLE() ([32]byte, error) {
+	return _Csaccounting.Contract.RESETBONDCURVEROLE(&_Csaccounting.CallOpts)
+}
+
+// RESETBONDCURVEROLE is a free data retrieval call binding the contract method 0x21d439d5.
+//
+// Solidity: function RESET_BOND_CURVE_ROLE() view returns(bytes32)
+func (_Csaccounting *CsaccountingCallerSession) RESETBONDCURVEROLE() ([32]byte, error) {
+	return _Csaccounting.Contract.RESETBONDCURVEROLE(&_Csaccounting.CallOpts)
+}
+
+// RESUMEROLE is a free data retrieval call binding the contract method 0x2de03aa1.
+//
+// Solidity: function RESUME_ROLE() view returns(bytes32)
+func (_Csaccounting *CsaccountingCaller) RESUMEROLE(opts *bind.CallOpts) ([32]byte, error) {
+	var out []interface{}
+	err := _Csaccounting.contract.Call(opts, &out, "RESUME_ROLE")
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// RESUMEROLE is a free data retrieval call binding the contract method 0x2de03aa1.
+//
+// Solidity: function RESUME_ROLE() view returns(bytes32)
+func (_Csaccounting *CsaccountingSession) RESUMEROLE() ([32]byte, error) {
+	return _Csaccounting.Contract.RESUMEROLE(&_Csaccounting.CallOpts)
+}
+
+// RESUMEROLE is a free data retrieval call binding the contract method 0x2de03aa1.
+//
+// Solidity: function RESUME_ROLE() view returns(bytes32)
+func (_Csaccounting *CsaccountingCallerSession) RESUMEROLE() ([32]byte, error) {
+	return _Csaccounting.Contract.RESUMEROLE(&_Csaccounting.CallOpts)
+}
+
+// SETBONDCURVEROLE is a free data retrieval call binding the contract method 0x4342b3c1.
+//
+// Solidity: function SET_BOND_CURVE_ROLE() view returns(bytes32)
+func (_Csaccounting *CsaccountingCaller) SETBONDCURVEROLE(opts *bind.CallOpts) ([32]byte, error) {
+	var out []interface{}
+	err := _Csaccounting.contract.Call(opts, &out, "SET_BOND_CURVE_ROLE")
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// SETBONDCURVEROLE is a free data retrieval call binding the contract method 0x4342b3c1.
+//
+// Solidity: function SET_BOND_CURVE_ROLE() view returns(bytes32)
+func (_Csaccounting *CsaccountingSession) SETBONDCURVEROLE() ([32]byte, error) {
+	return _Csaccounting.Contract.SETBONDCURVEROLE(&_Csaccounting.CallOpts)
+}
+
+// SETBONDCURVEROLE is a free data retrieval call binding the contract method 0x4342b3c1.
+//
+// Solidity: function SET_BOND_CURVE_ROLE() view returns(bytes32)
+func (_Csaccounting *CsaccountingCallerSession) SETBONDCURVEROLE() ([32]byte, error) {
+	return _Csaccounting.Contract.SETBONDCURVEROLE(&_Csaccounting.CallOpts)
+}
+
+// WITHDRAWALQUEUE is a free data retrieval call binding the contract method 0x699340f4.
+//
+// Solidity: function WITHDRAWAL_QUEUE() view returns(address)
+func (_Csaccounting *CsaccountingCaller) WITHDRAWALQUEUE(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _Csaccounting.contract.Call(opts, &out, "WITHDRAWAL_QUEUE")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// WITHDRAWALQUEUE is a free data retrieval call binding the contract method 0x699340f4.
+//
+// Solidity: function WITHDRAWAL_QUEUE() view returns(address)
+func (_Csaccounting *CsaccountingSession) WITHDRAWALQUEUE() (common.Address, error) {
+	return _Csaccounting.Contract.WITHDRAWALQUEUE(&_Csaccounting.CallOpts)
+}
+
+// WITHDRAWALQUEUE is a free data retrieval call binding the contract method 0x699340f4.
+//
+// Solidity: function WITHDRAWAL_QUEUE() view returns(address)
+func (_Csaccounting *CsaccountingCallerSession) WITHDRAWALQUEUE() (common.Address, error) {
+	return _Csaccounting.Contract.WITHDRAWALQUEUE(&_Csaccounting.CallOpts)
+}
+
+// WSTETH is a free data retrieval call binding the contract method 0xd9fb643a.
+//
+// Solidity: function WSTETH() view returns(address)
+func (_Csaccounting *CsaccountingCaller) WSTETH(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _Csaccounting.contract.Call(opts, &out, "WSTETH")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// WSTETH is a free data retrieval call binding the contract method 0xd9fb643a.
+//
+// Solidity: function WSTETH() view returns(address)
+func (_Csaccounting *CsaccountingSession) WSTETH() (common.Address, error) {
+	return _Csaccounting.Contract.WSTETH(&_Csaccounting.CallOpts)
+}
+
+// WSTETH is a free data retrieval call binding the contract method 0xd9fb643a.
+//
+// Solidity: function WSTETH() view returns(address)
+func (_Csaccounting *CsaccountingCallerSession) WSTETH() (common.Address, error) {
+	return _Csaccounting.Contract.WSTETH(&_Csaccounting.CallOpts)
+}
+
+// ChargePenaltyRecipient is a free data retrieval call binding the contract method 0x165123dd.
+//
+// Solidity: function chargePenaltyRecipient() view returns(address)
+func (_Csaccounting *CsaccountingCaller) ChargePenaltyRecipient(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _Csaccounting.contract.Call(opts, &out, "chargePenaltyRecipient")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// ChargePenaltyRecipient is a free data retrieval call binding the contract method 0x165123dd.
+//
+// Solidity: function chargePenaltyRecipient() view returns(address)
+func (_Csaccounting *CsaccountingSession) ChargePenaltyRecipient() (common.Address, error) {
+	return _Csaccounting.Contract.ChargePenaltyRecipient(&_Csaccounting.CallOpts)
+}
+
+// ChargePenaltyRecipient is a free data retrieval call binding the contract method 0x165123dd.
+//
+// Solidity: function chargePenaltyRecipient() view returns(address)
+func (_Csaccounting *CsaccountingCallerSession) ChargePenaltyRecipient() (common.Address, error) {
+	return _Csaccounting.Contract.ChargePenaltyRecipient(&_Csaccounting.CallOpts)
+}
+
+// FeeDistributor is a free data retrieval call binding the contract method 0x0d43e8ad.
+//
+// Solidity: function feeDistributor() view returns(address)
+func (_Csaccounting *CsaccountingCaller) FeeDistributor(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _Csaccounting.contract.Call(opts, &out, "feeDistributor")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// FeeDistributor is a free data retrieval call binding the contract method 0x0d43e8ad.
+//
+// Solidity: function feeDistributor() view returns(address)
+func (_Csaccounting *CsaccountingSession) FeeDistributor() (common.Address, error) {
+	return _Csaccounting.Contract.FeeDistributor(&_Csaccounting.CallOpts)
+}
+
+// FeeDistributor is a free data retrieval call binding the contract method 0x0d43e8ad.
+//
+// Solidity: function feeDistributor() view returns(address)
+func (_Csaccounting *CsaccountingCallerSession) FeeDistributor() (common.Address, error) {
+	return _Csaccounting.Contract.FeeDistributor(&_Csaccounting.CallOpts)
+}
+
+// GetActualLockedBond is a free data retrieval call binding the contract method 0xead42a69.
+//
+// Solidity: function getActualLockedBond(uint256 nodeOperatorId) view returns(uint256)
+func (_Csaccounting *CsaccountingCaller) GetActualLockedBond(opts *bind.CallOpts, nodeOperatorId *big.Int) (*big.Int, error) {
+	var out []interface{}
+	err := _Csaccounting.contract.Call(opts, &out, "getActualLockedBond", nodeOperatorId)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// GetActualLockedBond is a free data retrieval call binding the contract method 0xead42a69.
+//
+// Solidity: function getActualLockedBond(uint256 nodeOperatorId) view returns(uint256)
+func (_Csaccounting *CsaccountingSession) GetActualLockedBond(nodeOperatorId *big.Int) (*big.Int, error) {
+	return _Csaccounting.Contract.GetActualLockedBond(&_Csaccounting.CallOpts, nodeOperatorId)
+}
+
+// GetActualLockedBond is a free data retrieval call binding the contract method 0xead42a69.
+//
+// Solidity: function getActualLockedBond(uint256 nodeOperatorId) view returns(uint256)
+func (_Csaccounting *CsaccountingCallerSession) GetActualLockedBond(nodeOperatorId *big.Int) (*big.Int, error) {
+	return _Csaccounting.Contract.GetActualLockedBond(&_Csaccounting.CallOpts, nodeOperatorId)
+}
+
+// GetBond is a free data retrieval call binding the contract method 0xd8fe7642.
+//
+// Solidity: function getBond(uint256 nodeOperatorId) view returns(uint256)
+func (_Csaccounting *CsaccountingCaller) GetBond(opts *bind.CallOpts, nodeOperatorId *big.Int) (*big.Int, error) {
+	var out []interface{}
+	err := _Csaccounting.contract.Call(opts, &out, "getBond", nodeOperatorId)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// GetBond is a free data retrieval call binding the contract method 0xd8fe7642.
+//
+// Solidity: function getBond(uint256 nodeOperatorId) view returns(uint256)
+func (_Csaccounting *CsaccountingSession) GetBond(nodeOperatorId *big.Int) (*big.Int, error) {
+	return _Csaccounting.Contract.GetBond(&_Csaccounting.CallOpts, nodeOperatorId)
+}
+
+// GetBond is a free data retrieval call binding the contract method 0xd8fe7642.
+//
+// Solidity: function getBond(uint256 nodeOperatorId) view returns(uint256)
+func (_Csaccounting *CsaccountingCallerSession) GetBond(nodeOperatorId *big.Int) (*big.Int, error) {
+	return _Csaccounting.Contract.GetBond(&_Csaccounting.CallOpts, nodeOperatorId)
+}
+
+// GetBondAmountByKeysCount is a free data retrieval call binding the contract method 0x0f23e742.
+//
+// Solidity: function getBondAmountByKeysCount(uint256 keys, (uint256[],uint256) curve) pure returns(uint256)
+func (_Csaccounting *CsaccountingCaller) GetBondAmountByKeysCount(opts *bind.CallOpts, keys *big.Int, curve ICSBondCurveBondCurve) (*big.Int, error) {
+	var out []interface{}
+	err := _Csaccounting.contract.Call(opts, &out, "getBondAmountByKeysCount", keys, curve)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// GetBondAmountByKeysCount is a free data retrieval call binding the contract method 0x0f23e742.
+//
+// Solidity: function getBondAmountByKeysCount(uint256 keys, (uint256[],uint256) curve) pure returns(uint256)
+func (_Csaccounting *CsaccountingSession) GetBondAmountByKeysCount(keys *big.Int, curve ICSBondCurveBondCurve) (*big.Int, error) {
+	return _Csaccounting.Contract.GetBondAmountByKeysCount(&_Csaccounting.CallOpts, keys, curve)
+}
+
+// GetBondAmountByKeysCount is a free data retrieval call binding the contract method 0x0f23e742.
+//
+// Solidity: function getBondAmountByKeysCount(uint256 keys, (uint256[],uint256) curve) pure returns(uint256)
+func (_Csaccounting *CsaccountingCallerSession) GetBondAmountByKeysCount(keys *big.Int, curve ICSBondCurveBondCurve) (*big.Int, error) {
+	return _Csaccounting.Contract.GetBondAmountByKeysCount(&_Csaccounting.CallOpts, keys, curve)
+}
+
+// GetBondAmountByKeysCount0 is a free data retrieval call binding the contract method 0x546da24f.
+//
+// Solidity: function getBondAmountByKeysCount(uint256 keys, uint256 curveId) view returns(uint256)
+func (_Csaccounting *CsaccountingCaller) GetBondAmountByKeysCount0(opts *bind.CallOpts, keys *big.Int, curveId *big.Int) (*big.Int, error) {
+	var out []interface{}
+	err := _Csaccounting.contract.Call(opts, &out, "getBondAmountByKeysCount0", keys, curveId)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// GetBondAmountByKeysCount0 is a free data retrieval call binding the contract method 0x546da24f.
+//
+// Solidity: function getBondAmountByKeysCount(uint256 keys, uint256 curveId) view returns(uint256)
+func (_Csaccounting *CsaccountingSession) GetBondAmountByKeysCount0(keys *big.Int, curveId *big.Int) (*big.Int, error) {
+	return _Csaccounting.Contract.GetBondAmountByKeysCount0(&_Csaccounting.CallOpts, keys, curveId)
+}
+
+// GetBondAmountByKeysCount0 is a free data retrieval call binding the contract method 0x546da24f.
+//
+// Solidity: function getBondAmountByKeysCount(uint256 keys, uint256 curveId) view returns(uint256)
+func (_Csaccounting *CsaccountingCallerSession) GetBondAmountByKeysCount0(keys *big.Int, curveId *big.Int) (*big.Int, error) {
+	return _Csaccounting.Contract.GetBondAmountByKeysCount0(&_Csaccounting.CallOpts, keys, curveId)
+}
+
+// GetBondAmountByKeysCountWstETH is a free data retrieval call binding the contract method 0x13d1234b.
+//
+// Solidity: function getBondAmountByKeysCountWstETH(uint256 keysCount, uint256 curveId) view returns(uint256)
+func (_Csaccounting *CsaccountingCaller) GetBondAmountByKeysCountWstETH(opts *bind.CallOpts, keysCount *big.Int, curveId *big.Int) (*big.Int, error) {
+	var out []interface{}
+	err := _Csaccounting.contract.Call(opts, &out, "getBondAmountByKeysCountWstETH", keysCount, curveId)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// GetBondAmountByKeysCountWstETH is a free data retrieval call binding the contract method 0x13d1234b.
+//
+// Solidity: function getBondAmountByKeysCountWstETH(uint256 keysCount, uint256 curveId) view returns(uint256)
+func (_Csaccounting *CsaccountingSession) GetBondAmountByKeysCountWstETH(keysCount *big.Int, curveId *big.Int) (*big.Int, error) {
+	return _Csaccounting.Contract.GetBondAmountByKeysCountWstETH(&_Csaccounting.CallOpts, keysCount, curveId)
+}
+
+// GetBondAmountByKeysCountWstETH is a free data retrieval call binding the contract method 0x13d1234b.
+//
+// Solidity: function getBondAmountByKeysCountWstETH(uint256 keysCount, uint256 curveId) view returns(uint256)
+func (_Csaccounting *CsaccountingCallerSession) GetBondAmountByKeysCountWstETH(keysCount *big.Int, curveId *big.Int) (*big.Int, error) {
+	return _Csaccounting.Contract.GetBondAmountByKeysCountWstETH(&_Csaccounting.CallOpts, keysCount, curveId)
+}
+
+// GetBondAmountByKeysCountWstETH0 is a free data retrieval call binding the contract method 0x9a4df8f0.
+//
+// Solidity: function getBondAmountByKeysCountWstETH(uint256 keysCount, (uint256[],uint256) curve) view returns(uint256)
+func (_Csaccounting *CsaccountingCaller) GetBondAmountByKeysCountWstETH0(opts *bind.CallOpts, keysCount *big.Int, curve ICSBondCurveBondCurve) (*big.Int, error) {
+	var out []interface{}
+	err := _Csaccounting.contract.Call(opts, &out, "getBondAmountByKeysCountWstETH0", keysCount, curve)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// GetBondAmountByKeysCountWstETH0 is a free data retrieval call binding the contract method 0x9a4df8f0.
+//
+// Solidity: function getBondAmountByKeysCountWstETH(uint256 keysCount, (uint256[],uint256) curve) view returns(uint256)
+func (_Csaccounting *CsaccountingSession) GetBondAmountByKeysCountWstETH0(keysCount *big.Int, curve ICSBondCurveBondCurve) (*big.Int, error) {
+	return _Csaccounting.Contract.GetBondAmountByKeysCountWstETH0(&_Csaccounting.CallOpts, keysCount, curve)
+}
+
+// GetBondAmountByKeysCountWstETH0 is a free data retrieval call binding the contract method 0x9a4df8f0.
+//
+// Solidity: function getBondAmountByKeysCountWstETH(uint256 keysCount, (uint256[],uint256) curve) view returns(uint256)
+func (_Csaccounting *CsaccountingCallerSession) GetBondAmountByKeysCountWstETH0(keysCount *big.Int, curve ICSBondCurveBondCurve) (*big.Int, error) {
+	return _Csaccounting.Contract.GetBondAmountByKeysCountWstETH0(&_Csaccounting.CallOpts, keysCount, curve)
+}
+
+// GetBondCurve is a free data retrieval call binding the contract method 0x6e13f099.
+//
+// Solidity: function getBondCurve(uint256 nodeOperatorId) view returns((uint256[],uint256))
+func (_Csaccounting *CsaccountingCaller) GetBondCurve(opts *bind.CallOpts, nodeOperatorId *big.Int) (ICSBondCurveBondCurve, error) {
+	var out []interface{}
+	err := _Csaccounting.contract.Call(opts, &out, "getBondCurve", nodeOperatorId)
+
+	if err != nil {
+		return *new(ICSBondCurveBondCurve), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(ICSBondCurveBondCurve)).(*ICSBondCurveBondCurve)
+
+	return out0, err
+
+}
+
+// GetBondCurve is a free data retrieval call binding the contract method 0x6e13f099.
+//
+// Solidity: function getBondCurve(uint256 nodeOperatorId) view returns((uint256[],uint256))
+func (_Csaccounting *CsaccountingSession) GetBondCurve(nodeOperatorId *big.Int) (ICSBondCurveBondCurve, error) {
+	return _Csaccounting.Contract.GetBondCurve(&_Csaccounting.CallOpts, nodeOperatorId)
+}
+
+// GetBondCurve is a free data retrieval call binding the contract method 0x6e13f099.
+//
+// Solidity: function getBondCurve(uint256 nodeOperatorId) view returns((uint256[],uint256))
+func (_Csaccounting *CsaccountingCallerSession) GetBondCurve(nodeOperatorId *big.Int) (ICSBondCurveBondCurve, error) {
+	return _Csaccounting.Contract.GetBondCurve(&_Csaccounting.CallOpts, nodeOperatorId)
+}
+
+// GetBondCurveId is a free data retrieval call binding the contract method 0x0569b947.
+//
+// Solidity: function getBondCurveId(uint256 nodeOperatorId) view returns(uint256)
+func (_Csaccounting *CsaccountingCaller) GetBondCurveId(opts *bind.CallOpts, nodeOperatorId *big.Int) (*big.Int, error) {
+	var out []interface{}
+	err := _Csaccounting.contract.Call(opts, &out, "getBondCurveId", nodeOperatorId)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// GetBondCurveId is a free data retrieval call binding the contract method 0x0569b947.
+//
+// Solidity: function getBondCurveId(uint256 nodeOperatorId) view returns(uint256)
+func (_Csaccounting *CsaccountingSession) GetBondCurveId(nodeOperatorId *big.Int) (*big.Int, error) {
+	return _Csaccounting.Contract.GetBondCurveId(&_Csaccounting.CallOpts, nodeOperatorId)
+}
+
+// GetBondCurveId is a free data retrieval call binding the contract method 0x0569b947.
+//
+// Solidity: function getBondCurveId(uint256 nodeOperatorId) view returns(uint256)
+func (_Csaccounting *CsaccountingCallerSession) GetBondCurveId(nodeOperatorId *big.Int) (*big.Int, error) {
+	return _Csaccounting.Contract.GetBondCurveId(&_Csaccounting.CallOpts, nodeOperatorId)
+}
+
+// GetBondLockRetentionPeriod is a free data retrieval call binding the contract method 0xdef82d02.
+//
+// Solidity: function getBondLockRetentionPeriod() view returns(uint256)
+func (_Csaccounting *CsaccountingCaller) GetBondLockRetentionPeriod(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _Csaccounting.contract.Call(opts, &out, "getBondLockRetentionPeriod")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// GetBondLockRetentionPeriod is a free data retrieval call binding the contract method 0xdef82d02.
+//
+// Solidity: function getBondLockRetentionPeriod() view returns(uint256)
+func (_Csaccounting *CsaccountingSession) GetBondLockRetentionPeriod() (*big.Int, error) {
+	return _Csaccounting.Contract.GetBondLockRetentionPeriod(&_Csaccounting.CallOpts)
+}
+
+// GetBondLockRetentionPeriod is a free data retrieval call binding the contract method 0xdef82d02.
+//
+// Solidity: function getBondLockRetentionPeriod() view returns(uint256)
+func (_Csaccounting *CsaccountingCallerSession) GetBondLockRetentionPeriod() (*big.Int, error) {
+	return _Csaccounting.Contract.GetBondLockRetentionPeriod(&_Csaccounting.CallOpts)
+}
+
+// GetBondShares is a free data retrieval call binding the contract method 0x06cd0e90.
+//
+// Solidity: function getBondShares(uint256 nodeOperatorId) view returns(uint256)
+func (_Csaccounting *CsaccountingCaller) GetBondShares(opts *bind.CallOpts, nodeOperatorId *big.Int) (*big.Int, error) {
+	var out []interface{}
+	err := _Csaccounting.contract.Call(opts, &out, "getBondShares", nodeOperatorId)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// GetBondShares is a free data retrieval call binding the contract method 0x06cd0e90.
+//
+// Solidity: function getBondShares(uint256 nodeOperatorId) view returns(uint256)
+func (_Csaccounting *CsaccountingSession) GetBondShares(nodeOperatorId *big.Int) (*big.Int, error) {
+	return _Csaccounting.Contract.GetBondShares(&_Csaccounting.CallOpts, nodeOperatorId)
+}
+
+// GetBondShares is a free data retrieval call binding the contract method 0x06cd0e90.
+//
+// Solidity: function getBondShares(uint256 nodeOperatorId) view returns(uint256)
+func (_Csaccounting *CsaccountingCallerSession) GetBondShares(nodeOperatorId *big.Int) (*big.Int, error) {
+	return _Csaccounting.Contract.GetBondShares(&_Csaccounting.CallOpts, nodeOperatorId)
+}
+
+// GetBondSummary is a free data retrieval call binding the contract method 0xce19793f.
+//
+// Solidity: function getBondSummary(uint256 nodeOperatorId) view returns(uint256 current, uint256 required)
+func (_Csaccounting *CsaccountingCaller) GetBondSummary(opts *bind.CallOpts, nodeOperatorId *big.Int) (struct {
+	Current  *big.Int
+	Required *big.Int
+}, error) {
+	var out []interface{}
+	err := _Csaccounting.contract.Call(opts, &out, "getBondSummary", nodeOperatorId)
+
+	outstruct := new(struct {
+		Current  *big.Int
+		Required *big.Int
+	})
+	if err != nil {
+		return *outstruct, err
+	}
+
+	outstruct.Current = *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+	outstruct.Required = *abi.ConvertType(out[1], new(*big.Int)).(**big.Int)
+
+	return *outstruct, err
+
+}
+
+// GetBondSummary is a free data retrieval call binding the contract method 0xce19793f.
+//
+// Solidity: function getBondSummary(uint256 nodeOperatorId) view returns(uint256 current, uint256 required)
+func (_Csaccounting *CsaccountingSession) GetBondSummary(nodeOperatorId *big.Int) (struct {
+	Current  *big.Int
+	Required *big.Int
+}, error) {
+	return _Csaccounting.Contract.GetBondSummary(&_Csaccounting.CallOpts, nodeOperatorId)
+}
+
+// GetBondSummary is a free data retrieval call binding the contract method 0xce19793f.
+//
+// Solidity: function getBondSummary(uint256 nodeOperatorId) view returns(uint256 current, uint256 required)
+func (_Csaccounting *CsaccountingCallerSession) GetBondSummary(nodeOperatorId *big.Int) (struct {
+	Current  *big.Int
+	Required *big.Int
+}, error) {
+	return _Csaccounting.Contract.GetBondSummary(&_Csaccounting.CallOpts, nodeOperatorId)
+}
+
+// GetBondSummaryShares is a free data retrieval call binding the contract method 0x8f6549ae.
+//
+// Solidity: function getBondSummaryShares(uint256 nodeOperatorId) view returns(uint256 current, uint256 required)
+func (_Csaccounting *CsaccountingCaller) GetBondSummaryShares(opts *bind.CallOpts, nodeOperatorId *big.Int) (struct {
+	Current  *big.Int
+	Required *big.Int
+}, error) {
+	var out []interface{}
+	err := _Csaccounting.contract.Call(opts, &out, "getBondSummaryShares", nodeOperatorId)
+
+	outstruct := new(struct {
+		Current  *big.Int
+		Required *big.Int
+	})
+	if err != nil {
+		return *outstruct, err
+	}
+
+	outstruct.Current = *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+	outstruct.Required = *abi.ConvertType(out[1], new(*big.Int)).(**big.Int)
+
+	return *outstruct, err
+
+}
+
+// GetBondSummaryShares is a free data retrieval call binding the contract method 0x8f6549ae.
+//
+// Solidity: function getBondSummaryShares(uint256 nodeOperatorId) view returns(uint256 current, uint256 required)
+func (_Csaccounting *CsaccountingSession) GetBondSummaryShares(nodeOperatorId *big.Int) (struct {
+	Current  *big.Int
+	Required *big.Int
+}, error) {
+	return _Csaccounting.Contract.GetBondSummaryShares(&_Csaccounting.CallOpts, nodeOperatorId)
+}
+
+// GetBondSummaryShares is a free data retrieval call binding the contract method 0x8f6549ae.
+//
+// Solidity: function getBondSummaryShares(uint256 nodeOperatorId) view returns(uint256 current, uint256 required)
+func (_Csaccounting *CsaccountingCallerSession) GetBondSummaryShares(nodeOperatorId *big.Int) (struct {
+	Current  *big.Int
+	Required *big.Int
+}, error) {
+	return _Csaccounting.Contract.GetBondSummaryShares(&_Csaccounting.CallOpts, nodeOperatorId)
+}
+
+// GetCurveInfo is a free data retrieval call binding the contract method 0xb5b624bf.
+//
+// Solidity: function getCurveInfo(uint256 curveId) view returns((uint256[],uint256))
+func (_Csaccounting *CsaccountingCaller) GetCurveInfo(opts *bind.CallOpts, curveId *big.Int) (ICSBondCurveBondCurve, error) {
+	var out []interface{}
+	err := _Csaccounting.contract.Call(opts, &out, "getCurveInfo", curveId)
+
+	if err != nil {
+		return *new(ICSBondCurveBondCurve), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(ICSBondCurveBondCurve)).(*ICSBondCurveBondCurve)
+
+	return out0, err
+
+}
+
+// GetCurveInfo is a free data retrieval call binding the contract method 0xb5b624bf.
+//
+// Solidity: function getCurveInfo(uint256 curveId) view returns((uint256[],uint256))
+func (_Csaccounting *CsaccountingSession) GetCurveInfo(curveId *big.Int) (ICSBondCurveBondCurve, error) {
+	return _Csaccounting.Contract.GetCurveInfo(&_Csaccounting.CallOpts, curveId)
+}
+
+// GetCurveInfo is a free data retrieval call binding the contract method 0xb5b624bf.
+//
+// Solidity: function getCurveInfo(uint256 curveId) view returns((uint256[],uint256))
+func (_Csaccounting *CsaccountingCallerSession) GetCurveInfo(curveId *big.Int) (ICSBondCurveBondCurve, error) {
+	return _Csaccounting.Contract.GetCurveInfo(&_Csaccounting.CallOpts, curveId)
+}
+
+// GetKeysCountByBondAmount is a free data retrieval call binding the contract method 0xd2fa16a6.
+//
+// Solidity: function getKeysCountByBondAmount(uint256 amount, (uint256[],uint256) curve) pure returns(uint256)
+func (_Csaccounting *CsaccountingCaller) GetKeysCountByBondAmount(opts *bind.CallOpts, amount *big.Int, curve ICSBondCurveBondCurve) (*big.Int, error) {
+	var out []interface{}
+	err := _Csaccounting.contract.Call(opts, &out, "getKeysCountByBondAmount", amount, curve)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// GetKeysCountByBondAmount is a free data retrieval call binding the contract method 0xd2fa16a6.
+//
+// Solidity: function getKeysCountByBondAmount(uint256 amount, (uint256[],uint256) curve) pure returns(uint256)
+func (_Csaccounting *CsaccountingSession) GetKeysCountByBondAmount(amount *big.Int, curve ICSBondCurveBondCurve) (*big.Int, error) {
+	return _Csaccounting.Contract.GetKeysCountByBondAmount(&_Csaccounting.CallOpts, amount, curve)
+}
+
+// GetKeysCountByBondAmount is a free data retrieval call binding the contract method 0xd2fa16a6.
+//
+// Solidity: function getKeysCountByBondAmount(uint256 amount, (uint256[],uint256) curve) pure returns(uint256)
+func (_Csaccounting *CsaccountingCallerSession) GetKeysCountByBondAmount(amount *big.Int, curve ICSBondCurveBondCurve) (*big.Int, error) {
+	return _Csaccounting.Contract.GetKeysCountByBondAmount(&_Csaccounting.CallOpts, amount, curve)
+}
+
+// GetKeysCountByBondAmount0 is a free data retrieval call binding the contract method 0xdc38ea3d.
+//
+// Solidity: function getKeysCountByBondAmount(uint256 amount, uint256 curveId) view returns(uint256)
+func (_Csaccounting *CsaccountingCaller) GetKeysCountByBondAmount0(opts *bind.CallOpts, amount *big.Int, curveId *big.Int) (*big.Int, error) {
+	var out []interface{}
+	err := _Csaccounting.contract.Call(opts, &out, "getKeysCountByBondAmount0", amount, curveId)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// GetKeysCountByBondAmount0 is a free data retrieval call binding the contract method 0xdc38ea3d.
+//
+// Solidity: function getKeysCountByBondAmount(uint256 amount, uint256 curveId) view returns(uint256)
+func (_Csaccounting *CsaccountingSession) GetKeysCountByBondAmount0(amount *big.Int, curveId *big.Int) (*big.Int, error) {
+	return _Csaccounting.Contract.GetKeysCountByBondAmount0(&_Csaccounting.CallOpts, amount, curveId)
+}
+
+// GetKeysCountByBondAmount0 is a free data retrieval call binding the contract method 0xdc38ea3d.
+//
+// Solidity: function getKeysCountByBondAmount(uint256 amount, uint256 curveId) view returns(uint256)
+func (_Csaccounting *CsaccountingCallerSession) GetKeysCountByBondAmount0(amount *big.Int, curveId *big.Int) (*big.Int, error) {
+	return _Csaccounting.Contract.GetKeysCountByBondAmount0(&_Csaccounting.CallOpts, amount, curveId)
+}
+
+// GetLockedBondInfo is a free data retrieval call binding the contract method 0x83316184.
+//
+// Solidity: function getLockedBondInfo(uint256 nodeOperatorId) view returns((uint128,uint128))
+func (_Csaccounting *CsaccountingCaller) GetLockedBondInfo(opts *bind.CallOpts, nodeOperatorId *big.Int) (ICSBondLockBondLock, error) {
+	var out []interface{}
+	err := _Csaccounting.contract.Call(opts, &out, "getLockedBondInfo", nodeOperatorId)
+
+	if err != nil {
+		return *new(ICSBondLockBondLock), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(ICSBondLockBondLock)).(*ICSBondLockBondLock)
+
+	return out0, err
+
+}
+
+// GetLockedBondInfo is a free data retrieval call binding the contract method 0x83316184.
+//
+// Solidity: function getLockedBondInfo(uint256 nodeOperatorId) view returns((uint128,uint128))
+func (_Csaccounting *CsaccountingSession) GetLockedBondInfo(nodeOperatorId *big.Int) (ICSBondLockBondLock, error) {
+	return _Csaccounting.Contract.GetLockedBondInfo(&_Csaccounting.CallOpts, nodeOperatorId)
+}
+
+// GetLockedBondInfo is a free data retrieval call binding the contract method 0x83316184.
+//
+// Solidity: function getLockedBondInfo(uint256 nodeOperatorId) view returns((uint128,uint128))
+func (_Csaccounting *CsaccountingCallerSession) GetLockedBondInfo(nodeOperatorId *big.Int) (ICSBondLockBondLock, error) {
+	return _Csaccounting.Contract.GetLockedBondInfo(&_Csaccounting.CallOpts, nodeOperatorId)
+}
+
+// GetRequiredBondForNextKeys is a free data retrieval call binding the contract method 0xb148db6a.
+//
+// Solidity: function getRequiredBondForNextKeys(uint256 nodeOperatorId, uint256 additionalKeys) view returns(uint256)
+func (_Csaccounting *CsaccountingCaller) GetRequiredBondForNextKeys(opts *bind.CallOpts, nodeOperatorId *big.Int, additionalKeys *big.Int) (*big.Int, error) {
+	var out []interface{}
+	err := _Csaccounting.contract.Call(opts, &out, "getRequiredBondForNextKeys", nodeOperatorId, additionalKeys)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// GetRequiredBondForNextKeys is a free data retrieval call binding the contract method 0xb148db6a.
+//
+// Solidity: function getRequiredBondForNextKeys(uint256 nodeOperatorId, uint256 additionalKeys) view returns(uint256)
+func (_Csaccounting *CsaccountingSession) GetRequiredBondForNextKeys(nodeOperatorId *big.Int, additionalKeys *big.Int) (*big.Int, error) {
+	return _Csaccounting.Contract.GetRequiredBondForNextKeys(&_Csaccounting.CallOpts, nodeOperatorId, additionalKeys)
+}
+
+// GetRequiredBondForNextKeys is a free data retrieval call binding the contract method 0xb148db6a.
+//
+// Solidity: function getRequiredBondForNextKeys(uint256 nodeOperatorId, uint256 additionalKeys) view returns(uint256)
+func (_Csaccounting *CsaccountingCallerSession) GetRequiredBondForNextKeys(nodeOperatorId *big.Int, additionalKeys *big.Int) (*big.Int, error) {
+	return _Csaccounting.Contract.GetRequiredBondForNextKeys(&_Csaccounting.CallOpts, nodeOperatorId, additionalKeys)
+}
+
+// GetRequiredBondForNextKeysWstETH is a free data retrieval call binding the contract method 0x28846981.
+//
+// Solidity: function getRequiredBondForNextKeysWstETH(uint256 nodeOperatorId, uint256 additionalKeys) view returns(uint256)
+func (_Csaccounting *CsaccountingCaller) GetRequiredBondForNextKeysWstETH(opts *bind.CallOpts, nodeOperatorId *big.Int, additionalKeys *big.Int) (*big.Int, error) {
+	var out []interface{}
+	err := _Csaccounting.contract.Call(opts, &out, "getRequiredBondForNextKeysWstETH", nodeOperatorId, additionalKeys)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// GetRequiredBondForNextKeysWstETH is a free data retrieval call binding the contract method 0x28846981.
+//
+// Solidity: function getRequiredBondForNextKeysWstETH(uint256 nodeOperatorId, uint256 additionalKeys) view returns(uint256)
+func (_Csaccounting *CsaccountingSession) GetRequiredBondForNextKeysWstETH(nodeOperatorId *big.Int, additionalKeys *big.Int) (*big.Int, error) {
+	return _Csaccounting.Contract.GetRequiredBondForNextKeysWstETH(&_Csaccounting.CallOpts, nodeOperatorId, additionalKeys)
+}
+
+// GetRequiredBondForNextKeysWstETH is a free data retrieval call binding the contract method 0x28846981.
+//
+// Solidity: function getRequiredBondForNextKeysWstETH(uint256 nodeOperatorId, uint256 additionalKeys) view returns(uint256)
+func (_Csaccounting *CsaccountingCallerSession) GetRequiredBondForNextKeysWstETH(nodeOperatorId *big.Int, additionalKeys *big.Int) (*big.Int, error) {
+	return _Csaccounting.Contract.GetRequiredBondForNextKeysWstETH(&_Csaccounting.CallOpts, nodeOperatorId, additionalKeys)
+}
+
+// GetResumeSinceTimestamp is a free data retrieval call binding the contract method 0x589ff76c.
+//
+// Solidity: function getResumeSinceTimestamp() view returns(uint256)
+func (_Csaccounting *CsaccountingCaller) GetResumeSinceTimestamp(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _Csaccounting.contract.Call(opts, &out, "getResumeSinceTimestamp")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// GetResumeSinceTimestamp is a free data retrieval call binding the contract method 0x589ff76c.
+//
+// Solidity: function getResumeSinceTimestamp() view returns(uint256)
+func (_Csaccounting *CsaccountingSession) GetResumeSinceTimestamp() (*big.Int, error) {
+	return _Csaccounting.Contract.GetResumeSinceTimestamp(&_Csaccounting.CallOpts)
+}
+
+// GetResumeSinceTimestamp is a free data retrieval call binding the contract method 0x589ff76c.
+//
+// Solidity: function getResumeSinceTimestamp() view returns(uint256)
+func (_Csaccounting *CsaccountingCallerSession) GetResumeSinceTimestamp() (*big.Int, error) {
+	return _Csaccounting.Contract.GetResumeSinceTimestamp(&_Csaccounting.CallOpts)
+}
+
+// GetRoleAdmin is a free data retrieval call binding the contract method 0x248a9ca3.
+//
+// Solidity: function getRoleAdmin(bytes32 role) view returns(bytes32)
+func (_Csaccounting *CsaccountingCaller) GetRoleAdmin(opts *bind.CallOpts, role [32]byte) ([32]byte, error) {
+	var out []interface{}
+	err := _Csaccounting.contract.Call(opts, &out, "getRoleAdmin", role)
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// GetRoleAdmin is a free data retrieval call binding the contract method 0x248a9ca3.
+//
+// Solidity: function getRoleAdmin(bytes32 role) view returns(bytes32)
+func (_Csaccounting *CsaccountingSession) GetRoleAdmin(role [32]byte) ([32]byte, error) {
+	return _Csaccounting.Contract.GetRoleAdmin(&_Csaccounting.CallOpts, role)
+}
+
+// GetRoleAdmin is a free data retrieval call binding the contract method 0x248a9ca3.
+//
+// Solidity: function getRoleAdmin(bytes32 role) view returns(bytes32)
+func (_Csaccounting *CsaccountingCallerSession) GetRoleAdmin(role [32]byte) ([32]byte, error) {
+	return _Csaccounting.Contract.GetRoleAdmin(&_Csaccounting.CallOpts, role)
+}
+
+// GetRoleMember is a free data retrieval call binding the contract method 0x9010d07c.
+//
+// Solidity: function getRoleMember(bytes32 role, uint256 index) view returns(address)
+func (_Csaccounting *CsaccountingCaller) GetRoleMember(opts *bind.CallOpts, role [32]byte, index *big.Int) (common.Address, error) {
+	var out []interface{}
+	err := _Csaccounting.contract.Call(opts, &out, "getRoleMember", role, index)
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// GetRoleMember is a free data retrieval call binding the contract method 0x9010d07c.
+//
+// Solidity: function getRoleMember(bytes32 role, uint256 index) view returns(address)
+func (_Csaccounting *CsaccountingSession) GetRoleMember(role [32]byte, index *big.Int) (common.Address, error) {
+	return _Csaccounting.Contract.GetRoleMember(&_Csaccounting.CallOpts, role, index)
+}
+
+// GetRoleMember is a free data retrieval call binding the contract method 0x9010d07c.
+//
+// Solidity: function getRoleMember(bytes32 role, uint256 index) view returns(address)
+func (_Csaccounting *CsaccountingCallerSession) GetRoleMember(role [32]byte, index *big.Int) (common.Address, error) {
+	return _Csaccounting.Contract.GetRoleMember(&_Csaccounting.CallOpts, role, index)
+}
+
+// GetRoleMemberCount is a free data retrieval call binding the contract method 0xca15c873.
+//
+// Solidity: function getRoleMemberCount(bytes32 role) view returns(uint256)
+func (_Csaccounting *CsaccountingCaller) GetRoleMemberCount(opts *bind.CallOpts, role [32]byte) (*big.Int, error) {
+	var out []interface{}
+	err := _Csaccounting.contract.Call(opts, &out, "getRoleMemberCount", role)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// GetRoleMemberCount is a free data retrieval call binding the contract method 0xca15c873.
+//
+// Solidity: function getRoleMemberCount(bytes32 role) view returns(uint256)
+func (_Csaccounting *CsaccountingSession) GetRoleMemberCount(role [32]byte) (*big.Int, error) {
+	return _Csaccounting.Contract.GetRoleMemberCount(&_Csaccounting.CallOpts, role)
+}
+
+// GetRoleMemberCount is a free data retrieval call binding the contract method 0xca15c873.
+//
+// Solidity: function getRoleMemberCount(bytes32 role) view returns(uint256)
+func (_Csaccounting *CsaccountingCallerSession) GetRoleMemberCount(role [32]byte) (*big.Int, error) {
+	return _Csaccounting.Contract.GetRoleMemberCount(&_Csaccounting.CallOpts, role)
+}
+
+// GetUnbondedKeysCount is a free data retrieval call binding the contract method 0x01a5e9e3.
+//
+// Solidity: function getUnbondedKeysCount(uint256 nodeOperatorId) view returns(uint256)
+func (_Csaccounting *CsaccountingCaller) GetUnbondedKeysCount(opts *bind.CallOpts, nodeOperatorId *big.Int) (*big.Int, error) {
+	var out []interface{}
+	err := _Csaccounting.contract.Call(opts, &out, "getUnbondedKeysCount", nodeOperatorId)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// GetUnbondedKeysCount is a free data retrieval call binding the contract method 0x01a5e9e3.
+//
+// Solidity: function getUnbondedKeysCount(uint256 nodeOperatorId) view returns(uint256)
+func (_Csaccounting *CsaccountingSession) GetUnbondedKeysCount(nodeOperatorId *big.Int) (*big.Int, error) {
+	return _Csaccounting.Contract.GetUnbondedKeysCount(&_Csaccounting.CallOpts, nodeOperatorId)
+}
+
+// GetUnbondedKeysCount is a free data retrieval call binding the contract method 0x01a5e9e3.
+//
+// Solidity: function getUnbondedKeysCount(uint256 nodeOperatorId) view returns(uint256)
+func (_Csaccounting *CsaccountingCallerSession) GetUnbondedKeysCount(nodeOperatorId *big.Int) (*big.Int, error) {
+	return _Csaccounting.Contract.GetUnbondedKeysCount(&_Csaccounting.CallOpts, nodeOperatorId)
+}
+
+// GetUnbondedKeysCountToEject is a free data retrieval call binding the contract method 0x9c516102.
+//
+// Solidity: function getUnbondedKeysCountToEject(uint256 nodeOperatorId) view returns(uint256)
+func (_Csaccounting *CsaccountingCaller) GetUnbondedKeysCountToEject(opts *bind.CallOpts, nodeOperatorId *big.Int) (*big.Int, error) {
+	var out []interface{}
+	err := _Csaccounting.contract.Call(opts, &out, "getUnbondedKeysCountToEject", nodeOperatorId)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// GetUnbondedKeysCountToEject is a free data retrieval call binding the contract method 0x9c516102.
+//
+// Solidity: function getUnbondedKeysCountToEject(uint256 nodeOperatorId) view returns(uint256)
+func (_Csaccounting *CsaccountingSession) GetUnbondedKeysCountToEject(nodeOperatorId *big.Int) (*big.Int, error) {
+	return _Csaccounting.Contract.GetUnbondedKeysCountToEject(&_Csaccounting.CallOpts, nodeOperatorId)
+}
+
+// GetUnbondedKeysCountToEject is a free data retrieval call binding the contract method 0x9c516102.
+//
+// Solidity: function getUnbondedKeysCountToEject(uint256 nodeOperatorId) view returns(uint256)
+func (_Csaccounting *CsaccountingCallerSession) GetUnbondedKeysCountToEject(nodeOperatorId *big.Int) (*big.Int, error) {
+	return _Csaccounting.Contract.GetUnbondedKeysCountToEject(&_Csaccounting.CallOpts, nodeOperatorId)
+}
+
+// HasRole is a free data retrieval call binding the contract method 0x91d14854.
+//
+// Solidity: function hasRole(bytes32 role, address account) view returns(bool)
+func (_Csaccounting *CsaccountingCaller) HasRole(opts *bind.CallOpts, role [32]byte, account common.Address) (bool, error) {
+	var out []interface{}
+	err := _Csaccounting.contract.Call(opts, &out, "hasRole", role, account)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// HasRole is a free data retrieval call binding the contract method 0x91d14854.
+//
+// Solidity: function hasRole(bytes32 role, address account) view returns(bool)
+func (_Csaccounting *CsaccountingSession) HasRole(role [32]byte, account common.Address) (bool, error) {
+	return _Csaccounting.Contract.HasRole(&_Csaccounting.CallOpts, role, account)
+}
+
+// HasRole is a free data retrieval call binding the contract method 0x91d14854.
+//
+// Solidity: function hasRole(bytes32 role, address account) view returns(bool)
+func (_Csaccounting *CsaccountingCallerSession) HasRole(role [32]byte, account common.Address) (bool, error) {
+	return _Csaccounting.Contract.HasRole(&_Csaccounting.CallOpts, role, account)
+}
+
+// IsPaused is a free data retrieval call binding the contract method 0xb187bd26.
+//
+// Solidity: function isPaused() view returns(bool)
+func (_Csaccounting *CsaccountingCaller) IsPaused(opts *bind.CallOpts) (bool, error) {
+	var out []interface{}
+	err := _Csaccounting.contract.Call(opts, &out, "isPaused")
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// IsPaused is a free data retrieval call binding the contract method 0xb187bd26.
+//
+// Solidity: function isPaused() view returns(bool)
+func (_Csaccounting *CsaccountingSession) IsPaused() (bool, error) {
+	return _Csaccounting.Contract.IsPaused(&_Csaccounting.CallOpts)
+}
+
+// IsPaused is a free data retrieval call binding the contract method 0xb187bd26.
+//
+// Solidity: function isPaused() view returns(bool)
+func (_Csaccounting *CsaccountingCallerSession) IsPaused() (bool, error) {
+	return _Csaccounting.Contract.IsPaused(&_Csaccounting.CallOpts)
+}
+
+// SupportsInterface is a free data retrieval call binding the contract method 0x01ffc9a7.
+//
+// Solidity: function supportsInterface(bytes4 interfaceId) view returns(bool)
+func (_Csaccounting *CsaccountingCaller) SupportsInterface(opts *bind.CallOpts, interfaceId [4]byte) (bool, error) {
+	var out []interface{}
+	err := _Csaccounting.contract.Call(opts, &out, "supportsInterface", interfaceId)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// SupportsInterface is a free data retrieval call binding the contract method 0x01ffc9a7.
+//
+// Solidity: function supportsInterface(bytes4 interfaceId) view returns(bool)
+func (_Csaccounting *CsaccountingSession) SupportsInterface(interfaceId [4]byte) (bool, error) {
+	return _Csaccounting.Contract.SupportsInterface(&_Csaccounting.CallOpts, interfaceId)
+}
+
+// SupportsInterface is a free data retrieval call binding the contract method 0x01ffc9a7.
+//
+// Solidity: function supportsInterface(bytes4 interfaceId) view returns(bool)
+func (_Csaccounting *CsaccountingCallerSession) SupportsInterface(interfaceId [4]byte) (bool, error) {
+	return _Csaccounting.Contract.SupportsInterface(&_Csaccounting.CallOpts, interfaceId)
+}
+
+// TotalBondShares is a free data retrieval call binding the contract method 0x74d70aea.
+//
+// Solidity: function totalBondShares() view returns(uint256)
+func (_Csaccounting *CsaccountingCaller) TotalBondShares(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _Csaccounting.contract.Call(opts, &out, "totalBondShares")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// TotalBondShares is a free data retrieval call binding the contract method 0x74d70aea.
+//
+// Solidity: function totalBondShares() view returns(uint256)
+func (_Csaccounting *CsaccountingSession) TotalBondShares() (*big.Int, error) {
+	return _Csaccounting.Contract.TotalBondShares(&_Csaccounting.CallOpts)
+}
+
+// TotalBondShares is a free data retrieval call binding the contract method 0x74d70aea.
+//
+// Solidity: function totalBondShares() view returns(uint256)
+func (_Csaccounting *CsaccountingCallerSession) TotalBondShares() (*big.Int, error) {
+	return _Csaccounting.Contract.TotalBondShares(&_Csaccounting.CallOpts)
+}
+
+// AddBondCurve is a paid mutator transaction binding the contract method 0x573b6245.
+//
+// Solidity: function addBondCurve(uint256[] bondCurve) returns(uint256 id)
+func (_Csaccounting *CsaccountingTransactor) AddBondCurve(opts *bind.TransactOpts, bondCurve []*big.Int) (*types.Transaction, error) {
+	return _Csaccounting.contract.Transact(opts, "addBondCurve", bondCurve)
+}
+
+// AddBondCurve is a paid mutator transaction binding the contract method 0x573b6245.
+//
+// Solidity: function addBondCurve(uint256[] bondCurve) returns(uint256 id)
+func (_Csaccounting *CsaccountingSession) AddBondCurve(bondCurve []*big.Int) (*types.Transaction, error) {
+	return _Csaccounting.Contract.AddBondCurve(&_Csaccounting.TransactOpts, bondCurve)
+}
+
+// AddBondCurve is a paid mutator transaction binding the contract method 0x573b6245.
+//
+// Solidity: function addBondCurve(uint256[] bondCurve) returns(uint256 id)
+func (_Csaccounting *CsaccountingTransactorSession) AddBondCurve(bondCurve []*big.Int) (*types.Transaction, error) {
+	return _Csaccounting.Contract.AddBondCurve(&_Csaccounting.TransactOpts, bondCurve)
+}
+
+// ChargeFee is a paid mutator transaction binding the contract method 0x881fa03c.
+//
+// Solidity: function chargeFee(uint256 nodeOperatorId, uint256 amount) returns()
+func (_Csaccounting *CsaccountingTransactor) ChargeFee(opts *bind.TransactOpts, nodeOperatorId *big.Int, amount *big.Int) (*types.Transaction, error) {
+	return _Csaccounting.contract.Transact(opts, "chargeFee", nodeOperatorId, amount)
+}
+
+// ChargeFee is a paid mutator transaction binding the contract method 0x881fa03c.
+//
+// Solidity: function chargeFee(uint256 nodeOperatorId, uint256 amount) returns()
+func (_Csaccounting *CsaccountingSession) ChargeFee(nodeOperatorId *big.Int, amount *big.Int) (*types.Transaction, error) {
+	return _Csaccounting.Contract.ChargeFee(&_Csaccounting.TransactOpts, nodeOperatorId, amount)
+}
+
+// ChargeFee is a paid mutator transaction binding the contract method 0x881fa03c.
+//
+// Solidity: function chargeFee(uint256 nodeOperatorId, uint256 amount) returns()
+func (_Csaccounting *CsaccountingTransactorSession) ChargeFee(nodeOperatorId *big.Int, amount *big.Int) (*types.Transaction, error) {
+	return _Csaccounting.Contract.ChargeFee(&_Csaccounting.TransactOpts, nodeOperatorId, amount)
+}
+
+// ClaimRewardsStETH is a paid mutator transaction binding the contract method 0xf9391223.
+//
+// Solidity: function claimRewardsStETH(uint256 nodeOperatorId, uint256 stETHAmount, address rewardAddress, uint256 cumulativeFeeShares, bytes32[] rewardsProof) returns()
+func (_Csaccounting *CsaccountingTransactor) ClaimRewardsStETH(opts *bind.TransactOpts, nodeOperatorId *big.Int, stETHAmount *big.Int, rewardAddress common.Address, cumulativeFeeShares *big.Int, rewardsProof [][32]byte) (*types.Transaction, error) {
+	return _Csaccounting.contract.Transact(opts, "claimRewardsStETH", nodeOperatorId, stETHAmount, rewardAddress, cumulativeFeeShares, rewardsProof)
+}
+
+// ClaimRewardsStETH is a paid mutator transaction binding the contract method 0xf9391223.
+//
+// Solidity: function claimRewardsStETH(uint256 nodeOperatorId, uint256 stETHAmount, address rewardAddress, uint256 cumulativeFeeShares, bytes32[] rewardsProof) returns()
+func (_Csaccounting *CsaccountingSession) ClaimRewardsStETH(nodeOperatorId *big.Int, stETHAmount *big.Int, rewardAddress common.Address, cumulativeFeeShares *big.Int, rewardsProof [][32]byte) (*types.Transaction, error) {
+	return _Csaccounting.Contract.ClaimRewardsStETH(&_Csaccounting.TransactOpts, nodeOperatorId, stETHAmount, rewardAddress, cumulativeFeeShares, rewardsProof)
+}
+
+// ClaimRewardsStETH is a paid mutator transaction binding the contract method 0xf9391223.
+//
+// Solidity: function claimRewardsStETH(uint256 nodeOperatorId, uint256 stETHAmount, address rewardAddress, uint256 cumulativeFeeShares, bytes32[] rewardsProof) returns()
+func (_Csaccounting *CsaccountingTransactorSession) ClaimRewardsStETH(nodeOperatorId *big.Int, stETHAmount *big.Int, rewardAddress common.Address, cumulativeFeeShares *big.Int, rewardsProof [][32]byte) (*types.Transaction, error) {
+	return _Csaccounting.Contract.ClaimRewardsStETH(&_Csaccounting.TransactOpts, nodeOperatorId, stETHAmount, rewardAddress, cumulativeFeeShares, rewardsProof)
+}
+
+// ClaimRewardsUnstETH is a paid mutator transaction binding the contract method 0xcc810cb9.
+//
+// Solidity: function claimRewardsUnstETH(uint256 nodeOperatorId, uint256 stEthAmount, address rewardAddress, uint256 cumulativeFeeShares, bytes32[] rewardsProof) returns()
+func (_Csaccounting *CsaccountingTransactor) ClaimRewardsUnstETH(opts *bind.TransactOpts, nodeOperatorId *big.Int, stEthAmount *big.Int, rewardAddress common.Address, cumulativeFeeShares *big.Int, rewardsProof [][32]byte) (*types.Transaction, error) {
+	return _Csaccounting.contract.Transact(opts, "claimRewardsUnstETH", nodeOperatorId, stEthAmount, rewardAddress, cumulativeFeeShares, rewardsProof)
+}
+
+// ClaimRewardsUnstETH is a paid mutator transaction binding the contract method 0xcc810cb9.
+//
+// Solidity: function claimRewardsUnstETH(uint256 nodeOperatorId, uint256 stEthAmount, address rewardAddress, uint256 cumulativeFeeShares, bytes32[] rewardsProof) returns()
+func (_Csaccounting *CsaccountingSession) ClaimRewardsUnstETH(nodeOperatorId *big.Int, stEthAmount *big.Int, rewardAddress common.Address, cumulativeFeeShares *big.Int, rewardsProof [][32]byte) (*types.Transaction, error) {
+	return _Csaccounting.Contract.ClaimRewardsUnstETH(&_Csaccounting.TransactOpts, nodeOperatorId, stEthAmount, rewardAddress, cumulativeFeeShares, rewardsProof)
+}
+
+// ClaimRewardsUnstETH is a paid mutator transaction binding the contract method 0xcc810cb9.
+//
+// Solidity: function claimRewardsUnstETH(uint256 nodeOperatorId, uint256 stEthAmount, address rewardAddress, uint256 cumulativeFeeShares, bytes32[] rewardsProof) returns()
+func (_Csaccounting *CsaccountingTransactorSession) ClaimRewardsUnstETH(nodeOperatorId *big.Int, stEthAmount *big.Int, rewardAddress common.Address, cumulativeFeeShares *big.Int, rewardsProof [][32]byte) (*types.Transaction, error) {
+	return _Csaccounting.Contract.ClaimRewardsUnstETH(&_Csaccounting.TransactOpts, nodeOperatorId, stEthAmount, rewardAddress, cumulativeFeeShares, rewardsProof)
+}
+
+// ClaimRewardsWstETH is a paid mutator transaction binding the contract method 0x70903eb9.
+//
+// Solidity: function claimRewardsWstETH(uint256 nodeOperatorId, uint256 wstETHAmount, address rewardAddress, uint256 cumulativeFeeShares, bytes32[] rewardsProof) returns()
+func (_Csaccounting *CsaccountingTransactor) ClaimRewardsWstETH(opts *bind.TransactOpts, nodeOperatorId *big.Int, wstETHAmount *big.Int, rewardAddress common.Address, cumulativeFeeShares *big.Int, rewardsProof [][32]byte) (*types.Transaction, error) {
+	return _Csaccounting.contract.Transact(opts, "claimRewardsWstETH", nodeOperatorId, wstETHAmount, rewardAddress, cumulativeFeeShares, rewardsProof)
+}
+
+// ClaimRewardsWstETH is a paid mutator transaction binding the contract method 0x70903eb9.
+//
+// Solidity: function claimRewardsWstETH(uint256 nodeOperatorId, uint256 wstETHAmount, address rewardAddress, uint256 cumulativeFeeShares, bytes32[] rewardsProof) returns()
+func (_Csaccounting *CsaccountingSession) ClaimRewardsWstETH(nodeOperatorId *big.Int, wstETHAmount *big.Int, rewardAddress common.Address, cumulativeFeeShares *big.Int, rewardsProof [][32]byte) (*types.Transaction, error) {
+	return _Csaccounting.Contract.ClaimRewardsWstETH(&_Csaccounting.TransactOpts, nodeOperatorId, wstETHAmount, rewardAddress, cumulativeFeeShares, rewardsProof)
+}
+
+// ClaimRewardsWstETH is a paid mutator transaction binding the contract method 0x70903eb9.
+//
+// Solidity: function claimRewardsWstETH(uint256 nodeOperatorId, uint256 wstETHAmount, address rewardAddress, uint256 cumulativeFeeShares, bytes32[] rewardsProof) returns()
+func (_Csaccounting *CsaccountingTransactorSession) ClaimRewardsWstETH(nodeOperatorId *big.Int, wstETHAmount *big.Int, rewardAddress common.Address, cumulativeFeeShares *big.Int, rewardsProof [][32]byte) (*types.Transaction, error) {
+	return _Csaccounting.Contract.ClaimRewardsWstETH(&_Csaccounting.TransactOpts, nodeOperatorId, wstETHAmount, rewardAddress, cumulativeFeeShares, rewardsProof)
+}
+
+// CompensateLockedBondETH is a paid mutator transaction binding the contract method 0x15b5c477.
+//
+// Solidity: function compensateLockedBondETH(uint256 nodeOperatorId) payable returns()
+func (_Csaccounting *CsaccountingTransactor) CompensateLockedBondETH(opts *bind.TransactOpts, nodeOperatorId *big.Int) (*types.Transaction, error) {
+	return _Csaccounting.contract.Transact(opts, "compensateLockedBondETH", nodeOperatorId)
+}
+
+// CompensateLockedBondETH is a paid mutator transaction binding the contract method 0x15b5c477.
+//
+// Solidity: function compensateLockedBondETH(uint256 nodeOperatorId) payable returns()
+func (_Csaccounting *CsaccountingSession) CompensateLockedBondETH(nodeOperatorId *big.Int) (*types.Transaction, error) {
+	return _Csaccounting.Contract.CompensateLockedBondETH(&_Csaccounting.TransactOpts, nodeOperatorId)
+}
+
+// CompensateLockedBondETH is a paid mutator transaction binding the contract method 0x15b5c477.
+//
+// Solidity: function compensateLockedBondETH(uint256 nodeOperatorId) payable returns()
+func (_Csaccounting *CsaccountingTransactorSession) CompensateLockedBondETH(nodeOperatorId *big.Int) (*types.Transaction, error) {
+	return _Csaccounting.Contract.CompensateLockedBondETH(&_Csaccounting.TransactOpts, nodeOperatorId)
+}
+
+// DepositETH is a paid mutator transaction binding the contract method 0x2e599054.
+//
+// Solidity: function depositETH(address from, uint256 nodeOperatorId) payable returns()
+func (_Csaccounting *CsaccountingTransactor) DepositETH(opts *bind.TransactOpts, from common.Address, nodeOperatorId *big.Int) (*types.Transaction, error) {
+	return _Csaccounting.contract.Transact(opts, "depositETH", from, nodeOperatorId)
+}
+
+// DepositETH is a paid mutator transaction binding the contract method 0x2e599054.
+//
+// Solidity: function depositETH(address from, uint256 nodeOperatorId) payable returns()
+func (_Csaccounting *CsaccountingSession) DepositETH(from common.Address, nodeOperatorId *big.Int) (*types.Transaction, error) {
+	return _Csaccounting.Contract.DepositETH(&_Csaccounting.TransactOpts, from, nodeOperatorId)
+}
+
+// DepositETH is a paid mutator transaction binding the contract method 0x2e599054.
+//
+// Solidity: function depositETH(address from, uint256 nodeOperatorId) payable returns()
+func (_Csaccounting *CsaccountingTransactorSession) DepositETH(from common.Address, nodeOperatorId *big.Int) (*types.Transaction, error) {
+	return _Csaccounting.Contract.DepositETH(&_Csaccounting.TransactOpts, from, nodeOperatorId)
+}
+
+// DepositStETH is a paid mutator transaction binding the contract method 0x4c7ed3d2.
+//
+// Solidity: function depositStETH(address from, uint256 nodeOperatorId, uint256 stETHAmount, (uint256,uint256,uint8,bytes32,bytes32) permit) returns()
+func (_Csaccounting *CsaccountingTransactor) DepositStETH(opts *bind.TransactOpts, from common.Address, nodeOperatorId *big.Int, stETHAmount *big.Int, permit ICSAccountingPermitInput) (*types.Transaction, error) {
+	return _Csaccounting.contract.Transact(opts, "depositStETH", from, nodeOperatorId, stETHAmount, permit)
+}
+
+// DepositStETH is a paid mutator transaction binding the contract method 0x4c7ed3d2.
+//
+// Solidity: function depositStETH(address from, uint256 nodeOperatorId, uint256 stETHAmount, (uint256,uint256,uint8,bytes32,bytes32) permit) returns()
+func (_Csaccounting *CsaccountingSession) DepositStETH(from common.Address, nodeOperatorId *big.Int, stETHAmount *big.Int, permit ICSAccountingPermitInput) (*types.Transaction, error) {
+	return _Csaccounting.Contract.DepositStETH(&_Csaccounting.TransactOpts, from, nodeOperatorId, stETHAmount, permit)
+}
+
+// DepositStETH is a paid mutator transaction binding the contract method 0x4c7ed3d2.
+//
+// Solidity: function depositStETH(address from, uint256 nodeOperatorId, uint256 stETHAmount, (uint256,uint256,uint8,bytes32,bytes32) permit) returns()
+func (_Csaccounting *CsaccountingTransactorSession) DepositStETH(from common.Address, nodeOperatorId *big.Int, stETHAmount *big.Int, permit ICSAccountingPermitInput) (*types.Transaction, error) {
+	return _Csaccounting.Contract.DepositStETH(&_Csaccounting.TransactOpts, from, nodeOperatorId, stETHAmount, permit)
+}
+
+// DepositWstETH is a paid mutator transaction binding the contract method 0xf7966efe.
+//
+// Solidity: function depositWstETH(address from, uint256 nodeOperatorId, uint256 wstETHAmount, (uint256,uint256,uint8,bytes32,bytes32) permit) returns()
+func (_Csaccounting *CsaccountingTransactor) DepositWstETH(opts *bind.TransactOpts, from common.Address, nodeOperatorId *big.Int, wstETHAmount *big.Int, permit ICSAccountingPermitInput) (*types.Transaction, error) {
+	return _Csaccounting.contract.Transact(opts, "depositWstETH", from, nodeOperatorId, wstETHAmount, permit)
+}
+
+// DepositWstETH is a paid mutator transaction binding the contract method 0xf7966efe.
+//
+// Solidity: function depositWstETH(address from, uint256 nodeOperatorId, uint256 wstETHAmount, (uint256,uint256,uint8,bytes32,bytes32) permit) returns()
+func (_Csaccounting *CsaccountingSession) DepositWstETH(from common.Address, nodeOperatorId *big.Int, wstETHAmount *big.Int, permit ICSAccountingPermitInput) (*types.Transaction, error) {
+	return _Csaccounting.Contract.DepositWstETH(&_Csaccounting.TransactOpts, from, nodeOperatorId, wstETHAmount, permit)
+}
+
+// DepositWstETH is a paid mutator transaction binding the contract method 0xf7966efe.
+//
+// Solidity: function depositWstETH(address from, uint256 nodeOperatorId, uint256 wstETHAmount, (uint256,uint256,uint8,bytes32,bytes32) permit) returns()
+func (_Csaccounting *CsaccountingTransactorSession) DepositWstETH(from common.Address, nodeOperatorId *big.Int, wstETHAmount *big.Int, permit ICSAccountingPermitInput) (*types.Transaction, error) {
+	return _Csaccounting.Contract.DepositWstETH(&_Csaccounting.TransactOpts, from, nodeOperatorId, wstETHAmount, permit)
+}
+
+// GrantRole is a paid mutator transaction binding the contract method 0x2f2ff15d.
+//
+// Solidity: function grantRole(bytes32 role, address account) returns()
+func (_Csaccounting *CsaccountingTransactor) GrantRole(opts *bind.TransactOpts, role [32]byte, account common.Address) (*types.Transaction, error) {
+	return _Csaccounting.contract.Transact(opts, "grantRole", role, account)
+}
+
+// GrantRole is a paid mutator transaction binding the contract method 0x2f2ff15d.
+//
+// Solidity: function grantRole(bytes32 role, address account) returns()
+func (_Csaccounting *CsaccountingSession) GrantRole(role [32]byte, account common.Address) (*types.Transaction, error) {
+	return _Csaccounting.Contract.GrantRole(&_Csaccounting.TransactOpts, role, account)
+}
+
+// GrantRole is a paid mutator transaction binding the contract method 0x2f2ff15d.
+//
+// Solidity: function grantRole(bytes32 role, address account) returns()
+func (_Csaccounting *CsaccountingTransactorSession) GrantRole(role [32]byte, account common.Address) (*types.Transaction, error) {
+	return _Csaccounting.Contract.GrantRole(&_Csaccounting.TransactOpts, role, account)
+}
+
+// Initialize is a paid mutator transaction binding the contract method 0xfab382f1.
+//
+// Solidity: function initialize(uint256[] bondCurve, address admin, address _feeDistributor, uint256 bondLockRetentionPeriod, address _chargePenaltyRecipient) returns()
+func (_Csaccounting *CsaccountingTransactor) Initialize(opts *bind.TransactOpts, bondCurve []*big.Int, admin common.Address, _feeDistributor common.Address, bondLockRetentionPeriod *big.Int, _chargePenaltyRecipient common.Address) (*types.Transaction, error) {
+	return _Csaccounting.contract.Transact(opts, "initialize", bondCurve, admin, _feeDistributor, bondLockRetentionPeriod, _chargePenaltyRecipient)
+}
+
+// Initialize is a paid mutator transaction binding the contract method 0xfab382f1.
+//
+// Solidity: function initialize(uint256[] bondCurve, address admin, address _feeDistributor, uint256 bondLockRetentionPeriod, address _chargePenaltyRecipient) returns()
+func (_Csaccounting *CsaccountingSession) Initialize(bondCurve []*big.Int, admin common.Address, _feeDistributor common.Address, bondLockRetentionPeriod *big.Int, _chargePenaltyRecipient common.Address) (*types.Transaction, error) {
+	return _Csaccounting.Contract.Initialize(&_Csaccounting.TransactOpts, bondCurve, admin, _feeDistributor, bondLockRetentionPeriod, _chargePenaltyRecipient)
+}
+
+// Initialize is a paid mutator transaction binding the contract method 0xfab382f1.
+//
+// Solidity: function initialize(uint256[] bondCurve, address admin, address _feeDistributor, uint256 bondLockRetentionPeriod, address _chargePenaltyRecipient) returns()
+func (_Csaccounting *CsaccountingTransactorSession) Initialize(bondCurve []*big.Int, admin common.Address, _feeDistributor common.Address, bondLockRetentionPeriod *big.Int, _chargePenaltyRecipient common.Address) (*types.Transaction, error) {
+	return _Csaccounting.Contract.Initialize(&_Csaccounting.TransactOpts, bondCurve, admin, _feeDistributor, bondLockRetentionPeriod, _chargePenaltyRecipient)
+}
+
+// LockBondETH is a paid mutator transaction binding the contract method 0xdcab7f83.
+//
+// Solidity: function lockBondETH(uint256 nodeOperatorId, uint256 amount) returns()
+func (_Csaccounting *CsaccountingTransactor) LockBondETH(opts *bind.TransactOpts, nodeOperatorId *big.Int, amount *big.Int) (*types.Transaction, error) {
+	return _Csaccounting.contract.Transact(opts, "lockBondETH", nodeOperatorId, amount)
+}
+
+// LockBondETH is a paid mutator transaction binding the contract method 0xdcab7f83.
+//
+// Solidity: function lockBondETH(uint256 nodeOperatorId, uint256 amount) returns()
+func (_Csaccounting *CsaccountingSession) LockBondETH(nodeOperatorId *big.Int, amount *big.Int) (*types.Transaction, error) {
+	return _Csaccounting.Contract.LockBondETH(&_Csaccounting.TransactOpts, nodeOperatorId, amount)
+}
+
+// LockBondETH is a paid mutator transaction binding the contract method 0xdcab7f83.
+//
+// Solidity: function lockBondETH(uint256 nodeOperatorId, uint256 amount) returns()
+func (_Csaccounting *CsaccountingTransactorSession) LockBondETH(nodeOperatorId *big.Int, amount *big.Int) (*types.Transaction, error) {
+	return _Csaccounting.Contract.LockBondETH(&_Csaccounting.TransactOpts, nodeOperatorId, amount)
+}
+
+// PauseFor is a paid mutator transaction binding the contract method 0xf3f449c7.
+//
+// Solidity: function pauseFor(uint256 duration) returns()
+func (_Csaccounting *CsaccountingTransactor) PauseFor(opts *bind.TransactOpts, duration *big.Int) (*types.Transaction, error) {
+	return _Csaccounting.contract.Transact(opts, "pauseFor", duration)
+}
+
+// PauseFor is a paid mutator transaction binding the contract method 0xf3f449c7.
+//
+// Solidity: function pauseFor(uint256 duration) returns()
+func (_Csaccounting *CsaccountingSession) PauseFor(duration *big.Int) (*types.Transaction, error) {
+	return _Csaccounting.Contract.PauseFor(&_Csaccounting.TransactOpts, duration)
+}
+
+// PauseFor is a paid mutator transaction binding the contract method 0xf3f449c7.
+//
+// Solidity: function pauseFor(uint256 duration) returns()
+func (_Csaccounting *CsaccountingTransactorSession) PauseFor(duration *big.Int) (*types.Transaction, error) {
+	return _Csaccounting.Contract.PauseFor(&_Csaccounting.TransactOpts, duration)
+}
+
+// Penalize is a paid mutator transaction binding the contract method 0xe5220e3f.
+//
+// Solidity: function penalize(uint256 nodeOperatorId, uint256 amount) returns()
+func (_Csaccounting *CsaccountingTransactor) Penalize(opts *bind.TransactOpts, nodeOperatorId *big.Int, amount *big.Int) (*types.Transaction, error) {
+	return _Csaccounting.contract.Transact(opts, "penalize", nodeOperatorId, amount)
+}
+
+// Penalize is a paid mutator transaction binding the contract method 0xe5220e3f.
+//
+// Solidity: function penalize(uint256 nodeOperatorId, uint256 amount) returns()
+func (_Csaccounting *CsaccountingSession) Penalize(nodeOperatorId *big.Int, amount *big.Int) (*types.Transaction, error) {
+	return _Csaccounting.Contract.Penalize(&_Csaccounting.TransactOpts, nodeOperatorId, amount)
+}
+
+// Penalize is a paid mutator transaction binding the contract method 0xe5220e3f.
+//
+// Solidity: function penalize(uint256 nodeOperatorId, uint256 amount) returns()
+func (_Csaccounting *CsaccountingTransactorSession) Penalize(nodeOperatorId *big.Int, amount *big.Int) (*types.Transaction, error) {
+	return _Csaccounting.Contract.Penalize(&_Csaccounting.TransactOpts, nodeOperatorId, amount)
+}
+
+// PullFeeRewards is a paid mutator transaction binding the contract method 0x9b4c6c27.
+//
+// Solidity: function pullFeeRewards(uint256 nodeOperatorId, uint256 cumulativeFeeShares, bytes32[] rewardsProof) returns()
+func (_Csaccounting *CsaccountingTransactor) PullFeeRewards(opts *bind.TransactOpts, nodeOperatorId *big.Int, cumulativeFeeShares *big.Int, rewardsProof [][32]byte) (*types.Transaction, error) {
+	return _Csaccounting.contract.Transact(opts, "pullFeeRewards", nodeOperatorId, cumulativeFeeShares, rewardsProof)
+}
+
+// PullFeeRewards is a paid mutator transaction binding the contract method 0x9b4c6c27.
+//
+// Solidity: function pullFeeRewards(uint256 nodeOperatorId, uint256 cumulativeFeeShares, bytes32[] rewardsProof) returns()
+func (_Csaccounting *CsaccountingSession) PullFeeRewards(nodeOperatorId *big.Int, cumulativeFeeShares *big.Int, rewardsProof [][32]byte) (*types.Transaction, error) {
+	return _Csaccounting.Contract.PullFeeRewards(&_Csaccounting.TransactOpts, nodeOperatorId, cumulativeFeeShares, rewardsProof)
+}
+
+// PullFeeRewards is a paid mutator transaction binding the contract method 0x9b4c6c27.
+//
+// Solidity: function pullFeeRewards(uint256 nodeOperatorId, uint256 cumulativeFeeShares, bytes32[] rewardsProof) returns()
+func (_Csaccounting *CsaccountingTransactorSession) PullFeeRewards(nodeOperatorId *big.Int, cumulativeFeeShares *big.Int, rewardsProof [][32]byte) (*types.Transaction, error) {
+	return _Csaccounting.Contract.PullFeeRewards(&_Csaccounting.TransactOpts, nodeOperatorId, cumulativeFeeShares, rewardsProof)
+}
+
+// RecoverERC1155 is a paid mutator transaction binding the contract method 0x5c654ad9.
+//
+// Solidity: function recoverERC1155(address token, uint256 tokenId) returns()
+func (_Csaccounting *CsaccountingTransactor) RecoverERC1155(opts *bind.TransactOpts, token common.Address, tokenId *big.Int) (*types.Transaction, error) {
+	return _Csaccounting.contract.Transact(opts, "recoverERC1155", token, tokenId)
+}
+
+// RecoverERC1155 is a paid mutator transaction binding the contract method 0x5c654ad9.
+//
+// Solidity: function recoverERC1155(address token, uint256 tokenId) returns()
+func (_Csaccounting *CsaccountingSession) RecoverERC1155(token common.Address, tokenId *big.Int) (*types.Transaction, error) {
+	return _Csaccounting.Contract.RecoverERC1155(&_Csaccounting.TransactOpts, token, tokenId)
+}
+
+// RecoverERC1155 is a paid mutator transaction binding the contract method 0x5c654ad9.
+//
+// Solidity: function recoverERC1155(address token, uint256 tokenId) returns()
+func (_Csaccounting *CsaccountingTransactorSession) RecoverERC1155(token common.Address, tokenId *big.Int) (*types.Transaction, error) {
+	return _Csaccounting.Contract.RecoverERC1155(&_Csaccounting.TransactOpts, token, tokenId)
+}
+
+// RecoverERC20 is a paid mutator transaction binding the contract method 0x8980f11f.
+//
+// Solidity: function recoverERC20(address token, uint256 amount) returns()
+func (_Csaccounting *CsaccountingTransactor) RecoverERC20(opts *bind.TransactOpts, token common.Address, amount *big.Int) (*types.Transaction, error) {
+	return _Csaccounting.contract.Transact(opts, "recoverERC20", token, amount)
+}
+
+// RecoverERC20 is a paid mutator transaction binding the contract method 0x8980f11f.
+//
+// Solidity: function recoverERC20(address token, uint256 amount) returns()
+func (_Csaccounting *CsaccountingSession) RecoverERC20(token common.Address, amount *big.Int) (*types.Transaction, error) {
+	return _Csaccounting.Contract.RecoverERC20(&_Csaccounting.TransactOpts, token, amount)
+}
+
+// RecoverERC20 is a paid mutator transaction binding the contract method 0x8980f11f.
+//
+// Solidity: function recoverERC20(address token, uint256 amount) returns()
+func (_Csaccounting *CsaccountingTransactorSession) RecoverERC20(token common.Address, amount *big.Int) (*types.Transaction, error) {
+	return _Csaccounting.Contract.RecoverERC20(&_Csaccounting.TransactOpts, token, amount)
+}
+
+// RecoverERC721 is a paid mutator transaction binding the contract method 0x819d4cc6.
+//
+// Solidity: function recoverERC721(address token, uint256 tokenId) returns()
+func (_Csaccounting *CsaccountingTransactor) RecoverERC721(opts *bind.TransactOpts, token common.Address, tokenId *big.Int) (*types.Transaction, error) {
+	return _Csaccounting.contract.Transact(opts, "recoverERC721", token, tokenId)
+}
+
+// RecoverERC721 is a paid mutator transaction binding the contract method 0x819d4cc6.
+//
+// Solidity: function recoverERC721(address token, uint256 tokenId) returns()
+func (_Csaccounting *CsaccountingSession) RecoverERC721(token common.Address, tokenId *big.Int) (*types.Transaction, error) {
+	return _Csaccounting.Contract.RecoverERC721(&_Csaccounting.TransactOpts, token, tokenId)
+}
+
+// RecoverERC721 is a paid mutator transaction binding the contract method 0x819d4cc6.
+//
+// Solidity: function recoverERC721(address token, uint256 tokenId) returns()
+func (_Csaccounting *CsaccountingTransactorSession) RecoverERC721(token common.Address, tokenId *big.Int) (*types.Transaction, error) {
+	return _Csaccounting.Contract.RecoverERC721(&_Csaccounting.TransactOpts, token, tokenId)
+}
+
+// RecoverEther is a paid mutator transaction binding the contract method 0x52d8bfc2.
+//
+// Solidity: function recoverEther() returns()
+func (_Csaccounting *CsaccountingTransactor) RecoverEther(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Csaccounting.contract.Transact(opts, "recoverEther")
+}
+
+// RecoverEther is a paid mutator transaction binding the contract method 0x52d8bfc2.
+//
+// Solidity: function recoverEther() returns()
+func (_Csaccounting *CsaccountingSession) RecoverEther() (*types.Transaction, error) {
+	return _Csaccounting.Contract.RecoverEther(&_Csaccounting.TransactOpts)
+}
+
+// RecoverEther is a paid mutator transaction binding the contract method 0x52d8bfc2.
+//
+// Solidity: function recoverEther() returns()
+func (_Csaccounting *CsaccountingTransactorSession) RecoverEther() (*types.Transaction, error) {
+	return _Csaccounting.Contract.RecoverEther(&_Csaccounting.TransactOpts)
+}
+
+// RecoverStETHShares is a paid mutator transaction binding the contract method 0x5a73bdc8.
+//
+// Solidity: function recoverStETHShares() returns()
+func (_Csaccounting *CsaccountingTransactor) RecoverStETHShares(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Csaccounting.contract.Transact(opts, "recoverStETHShares")
+}
+
+// RecoverStETHShares is a paid mutator transaction binding the contract method 0x5a73bdc8.
+//
+// Solidity: function recoverStETHShares() returns()
+func (_Csaccounting *CsaccountingSession) RecoverStETHShares() (*types.Transaction, error) {
+	return _Csaccounting.Contract.RecoverStETHShares(&_Csaccounting.TransactOpts)
+}
+
+// RecoverStETHShares is a paid mutator transaction binding the contract method 0x5a73bdc8.
+//
+// Solidity: function recoverStETHShares() returns()
+func (_Csaccounting *CsaccountingTransactorSession) RecoverStETHShares() (*types.Transaction, error) {
+	return _Csaccounting.Contract.RecoverStETHShares(&_Csaccounting.TransactOpts)
+}
+
+// ReleaseLockedBondETH is a paid mutator transaction binding the contract method 0xd963ae55.
+//
+// Solidity: function releaseLockedBondETH(uint256 nodeOperatorId, uint256 amount) returns()
+func (_Csaccounting *CsaccountingTransactor) ReleaseLockedBondETH(opts *bind.TransactOpts, nodeOperatorId *big.Int, amount *big.Int) (*types.Transaction, error) {
+	return _Csaccounting.contract.Transact(opts, "releaseLockedBondETH", nodeOperatorId, amount)
+}
+
+// ReleaseLockedBondETH is a paid mutator transaction binding the contract method 0xd963ae55.
+//
+// Solidity: function releaseLockedBondETH(uint256 nodeOperatorId, uint256 amount) returns()
+func (_Csaccounting *CsaccountingSession) ReleaseLockedBondETH(nodeOperatorId *big.Int, amount *big.Int) (*types.Transaction, error) {
+	return _Csaccounting.Contract.ReleaseLockedBondETH(&_Csaccounting.TransactOpts, nodeOperatorId, amount)
+}
+
+// ReleaseLockedBondETH is a paid mutator transaction binding the contract method 0xd963ae55.
+//
+// Solidity: function releaseLockedBondETH(uint256 nodeOperatorId, uint256 amount) returns()
+func (_Csaccounting *CsaccountingTransactorSession) ReleaseLockedBondETH(nodeOperatorId *big.Int, amount *big.Int) (*types.Transaction, error) {
+	return _Csaccounting.Contract.ReleaseLockedBondETH(&_Csaccounting.TransactOpts, nodeOperatorId, amount)
+}
+
+// RenewBurnerAllowance is a paid mutator transaction binding the contract method 0xf3efecc4.
+//
+// Solidity: function renewBurnerAllowance() returns()
+func (_Csaccounting *CsaccountingTransactor) RenewBurnerAllowance(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Csaccounting.contract.Transact(opts, "renewBurnerAllowance")
+}
+
+// RenewBurnerAllowance is a paid mutator transaction binding the contract method 0xf3efecc4.
+//
+// Solidity: function renewBurnerAllowance() returns()
+func (_Csaccounting *CsaccountingSession) RenewBurnerAllowance() (*types.Transaction, error) {
+	return _Csaccounting.Contract.RenewBurnerAllowance(&_Csaccounting.TransactOpts)
+}
+
+// RenewBurnerAllowance is a paid mutator transaction binding the contract method 0xf3efecc4.
+//
+// Solidity: function renewBurnerAllowance() returns()
+func (_Csaccounting *CsaccountingTransactorSession) RenewBurnerAllowance() (*types.Transaction, error) {
+	return _Csaccounting.Contract.RenewBurnerAllowance(&_Csaccounting.TransactOpts)
+}
+
+// RenounceRole is a paid mutator transaction binding the contract method 0x36568abe.
+//
+// Solidity: function renounceRole(bytes32 role, address callerConfirmation) returns()
+func (_Csaccounting *CsaccountingTransactor) RenounceRole(opts *bind.TransactOpts, role [32]byte, callerConfirmation common.Address) (*types.Transaction, error) {
+	return _Csaccounting.contract.Transact(opts, "renounceRole", role, callerConfirmation)
+}
+
+// RenounceRole is a paid mutator transaction binding the contract method 0x36568abe.
+//
+// Solidity: function renounceRole(bytes32 role, address callerConfirmation) returns()
+func (_Csaccounting *CsaccountingSession) RenounceRole(role [32]byte, callerConfirmation common.Address) (*types.Transaction, error) {
+	return _Csaccounting.Contract.RenounceRole(&_Csaccounting.TransactOpts, role, callerConfirmation)
+}
+
+// RenounceRole is a paid mutator transaction binding the contract method 0x36568abe.
+//
+// Solidity: function renounceRole(bytes32 role, address callerConfirmation) returns()
+func (_Csaccounting *CsaccountingTransactorSession) RenounceRole(role [32]byte, callerConfirmation common.Address) (*types.Transaction, error) {
+	return _Csaccounting.Contract.RenounceRole(&_Csaccounting.TransactOpts, role, callerConfirmation)
+}
+
+// ResetBondCurve is a paid mutator transaction binding the contract method 0x449add1b.
+//
+// Solidity: function resetBondCurve(uint256 nodeOperatorId) returns()
+func (_Csaccounting *CsaccountingTransactor) ResetBondCurve(opts *bind.TransactOpts, nodeOperatorId *big.Int) (*types.Transaction, error) {
+	return _Csaccounting.contract.Transact(opts, "resetBondCurve", nodeOperatorId)
+}
+
+// ResetBondCurve is a paid mutator transaction binding the contract method 0x449add1b.
+//
+// Solidity: function resetBondCurve(uint256 nodeOperatorId) returns()
+func (_Csaccounting *CsaccountingSession) ResetBondCurve(nodeOperatorId *big.Int) (*types.Transaction, error) {
+	return _Csaccounting.Contract.ResetBondCurve(&_Csaccounting.TransactOpts, nodeOperatorId)
+}
+
+// ResetBondCurve is a paid mutator transaction binding the contract method 0x449add1b.
+//
+// Solidity: function resetBondCurve(uint256 nodeOperatorId) returns()
+func (_Csaccounting *CsaccountingTransactorSession) ResetBondCurve(nodeOperatorId *big.Int) (*types.Transaction, error) {
+	return _Csaccounting.Contract.ResetBondCurve(&_Csaccounting.TransactOpts, nodeOperatorId)
+}
+
+// Resume is a paid mutator transaction binding the contract method 0x046f7da2.
+//
+// Solidity: function resume() returns()
+func (_Csaccounting *CsaccountingTransactor) Resume(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Csaccounting.contract.Transact(opts, "resume")
+}
+
+// Resume is a paid mutator transaction binding the contract method 0x046f7da2.
+//
+// Solidity: function resume() returns()
+func (_Csaccounting *CsaccountingSession) Resume() (*types.Transaction, error) {
+	return _Csaccounting.Contract.Resume(&_Csaccounting.TransactOpts)
+}
+
+// Resume is a paid mutator transaction binding the contract method 0x046f7da2.
+//
+// Solidity: function resume() returns()
+func (_Csaccounting *CsaccountingTransactorSession) Resume() (*types.Transaction, error) {
+	return _Csaccounting.Contract.Resume(&_Csaccounting.TransactOpts)
+}
+
+// RevokeRole is a paid mutator transaction binding the contract method 0xd547741f.
+//
+// Solidity: function revokeRole(bytes32 role, address account) returns()
+func (_Csaccounting *CsaccountingTransactor) RevokeRole(opts *bind.TransactOpts, role [32]byte, account common.Address) (*types.Transaction, error) {
+	return _Csaccounting.contract.Transact(opts, "revokeRole", role, account)
+}
+
+// RevokeRole is a paid mutator transaction binding the contract method 0xd547741f.
+//
+// Solidity: function revokeRole(bytes32 role, address account) returns()
+func (_Csaccounting *CsaccountingSession) RevokeRole(role [32]byte, account common.Address) (*types.Transaction, error) {
+	return _Csaccounting.Contract.RevokeRole(&_Csaccounting.TransactOpts, role, account)
+}
+
+// RevokeRole is a paid mutator transaction binding the contract method 0xd547741f.
+//
+// Solidity: function revokeRole(bytes32 role, address account) returns()
+func (_Csaccounting *CsaccountingTransactorSession) RevokeRole(role [32]byte, account common.Address) (*types.Transaction, error) {
+	return _Csaccounting.Contract.RevokeRole(&_Csaccounting.TransactOpts, role, account)
+}
+
+// SetBondCurve is a paid mutator transaction binding the contract method 0xb2d03e4d.
+//
+// Solidity: function setBondCurve(uint256 nodeOperatorId, uint256 curveId) returns()
+func (_Csaccounting *CsaccountingTransactor) SetBondCurve(opts *bind.TransactOpts, nodeOperatorId *big.Int, curveId *big.Int) (*types.Transaction, error) {
+	return _Csaccounting.contract.Transact(opts, "setBondCurve", nodeOperatorId, curveId)
+}
+
+// SetBondCurve is a paid mutator transaction binding the contract method 0xb2d03e4d.
+//
+// Solidity: function setBondCurve(uint256 nodeOperatorId, uint256 curveId) returns()
+func (_Csaccounting *CsaccountingSession) SetBondCurve(nodeOperatorId *big.Int, curveId *big.Int) (*types.Transaction, error) {
+	return _Csaccounting.Contract.SetBondCurve(&_Csaccounting.TransactOpts, nodeOperatorId, curveId)
+}
+
+// SetBondCurve is a paid mutator transaction binding the contract method 0xb2d03e4d.
+//
+// Solidity: function setBondCurve(uint256 nodeOperatorId, uint256 curveId) returns()
+func (_Csaccounting *CsaccountingTransactorSession) SetBondCurve(nodeOperatorId *big.Int, curveId *big.Int) (*types.Transaction, error) {
+	return _Csaccounting.Contract.SetBondCurve(&_Csaccounting.TransactOpts, nodeOperatorId, curveId)
+}
+
+// SetChargePenaltyRecipient is a paid mutator transaction binding the contract method 0x433cd6c3.
+//
+// Solidity: function setChargePenaltyRecipient(address _chargePenaltyRecipient) returns()
+func (_Csaccounting *CsaccountingTransactor) SetChargePenaltyRecipient(opts *bind.TransactOpts, _chargePenaltyRecipient common.Address) (*types.Transaction, error) {
+	return _Csaccounting.contract.Transact(opts, "setChargePenaltyRecipient", _chargePenaltyRecipient)
+}
+
+// SetChargePenaltyRecipient is a paid mutator transaction binding the contract method 0x433cd6c3.
+//
+// Solidity: function setChargePenaltyRecipient(address _chargePenaltyRecipient) returns()
+func (_Csaccounting *CsaccountingSession) SetChargePenaltyRecipient(_chargePenaltyRecipient common.Address) (*types.Transaction, error) {
+	return _Csaccounting.Contract.SetChargePenaltyRecipient(&_Csaccounting.TransactOpts, _chargePenaltyRecipient)
+}
+
+// SetChargePenaltyRecipient is a paid mutator transaction binding the contract method 0x433cd6c3.
+//
+// Solidity: function setChargePenaltyRecipient(address _chargePenaltyRecipient) returns()
+func (_Csaccounting *CsaccountingTransactorSession) SetChargePenaltyRecipient(_chargePenaltyRecipient common.Address) (*types.Transaction, error) {
+	return _Csaccounting.Contract.SetChargePenaltyRecipient(&_Csaccounting.TransactOpts, _chargePenaltyRecipient)
+}
+
+// SetLockedBondRetentionPeriod is a paid mutator transaction binding the contract method 0x99965225.
+//
+// Solidity: function setLockedBondRetentionPeriod(uint256 retention) returns()
+func (_Csaccounting *CsaccountingTransactor) SetLockedBondRetentionPeriod(opts *bind.TransactOpts, retention *big.Int) (*types.Transaction, error) {
+	return _Csaccounting.contract.Transact(opts, "setLockedBondRetentionPeriod", retention)
+}
+
+// SetLockedBondRetentionPeriod is a paid mutator transaction binding the contract method 0x99965225.
+//
+// Solidity: function setLockedBondRetentionPeriod(uint256 retention) returns()
+func (_Csaccounting *CsaccountingSession) SetLockedBondRetentionPeriod(retention *big.Int) (*types.Transaction, error) {
+	return _Csaccounting.Contract.SetLockedBondRetentionPeriod(&_Csaccounting.TransactOpts, retention)
+}
+
+// SetLockedBondRetentionPeriod is a paid mutator transaction binding the contract method 0x99965225.
+//
+// Solidity: function setLockedBondRetentionPeriod(uint256 retention) returns()
+func (_Csaccounting *CsaccountingTransactorSession) SetLockedBondRetentionPeriod(retention *big.Int) (*types.Transaction, error) {
+	return _Csaccounting.Contract.SetLockedBondRetentionPeriod(&_Csaccounting.TransactOpts, retention)
+}
+
+// SettleLockedBondETH is a paid mutator transaction binding the contract method 0x4bb22a72.
+//
+// Solidity: function settleLockedBondETH(uint256 nodeOperatorId) returns(uint256 settledAmount)
+func (_Csaccounting *CsaccountingTransactor) SettleLockedBondETH(opts *bind.TransactOpts, nodeOperatorId *big.Int) (*types.Transaction, error) {
+	return _Csaccounting.contract.Transact(opts, "settleLockedBondETH", nodeOperatorId)
+}
+
+// SettleLockedBondETH is a paid mutator transaction binding the contract method 0x4bb22a72.
+//
+// Solidity: function settleLockedBondETH(uint256 nodeOperatorId) returns(uint256 settledAmount)
+func (_Csaccounting *CsaccountingSession) SettleLockedBondETH(nodeOperatorId *big.Int) (*types.Transaction, error) {
+	return _Csaccounting.Contract.SettleLockedBondETH(&_Csaccounting.TransactOpts, nodeOperatorId)
+}
+
+// SettleLockedBondETH is a paid mutator transaction binding the contract method 0x4bb22a72.
+//
+// Solidity: function settleLockedBondETH(uint256 nodeOperatorId) returns(uint256 settledAmount)
+func (_Csaccounting *CsaccountingTransactorSession) SettleLockedBondETH(nodeOperatorId *big.Int) (*types.Transaction, error) {
+	return _Csaccounting.Contract.SettleLockedBondETH(&_Csaccounting.TransactOpts, nodeOperatorId)
+}
+
+// UpdateBondCurve is a paid mutator transaction binding the contract method 0x019c1a4f.
+//
+// Solidity: function updateBondCurve(uint256 curveId, uint256[] bondCurve) returns()
+func (_Csaccounting *CsaccountingTransactor) UpdateBondCurve(opts *bind.TransactOpts, curveId *big.Int, bondCurve []*big.Int) (*types.Transaction, error) {
+	return _Csaccounting.contract.Transact(opts, "updateBondCurve", curveId, bondCurve)
+}
+
+// UpdateBondCurve is a paid mutator transaction binding the contract method 0x019c1a4f.
+//
+// Solidity: function updateBondCurve(uint256 curveId, uint256[] bondCurve) returns()
+func (_Csaccounting *CsaccountingSession) UpdateBondCurve(curveId *big.Int, bondCurve []*big.Int) (*types.Transaction, error) {
+	return _Csaccounting.Contract.UpdateBondCurve(&_Csaccounting.TransactOpts, curveId, bondCurve)
+}
+
+// UpdateBondCurve is a paid mutator transaction binding the contract method 0x019c1a4f.
+//
+// Solidity: function updateBondCurve(uint256 curveId, uint256[] bondCurve) returns()
+func (_Csaccounting *CsaccountingTransactorSession) UpdateBondCurve(curveId *big.Int, bondCurve []*big.Int) (*types.Transaction, error) {
+	return _Csaccounting.Contract.UpdateBondCurve(&_Csaccounting.TransactOpts, curveId, bondCurve)
+}
+
+// CsaccountingBondBurnedIterator is returned from FilterBondBurned and is used to iterate over the raw logs and unpacked data for BondBurned events raised by the Csaccounting contract.
+type CsaccountingBondBurnedIterator struct {
+	Event *CsaccountingBondBurned // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *CsaccountingBondBurnedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(CsaccountingBondBurned)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(CsaccountingBondBurned)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *CsaccountingBondBurnedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *CsaccountingBondBurnedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// CsaccountingBondBurned represents a BondBurned event raised by the Csaccounting contract.
+type CsaccountingBondBurned struct {
+	NodeOperatorId *big.Int
+	ToBurnAmount   *big.Int
+	BurnedAmount   *big.Int
+	Raw            types.Log // Blockchain specific contextual infos
+}
+
+// FilterBondBurned is a free log retrieval operation binding the contract event 0x4da924ae7845fe96897faab524b536685b8bbc4d82fbb45c10d941e0f86ade0f.
+//
+// Solidity: event BondBurned(uint256 indexed nodeOperatorId, uint256 toBurnAmount, uint256 burnedAmount)
+func (_Csaccounting *CsaccountingFilterer) FilterBondBurned(opts *bind.FilterOpts, nodeOperatorId []*big.Int) (*CsaccountingBondBurnedIterator, error) {
+
+	var nodeOperatorIdRule []interface{}
+	for _, nodeOperatorIdItem := range nodeOperatorId {
+		nodeOperatorIdRule = append(nodeOperatorIdRule, nodeOperatorIdItem)
+	}
+
+	logs, sub, err := _Csaccounting.contract.FilterLogs(opts, "BondBurned", nodeOperatorIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return &CsaccountingBondBurnedIterator{contract: _Csaccounting.contract, event: "BondBurned", logs: logs, sub: sub}, nil
+}
+
+// WatchBondBurned is a free log subscription operation binding the contract event 0x4da924ae7845fe96897faab524b536685b8bbc4d82fbb45c10d941e0f86ade0f.
+//
+// Solidity: event BondBurned(uint256 indexed nodeOperatorId, uint256 toBurnAmount, uint256 burnedAmount)
+func (_Csaccounting *CsaccountingFilterer) WatchBondBurned(opts *bind.WatchOpts, sink chan<- *CsaccountingBondBurned, nodeOperatorId []*big.Int) (event.Subscription, error) {
+
+	var nodeOperatorIdRule []interface{}
+	for _, nodeOperatorIdItem := range nodeOperatorId {
+		nodeOperatorIdRule = append(nodeOperatorIdRule, nodeOperatorIdItem)
+	}
+
+	logs, sub, err := _Csaccounting.contract.WatchLogs(opts, "BondBurned", nodeOperatorIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(CsaccountingBondBurned)
+				if err := _Csaccounting.contract.UnpackLog(event, "BondBurned", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseBondBurned is a log parse operation binding the contract event 0x4da924ae7845fe96897faab524b536685b8bbc4d82fbb45c10d941e0f86ade0f.
+//
+// Solidity: event BondBurned(uint256 indexed nodeOperatorId, uint256 toBurnAmount, uint256 burnedAmount)
+func (_Csaccounting *CsaccountingFilterer) ParseBondBurned(log types.Log) (*CsaccountingBondBurned, error) {
+	event := new(CsaccountingBondBurned)
+	if err := _Csaccounting.contract.UnpackLog(event, "BondBurned", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// CsaccountingBondChargedIterator is returned from FilterBondCharged and is used to iterate over the raw logs and unpacked data for BondCharged events raised by the Csaccounting contract.
+type CsaccountingBondChargedIterator struct {
+	Event *CsaccountingBondCharged // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *CsaccountingBondChargedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(CsaccountingBondCharged)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(CsaccountingBondCharged)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *CsaccountingBondChargedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *CsaccountingBondChargedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// CsaccountingBondCharged represents a BondCharged event raised by the Csaccounting contract.
+type CsaccountingBondCharged struct {
+	NodeOperatorId *big.Int
+	ToChargeAmount *big.Int
+	ChargedAmount  *big.Int
+	Raw            types.Log // Blockchain specific contextual infos
+}
+
+// FilterBondCharged is a free log retrieval operation binding the contract event 0x8615528474a7bb3a28d9971535d956b79242b8e8fcfb27f3e331270fff088afd.
+//
+// Solidity: event BondCharged(uint256 indexed nodeOperatorId, uint256 toChargeAmount, uint256 chargedAmount)
+func (_Csaccounting *CsaccountingFilterer) FilterBondCharged(opts *bind.FilterOpts, nodeOperatorId []*big.Int) (*CsaccountingBondChargedIterator, error) {
+
+	var nodeOperatorIdRule []interface{}
+	for _, nodeOperatorIdItem := range nodeOperatorId {
+		nodeOperatorIdRule = append(nodeOperatorIdRule, nodeOperatorIdItem)
+	}
+
+	logs, sub, err := _Csaccounting.contract.FilterLogs(opts, "BondCharged", nodeOperatorIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return &CsaccountingBondChargedIterator{contract: _Csaccounting.contract, event: "BondCharged", logs: logs, sub: sub}, nil
+}
+
+// WatchBondCharged is a free log subscription operation binding the contract event 0x8615528474a7bb3a28d9971535d956b79242b8e8fcfb27f3e331270fff088afd.
+//
+// Solidity: event BondCharged(uint256 indexed nodeOperatorId, uint256 toChargeAmount, uint256 chargedAmount)
+func (_Csaccounting *CsaccountingFilterer) WatchBondCharged(opts *bind.WatchOpts, sink chan<- *CsaccountingBondCharged, nodeOperatorId []*big.Int) (event.Subscription, error) {
+
+	var nodeOperatorIdRule []interface{}
+	for _, nodeOperatorIdItem := range nodeOperatorId {
+		nodeOperatorIdRule = append(nodeOperatorIdRule, nodeOperatorIdItem)
+	}
+
+	logs, sub, err := _Csaccounting.contract.WatchLogs(opts, "BondCharged", nodeOperatorIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(CsaccountingBondCharged)
+				if err := _Csaccounting.contract.UnpackLog(event, "BondCharged", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseBondCharged is a log parse operation binding the contract event 0x8615528474a7bb3a28d9971535d956b79242b8e8fcfb27f3e331270fff088afd.
+//
+// Solidity: event BondCharged(uint256 indexed nodeOperatorId, uint256 toChargeAmount, uint256 chargedAmount)
+func (_Csaccounting *CsaccountingFilterer) ParseBondCharged(log types.Log) (*CsaccountingBondCharged, error) {
+	event := new(CsaccountingBondCharged)
+	if err := _Csaccounting.contract.UnpackLog(event, "BondCharged", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// CsaccountingBondClaimedStETHIterator is returned from FilterBondClaimedStETH and is used to iterate over the raw logs and unpacked data for BondClaimedStETH events raised by the Csaccounting contract.
+type CsaccountingBondClaimedStETHIterator struct {
+	Event *CsaccountingBondClaimedStETH // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *CsaccountingBondClaimedStETHIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(CsaccountingBondClaimedStETH)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(CsaccountingBondClaimedStETH)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *CsaccountingBondClaimedStETHIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *CsaccountingBondClaimedStETHIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// CsaccountingBondClaimedStETH represents a BondClaimedStETH event raised by the Csaccounting contract.
+type CsaccountingBondClaimedStETH struct {
+	NodeOperatorId *big.Int
+	To             common.Address
+	Amount         *big.Int
+	Raw            types.Log // Blockchain specific contextual infos
+}
+
+// FilterBondClaimedStETH is a free log retrieval operation binding the contract event 0x3e3a1398fe71575ed0c17a80cd9d46ad684c2c75c2fad7b0e7dde15e78ab22d3.
+//
+// Solidity: event BondClaimedStETH(uint256 indexed nodeOperatorId, address to, uint256 amount)
+func (_Csaccounting *CsaccountingFilterer) FilterBondClaimedStETH(opts *bind.FilterOpts, nodeOperatorId []*big.Int) (*CsaccountingBondClaimedStETHIterator, error) {
+
+	var nodeOperatorIdRule []interface{}
+	for _, nodeOperatorIdItem := range nodeOperatorId {
+		nodeOperatorIdRule = append(nodeOperatorIdRule, nodeOperatorIdItem)
+	}
+
+	logs, sub, err := _Csaccounting.contract.FilterLogs(opts, "BondClaimedStETH", nodeOperatorIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return &CsaccountingBondClaimedStETHIterator{contract: _Csaccounting.contract, event: "BondClaimedStETH", logs: logs, sub: sub}, nil
+}
+
+// WatchBondClaimedStETH is a free log subscription operation binding the contract event 0x3e3a1398fe71575ed0c17a80cd9d46ad684c2c75c2fad7b0e7dde15e78ab22d3.
+//
+// Solidity: event BondClaimedStETH(uint256 indexed nodeOperatorId, address to, uint256 amount)
+func (_Csaccounting *CsaccountingFilterer) WatchBondClaimedStETH(opts *bind.WatchOpts, sink chan<- *CsaccountingBondClaimedStETH, nodeOperatorId []*big.Int) (event.Subscription, error) {
+
+	var nodeOperatorIdRule []interface{}
+	for _, nodeOperatorIdItem := range nodeOperatorId {
+		nodeOperatorIdRule = append(nodeOperatorIdRule, nodeOperatorIdItem)
+	}
+
+	logs, sub, err := _Csaccounting.contract.WatchLogs(opts, "BondClaimedStETH", nodeOperatorIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(CsaccountingBondClaimedStETH)
+				if err := _Csaccounting.contract.UnpackLog(event, "BondClaimedStETH", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseBondClaimedStETH is a log parse operation binding the contract event 0x3e3a1398fe71575ed0c17a80cd9d46ad684c2c75c2fad7b0e7dde15e78ab22d3.
+//
+// Solidity: event BondClaimedStETH(uint256 indexed nodeOperatorId, address to, uint256 amount)
+func (_Csaccounting *CsaccountingFilterer) ParseBondClaimedStETH(log types.Log) (*CsaccountingBondClaimedStETH, error) {
+	event := new(CsaccountingBondClaimedStETH)
+	if err := _Csaccounting.contract.UnpackLog(event, "BondClaimedStETH", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// CsaccountingBondClaimedUnstETHIterator is returned from FilterBondClaimedUnstETH and is used to iterate over the raw logs and unpacked data for BondClaimedUnstETH events raised by the Csaccounting contract.
+type CsaccountingBondClaimedUnstETHIterator struct {
+	Event *CsaccountingBondClaimedUnstETH // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *CsaccountingBondClaimedUnstETHIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(CsaccountingBondClaimedUnstETH)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(CsaccountingBondClaimedUnstETH)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *CsaccountingBondClaimedUnstETHIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *CsaccountingBondClaimedUnstETHIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// CsaccountingBondClaimedUnstETH represents a BondClaimedUnstETH event raised by the Csaccounting contract.
+type CsaccountingBondClaimedUnstETH struct {
+	NodeOperatorId *big.Int
+	To             common.Address
+	Amount         *big.Int
+	RequestId      *big.Int
+	Raw            types.Log // Blockchain specific contextual infos
+}
+
+// FilterBondClaimedUnstETH is a free log retrieval operation binding the contract event 0x26673a9d018b21192d08ee14377b798f11b9e5b15ea1559c110265716b8985b5.
+//
+// Solidity: event BondClaimedUnstETH(uint256 indexed nodeOperatorId, address to, uint256 amount, uint256 requestId)
+func (_Csaccounting *CsaccountingFilterer) FilterBondClaimedUnstETH(opts *bind.FilterOpts, nodeOperatorId []*big.Int) (*CsaccountingBondClaimedUnstETHIterator, error) {
+
+	var nodeOperatorIdRule []interface{}
+	for _, nodeOperatorIdItem := range nodeOperatorId {
+		nodeOperatorIdRule = append(nodeOperatorIdRule, nodeOperatorIdItem)
+	}
+
+	logs, sub, err := _Csaccounting.contract.FilterLogs(opts, "BondClaimedUnstETH", nodeOperatorIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return &CsaccountingBondClaimedUnstETHIterator{contract: _Csaccounting.contract, event: "BondClaimedUnstETH", logs: logs, sub: sub}, nil
+}
+
+// WatchBondClaimedUnstETH is a free log subscription operation binding the contract event 0x26673a9d018b21192d08ee14377b798f11b9e5b15ea1559c110265716b8985b5.
+//
+// Solidity: event BondClaimedUnstETH(uint256 indexed nodeOperatorId, address to, uint256 amount, uint256 requestId)
+func (_Csaccounting *CsaccountingFilterer) WatchBondClaimedUnstETH(opts *bind.WatchOpts, sink chan<- *CsaccountingBondClaimedUnstETH, nodeOperatorId []*big.Int) (event.Subscription, error) {
+
+	var nodeOperatorIdRule []interface{}
+	for _, nodeOperatorIdItem := range nodeOperatorId {
+		nodeOperatorIdRule = append(nodeOperatorIdRule, nodeOperatorIdItem)
+	}
+
+	logs, sub, err := _Csaccounting.contract.WatchLogs(opts, "BondClaimedUnstETH", nodeOperatorIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(CsaccountingBondClaimedUnstETH)
+				if err := _Csaccounting.contract.UnpackLog(event, "BondClaimedUnstETH", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseBondClaimedUnstETH is a log parse operation binding the contract event 0x26673a9d018b21192d08ee14377b798f11b9e5b15ea1559c110265716b8985b5.
+//
+// Solidity: event BondClaimedUnstETH(uint256 indexed nodeOperatorId, address to, uint256 amount, uint256 requestId)
+func (_Csaccounting *CsaccountingFilterer) ParseBondClaimedUnstETH(log types.Log) (*CsaccountingBondClaimedUnstETH, error) {
+	event := new(CsaccountingBondClaimedUnstETH)
+	if err := _Csaccounting.contract.UnpackLog(event, "BondClaimedUnstETH", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// CsaccountingBondClaimedWstETHIterator is returned from FilterBondClaimedWstETH and is used to iterate over the raw logs and unpacked data for BondClaimedWstETH events raised by the Csaccounting contract.
+type CsaccountingBondClaimedWstETHIterator struct {
+	Event *CsaccountingBondClaimedWstETH // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *CsaccountingBondClaimedWstETHIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(CsaccountingBondClaimedWstETH)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(CsaccountingBondClaimedWstETH)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *CsaccountingBondClaimedWstETHIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *CsaccountingBondClaimedWstETHIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// CsaccountingBondClaimedWstETH represents a BondClaimedWstETH event raised by the Csaccounting contract.
+type CsaccountingBondClaimedWstETH struct {
+	NodeOperatorId *big.Int
+	To             common.Address
+	Amount         *big.Int
+	Raw            types.Log // Blockchain specific contextual infos
+}
+
+// FilterBondClaimedWstETH is a free log retrieval operation binding the contract event 0xe6a8c06447e05a412e5e9581e088941f3994db3d8a9bfd3275b38d77acacafac.
+//
+// Solidity: event BondClaimedWstETH(uint256 indexed nodeOperatorId, address to, uint256 amount)
+func (_Csaccounting *CsaccountingFilterer) FilterBondClaimedWstETH(opts *bind.FilterOpts, nodeOperatorId []*big.Int) (*CsaccountingBondClaimedWstETHIterator, error) {
+
+	var nodeOperatorIdRule []interface{}
+	for _, nodeOperatorIdItem := range nodeOperatorId {
+		nodeOperatorIdRule = append(nodeOperatorIdRule, nodeOperatorIdItem)
+	}
+
+	logs, sub, err := _Csaccounting.contract.FilterLogs(opts, "BondClaimedWstETH", nodeOperatorIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return &CsaccountingBondClaimedWstETHIterator{contract: _Csaccounting.contract, event: "BondClaimedWstETH", logs: logs, sub: sub}, nil
+}
+
+// WatchBondClaimedWstETH is a free log subscription operation binding the contract event 0xe6a8c06447e05a412e5e9581e088941f3994db3d8a9bfd3275b38d77acacafac.
+//
+// Solidity: event BondClaimedWstETH(uint256 indexed nodeOperatorId, address to, uint256 amount)
+func (_Csaccounting *CsaccountingFilterer) WatchBondClaimedWstETH(opts *bind.WatchOpts, sink chan<- *CsaccountingBondClaimedWstETH, nodeOperatorId []*big.Int) (event.Subscription, error) {
+
+	var nodeOperatorIdRule []interface{}
+	for _, nodeOperatorIdItem := range nodeOperatorId {
+		nodeOperatorIdRule = append(nodeOperatorIdRule, nodeOperatorIdItem)
+	}
+
+	logs, sub, err := _Csaccounting.contract.WatchLogs(opts, "BondClaimedWstETH", nodeOperatorIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(CsaccountingBondClaimedWstETH)
+				if err := _Csaccounting.contract.UnpackLog(event, "BondClaimedWstETH", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseBondClaimedWstETH is a log parse operation binding the contract event 0xe6a8c06447e05a412e5e9581e088941f3994db3d8a9bfd3275b38d77acacafac.
+//
+// Solidity: event BondClaimedWstETH(uint256 indexed nodeOperatorId, address to, uint256 amount)
+func (_Csaccounting *CsaccountingFilterer) ParseBondClaimedWstETH(log types.Log) (*CsaccountingBondClaimedWstETH, error) {
+	event := new(CsaccountingBondClaimedWstETH)
+	if err := _Csaccounting.contract.UnpackLog(event, "BondClaimedWstETH", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// CsaccountingBondCurveAddedIterator is returned from FilterBondCurveAdded and is used to iterate over the raw logs and unpacked data for BondCurveAdded events raised by the Csaccounting contract.
+type CsaccountingBondCurveAddedIterator struct {
+	Event *CsaccountingBondCurveAdded // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *CsaccountingBondCurveAddedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(CsaccountingBondCurveAdded)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(CsaccountingBondCurveAdded)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *CsaccountingBondCurveAddedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *CsaccountingBondCurveAddedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// CsaccountingBondCurveAdded represents a BondCurveAdded event raised by the Csaccounting contract.
+type CsaccountingBondCurveAdded struct {
+	BondCurve []*big.Int
+	Raw       types.Log // Blockchain specific contextual infos
+}
+
+// FilterBondCurveAdded is a free log retrieval operation binding the contract event 0x1fb1d9b944dd7015e95b7b7a9623c45792e4532badcf9c6e7a284d7d4d0570f0.
+//
+// Solidity: event BondCurveAdded(uint256[] bondCurve)
+func (_Csaccounting *CsaccountingFilterer) FilterBondCurveAdded(opts *bind.FilterOpts) (*CsaccountingBondCurveAddedIterator, error) {
+
+	logs, sub, err := _Csaccounting.contract.FilterLogs(opts, "BondCurveAdded")
+	if err != nil {
+		return nil, err
+	}
+	return &CsaccountingBondCurveAddedIterator{contract: _Csaccounting.contract, event: "BondCurveAdded", logs: logs, sub: sub}, nil
+}
+
+// WatchBondCurveAdded is a free log subscription operation binding the contract event 0x1fb1d9b944dd7015e95b7b7a9623c45792e4532badcf9c6e7a284d7d4d0570f0.
+//
+// Solidity: event BondCurveAdded(uint256[] bondCurve)
+func (_Csaccounting *CsaccountingFilterer) WatchBondCurveAdded(opts *bind.WatchOpts, sink chan<- *CsaccountingBondCurveAdded) (event.Subscription, error) {
+
+	logs, sub, err := _Csaccounting.contract.WatchLogs(opts, "BondCurveAdded")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(CsaccountingBondCurveAdded)
+				if err := _Csaccounting.contract.UnpackLog(event, "BondCurveAdded", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseBondCurveAdded is a log parse operation binding the contract event 0x1fb1d9b944dd7015e95b7b7a9623c45792e4532badcf9c6e7a284d7d4d0570f0.
+//
+// Solidity: event BondCurveAdded(uint256[] bondCurve)
+func (_Csaccounting *CsaccountingFilterer) ParseBondCurveAdded(log types.Log) (*CsaccountingBondCurveAdded, error) {
+	event := new(CsaccountingBondCurveAdded)
+	if err := _Csaccounting.contract.UnpackLog(event, "BondCurveAdded", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// CsaccountingBondCurveSetIterator is returned from FilterBondCurveSet and is used to iterate over the raw logs and unpacked data for BondCurveSet events raised by the Csaccounting contract.
+type CsaccountingBondCurveSetIterator struct {
+	Event *CsaccountingBondCurveSet // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *CsaccountingBondCurveSetIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(CsaccountingBondCurveSet)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(CsaccountingBondCurveSet)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *CsaccountingBondCurveSetIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *CsaccountingBondCurveSetIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// CsaccountingBondCurveSet represents a BondCurveSet event raised by the Csaccounting contract.
+type CsaccountingBondCurveSet struct {
+	NodeOperatorId *big.Int
+	CurveId        *big.Int
+	Raw            types.Log // Blockchain specific contextual infos
+}
+
+// FilterBondCurveSet is a free log retrieval operation binding the contract event 0x4642db1736894887bc907d721f20af84d3e585a0a3cea90f41b78b2aa906541b.
+//
+// Solidity: event BondCurveSet(uint256 indexed nodeOperatorId, uint256 curveId)
+func (_Csaccounting *CsaccountingFilterer) FilterBondCurveSet(opts *bind.FilterOpts, nodeOperatorId []*big.Int) (*CsaccountingBondCurveSetIterator, error) {
+
+	var nodeOperatorIdRule []interface{}
+	for _, nodeOperatorIdItem := range nodeOperatorId {
+		nodeOperatorIdRule = append(nodeOperatorIdRule, nodeOperatorIdItem)
+	}
+
+	logs, sub, err := _Csaccounting.contract.FilterLogs(opts, "BondCurveSet", nodeOperatorIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return &CsaccountingBondCurveSetIterator{contract: _Csaccounting.contract, event: "BondCurveSet", logs: logs, sub: sub}, nil
+}
+
+// WatchBondCurveSet is a free log subscription operation binding the contract event 0x4642db1736894887bc907d721f20af84d3e585a0a3cea90f41b78b2aa906541b.
+//
+// Solidity: event BondCurveSet(uint256 indexed nodeOperatorId, uint256 curveId)
+func (_Csaccounting *CsaccountingFilterer) WatchBondCurveSet(opts *bind.WatchOpts, sink chan<- *CsaccountingBondCurveSet, nodeOperatorId []*big.Int) (event.Subscription, error) {
+
+	var nodeOperatorIdRule []interface{}
+	for _, nodeOperatorIdItem := range nodeOperatorId {
+		nodeOperatorIdRule = append(nodeOperatorIdRule, nodeOperatorIdItem)
+	}
+
+	logs, sub, err := _Csaccounting.contract.WatchLogs(opts, "BondCurveSet", nodeOperatorIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(CsaccountingBondCurveSet)
+				if err := _Csaccounting.contract.UnpackLog(event, "BondCurveSet", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseBondCurveSet is a log parse operation binding the contract event 0x4642db1736894887bc907d721f20af84d3e585a0a3cea90f41b78b2aa906541b.
+//
+// Solidity: event BondCurveSet(uint256 indexed nodeOperatorId, uint256 curveId)
+func (_Csaccounting *CsaccountingFilterer) ParseBondCurveSet(log types.Log) (*CsaccountingBondCurveSet, error) {
+	event := new(CsaccountingBondCurveSet)
+	if err := _Csaccounting.contract.UnpackLog(event, "BondCurveSet", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// CsaccountingBondCurveUpdatedIterator is returned from FilterBondCurveUpdated and is used to iterate over the raw logs and unpacked data for BondCurveUpdated events raised by the Csaccounting contract.
+type CsaccountingBondCurveUpdatedIterator struct {
+	Event *CsaccountingBondCurveUpdated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *CsaccountingBondCurveUpdatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(CsaccountingBondCurveUpdated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(CsaccountingBondCurveUpdated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *CsaccountingBondCurveUpdatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *CsaccountingBondCurveUpdatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// CsaccountingBondCurveUpdated represents a BondCurveUpdated event raised by the Csaccounting contract.
+type CsaccountingBondCurveUpdated struct {
+	CurveId   *big.Int
+	BondCurve []*big.Int
+	Raw       types.Log // Blockchain specific contextual infos
+}
+
+// FilterBondCurveUpdated is a free log retrieval operation binding the contract event 0x53da7af401538204fd91f2946f2fe85d05224d2cc766fd7aa9fbd8bf4fb4ce9f.
+//
+// Solidity: event BondCurveUpdated(uint256 indexed curveId, uint256[] bondCurve)
+func (_Csaccounting *CsaccountingFilterer) FilterBondCurveUpdated(opts *bind.FilterOpts, curveId []*big.Int) (*CsaccountingBondCurveUpdatedIterator, error) {
+
+	var curveIdRule []interface{}
+	for _, curveIdItem := range curveId {
+		curveIdRule = append(curveIdRule, curveIdItem)
+	}
+
+	logs, sub, err := _Csaccounting.contract.FilterLogs(opts, "BondCurveUpdated", curveIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return &CsaccountingBondCurveUpdatedIterator{contract: _Csaccounting.contract, event: "BondCurveUpdated", logs: logs, sub: sub}, nil
+}
+
+// WatchBondCurveUpdated is a free log subscription operation binding the contract event 0x53da7af401538204fd91f2946f2fe85d05224d2cc766fd7aa9fbd8bf4fb4ce9f.
+//
+// Solidity: event BondCurveUpdated(uint256 indexed curveId, uint256[] bondCurve)
+func (_Csaccounting *CsaccountingFilterer) WatchBondCurveUpdated(opts *bind.WatchOpts, sink chan<- *CsaccountingBondCurveUpdated, curveId []*big.Int) (event.Subscription, error) {
+
+	var curveIdRule []interface{}
+	for _, curveIdItem := range curveId {
+		curveIdRule = append(curveIdRule, curveIdItem)
+	}
+
+	logs, sub, err := _Csaccounting.contract.WatchLogs(opts, "BondCurveUpdated", curveIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(CsaccountingBondCurveUpdated)
+				if err := _Csaccounting.contract.UnpackLog(event, "BondCurveUpdated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseBondCurveUpdated is a log parse operation binding the contract event 0x53da7af401538204fd91f2946f2fe85d05224d2cc766fd7aa9fbd8bf4fb4ce9f.
+//
+// Solidity: event BondCurveUpdated(uint256 indexed curveId, uint256[] bondCurve)
+func (_Csaccounting *CsaccountingFilterer) ParseBondCurveUpdated(log types.Log) (*CsaccountingBondCurveUpdated, error) {
+	event := new(CsaccountingBondCurveUpdated)
+	if err := _Csaccounting.contract.UnpackLog(event, "BondCurveUpdated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// CsaccountingBondDepositedETHIterator is returned from FilterBondDepositedETH and is used to iterate over the raw logs and unpacked data for BondDepositedETH events raised by the Csaccounting contract.
+type CsaccountingBondDepositedETHIterator struct {
+	Event *CsaccountingBondDepositedETH // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *CsaccountingBondDepositedETHIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(CsaccountingBondDepositedETH)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(CsaccountingBondDepositedETH)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *CsaccountingBondDepositedETHIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *CsaccountingBondDepositedETHIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// CsaccountingBondDepositedETH represents a BondDepositedETH event raised by the Csaccounting contract.
+type CsaccountingBondDepositedETH struct {
+	NodeOperatorId *big.Int
+	From           common.Address
+	Amount         *big.Int
+	Raw            types.Log // Blockchain specific contextual infos
+}
+
+// FilterBondDepositedETH is a free log retrieval operation binding the contract event 0x16ec5116295424dec7fd52c87d9971a963ea7f59f741ad9ad468f0312055dc49.
+//
+// Solidity: event BondDepositedETH(uint256 indexed nodeOperatorId, address from, uint256 amount)
+func (_Csaccounting *CsaccountingFilterer) FilterBondDepositedETH(opts *bind.FilterOpts, nodeOperatorId []*big.Int) (*CsaccountingBondDepositedETHIterator, error) {
+
+	var nodeOperatorIdRule []interface{}
+	for _, nodeOperatorIdItem := range nodeOperatorId {
+		nodeOperatorIdRule = append(nodeOperatorIdRule, nodeOperatorIdItem)
+	}
+
+	logs, sub, err := _Csaccounting.contract.FilterLogs(opts, "BondDepositedETH", nodeOperatorIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return &CsaccountingBondDepositedETHIterator{contract: _Csaccounting.contract, event: "BondDepositedETH", logs: logs, sub: sub}, nil
+}
+
+// WatchBondDepositedETH is a free log subscription operation binding the contract event 0x16ec5116295424dec7fd52c87d9971a963ea7f59f741ad9ad468f0312055dc49.
+//
+// Solidity: event BondDepositedETH(uint256 indexed nodeOperatorId, address from, uint256 amount)
+func (_Csaccounting *CsaccountingFilterer) WatchBondDepositedETH(opts *bind.WatchOpts, sink chan<- *CsaccountingBondDepositedETH, nodeOperatorId []*big.Int) (event.Subscription, error) {
+
+	var nodeOperatorIdRule []interface{}
+	for _, nodeOperatorIdItem := range nodeOperatorId {
+		nodeOperatorIdRule = append(nodeOperatorIdRule, nodeOperatorIdItem)
+	}
+
+	logs, sub, err := _Csaccounting.contract.WatchLogs(opts, "BondDepositedETH", nodeOperatorIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(CsaccountingBondDepositedETH)
+				if err := _Csaccounting.contract.UnpackLog(event, "BondDepositedETH", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseBondDepositedETH is a log parse operation binding the contract event 0x16ec5116295424dec7fd52c87d9971a963ea7f59f741ad9ad468f0312055dc49.
+//
+// Solidity: event BondDepositedETH(uint256 indexed nodeOperatorId, address from, uint256 amount)
+func (_Csaccounting *CsaccountingFilterer) ParseBondDepositedETH(log types.Log) (*CsaccountingBondDepositedETH, error) {
+	event := new(CsaccountingBondDepositedETH)
+	if err := _Csaccounting.contract.UnpackLog(event, "BondDepositedETH", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// CsaccountingBondDepositedStETHIterator is returned from FilterBondDepositedStETH and is used to iterate over the raw logs and unpacked data for BondDepositedStETH events raised by the Csaccounting contract.
+type CsaccountingBondDepositedStETHIterator struct {
+	Event *CsaccountingBondDepositedStETH // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *CsaccountingBondDepositedStETHIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(CsaccountingBondDepositedStETH)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(CsaccountingBondDepositedStETH)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *CsaccountingBondDepositedStETHIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *CsaccountingBondDepositedStETHIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// CsaccountingBondDepositedStETH represents a BondDepositedStETH event raised by the Csaccounting contract.
+type CsaccountingBondDepositedStETH struct {
+	NodeOperatorId *big.Int
+	From           common.Address
+	Amount         *big.Int
+	Raw            types.Log // Blockchain specific contextual infos
+}
+
+// FilterBondDepositedStETH is a free log retrieval operation binding the contract event 0xee31ebba29fd5471227e42fd8ca621a892d689901892cb8febb03fe802c3214b.
+//
+// Solidity: event BondDepositedStETH(uint256 indexed nodeOperatorId, address from, uint256 amount)
+func (_Csaccounting *CsaccountingFilterer) FilterBondDepositedStETH(opts *bind.FilterOpts, nodeOperatorId []*big.Int) (*CsaccountingBondDepositedStETHIterator, error) {
+
+	var nodeOperatorIdRule []interface{}
+	for _, nodeOperatorIdItem := range nodeOperatorId {
+		nodeOperatorIdRule = append(nodeOperatorIdRule, nodeOperatorIdItem)
+	}
+
+	logs, sub, err := _Csaccounting.contract.FilterLogs(opts, "BondDepositedStETH", nodeOperatorIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return &CsaccountingBondDepositedStETHIterator{contract: _Csaccounting.contract, event: "BondDepositedStETH", logs: logs, sub: sub}, nil
+}
+
+// WatchBondDepositedStETH is a free log subscription operation binding the contract event 0xee31ebba29fd5471227e42fd8ca621a892d689901892cb8febb03fe802c3214b.
+//
+// Solidity: event BondDepositedStETH(uint256 indexed nodeOperatorId, address from, uint256 amount)
+func (_Csaccounting *CsaccountingFilterer) WatchBondDepositedStETH(opts *bind.WatchOpts, sink chan<- *CsaccountingBondDepositedStETH, nodeOperatorId []*big.Int) (event.Subscription, error) {
+
+	var nodeOperatorIdRule []interface{}
+	for _, nodeOperatorIdItem := range nodeOperatorId {
+		nodeOperatorIdRule = append(nodeOperatorIdRule, nodeOperatorIdItem)
+	}
+
+	logs, sub, err := _Csaccounting.contract.WatchLogs(opts, "BondDepositedStETH", nodeOperatorIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(CsaccountingBondDepositedStETH)
+				if err := _Csaccounting.contract.UnpackLog(event, "BondDepositedStETH", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseBondDepositedStETH is a log parse operation binding the contract event 0xee31ebba29fd5471227e42fd8ca621a892d689901892cb8febb03fe802c3214b.
+//
+// Solidity: event BondDepositedStETH(uint256 indexed nodeOperatorId, address from, uint256 amount)
+func (_Csaccounting *CsaccountingFilterer) ParseBondDepositedStETH(log types.Log) (*CsaccountingBondDepositedStETH, error) {
+	event := new(CsaccountingBondDepositedStETH)
+	if err := _Csaccounting.contract.UnpackLog(event, "BondDepositedStETH", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// CsaccountingBondDepositedWstETHIterator is returned from FilterBondDepositedWstETH and is used to iterate over the raw logs and unpacked data for BondDepositedWstETH events raised by the Csaccounting contract.
+type CsaccountingBondDepositedWstETHIterator struct {
+	Event *CsaccountingBondDepositedWstETH // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *CsaccountingBondDepositedWstETHIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(CsaccountingBondDepositedWstETH)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(CsaccountingBondDepositedWstETH)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *CsaccountingBondDepositedWstETHIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *CsaccountingBondDepositedWstETHIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// CsaccountingBondDepositedWstETH represents a BondDepositedWstETH event raised by the Csaccounting contract.
+type CsaccountingBondDepositedWstETH struct {
+	NodeOperatorId *big.Int
+	From           common.Address
+	Amount         *big.Int
+	Raw            types.Log // Blockchain specific contextual infos
+}
+
+// FilterBondDepositedWstETH is a free log retrieval operation binding the contract event 0x6576bbc9c5b478bf9717dc3d2bcb485e5ff0727df77c72558727597f3609d3f1.
+//
+// Solidity: event BondDepositedWstETH(uint256 indexed nodeOperatorId, address from, uint256 amount)
+func (_Csaccounting *CsaccountingFilterer) FilterBondDepositedWstETH(opts *bind.FilterOpts, nodeOperatorId []*big.Int) (*CsaccountingBondDepositedWstETHIterator, error) {
+
+	var nodeOperatorIdRule []interface{}
+	for _, nodeOperatorIdItem := range nodeOperatorId {
+		nodeOperatorIdRule = append(nodeOperatorIdRule, nodeOperatorIdItem)
+	}
+
+	logs, sub, err := _Csaccounting.contract.FilterLogs(opts, "BondDepositedWstETH", nodeOperatorIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return &CsaccountingBondDepositedWstETHIterator{contract: _Csaccounting.contract, event: "BondDepositedWstETH", logs: logs, sub: sub}, nil
+}
+
+// WatchBondDepositedWstETH is a free log subscription operation binding the contract event 0x6576bbc9c5b478bf9717dc3d2bcb485e5ff0727df77c72558727597f3609d3f1.
+//
+// Solidity: event BondDepositedWstETH(uint256 indexed nodeOperatorId, address from, uint256 amount)
+func (_Csaccounting *CsaccountingFilterer) WatchBondDepositedWstETH(opts *bind.WatchOpts, sink chan<- *CsaccountingBondDepositedWstETH, nodeOperatorId []*big.Int) (event.Subscription, error) {
+
+	var nodeOperatorIdRule []interface{}
+	for _, nodeOperatorIdItem := range nodeOperatorId {
+		nodeOperatorIdRule = append(nodeOperatorIdRule, nodeOperatorIdItem)
+	}
+
+	logs, sub, err := _Csaccounting.contract.WatchLogs(opts, "BondDepositedWstETH", nodeOperatorIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(CsaccountingBondDepositedWstETH)
+				if err := _Csaccounting.contract.UnpackLog(event, "BondDepositedWstETH", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseBondDepositedWstETH is a log parse operation binding the contract event 0x6576bbc9c5b478bf9717dc3d2bcb485e5ff0727df77c72558727597f3609d3f1.
+//
+// Solidity: event BondDepositedWstETH(uint256 indexed nodeOperatorId, address from, uint256 amount)
+func (_Csaccounting *CsaccountingFilterer) ParseBondDepositedWstETH(log types.Log) (*CsaccountingBondDepositedWstETH, error) {
+	event := new(CsaccountingBondDepositedWstETH)
+	if err := _Csaccounting.contract.UnpackLog(event, "BondDepositedWstETH", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// CsaccountingBondLockChangedIterator is returned from FilterBondLockChanged and is used to iterate over the raw logs and unpacked data for BondLockChanged events raised by the Csaccounting contract.
+type CsaccountingBondLockChangedIterator struct {
+	Event *CsaccountingBondLockChanged // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *CsaccountingBondLockChangedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(CsaccountingBondLockChanged)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(CsaccountingBondLockChanged)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *CsaccountingBondLockChangedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *CsaccountingBondLockChangedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// CsaccountingBondLockChanged represents a BondLockChanged event raised by the Csaccounting contract.
+type CsaccountingBondLockChanged struct {
+	NodeOperatorId *big.Int
+	NewAmount      *big.Int
+	RetentionUntil *big.Int
+	Raw            types.Log // Blockchain specific contextual infos
+}
+
+// FilterBondLockChanged is a free log retrieval operation binding the contract event 0x69a153d448f54b17f05cf3b268a2efab87c94a4727d108c4ca4aa3e5d65113de.
+//
+// Solidity: event BondLockChanged(uint256 indexed nodeOperatorId, uint256 newAmount, uint256 retentionUntil)
+func (_Csaccounting *CsaccountingFilterer) FilterBondLockChanged(opts *bind.FilterOpts, nodeOperatorId []*big.Int) (*CsaccountingBondLockChangedIterator, error) {
+
+	var nodeOperatorIdRule []interface{}
+	for _, nodeOperatorIdItem := range nodeOperatorId {
+		nodeOperatorIdRule = append(nodeOperatorIdRule, nodeOperatorIdItem)
+	}
+
+	logs, sub, err := _Csaccounting.contract.FilterLogs(opts, "BondLockChanged", nodeOperatorIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return &CsaccountingBondLockChangedIterator{contract: _Csaccounting.contract, event: "BondLockChanged", logs: logs, sub: sub}, nil
+}
+
+// WatchBondLockChanged is a free log subscription operation binding the contract event 0x69a153d448f54b17f05cf3b268a2efab87c94a4727d108c4ca4aa3e5d65113de.
+//
+// Solidity: event BondLockChanged(uint256 indexed nodeOperatorId, uint256 newAmount, uint256 retentionUntil)
+func (_Csaccounting *CsaccountingFilterer) WatchBondLockChanged(opts *bind.WatchOpts, sink chan<- *CsaccountingBondLockChanged, nodeOperatorId []*big.Int) (event.Subscription, error) {
+
+	var nodeOperatorIdRule []interface{}
+	for _, nodeOperatorIdItem := range nodeOperatorId {
+		nodeOperatorIdRule = append(nodeOperatorIdRule, nodeOperatorIdItem)
+	}
+
+	logs, sub, err := _Csaccounting.contract.WatchLogs(opts, "BondLockChanged", nodeOperatorIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(CsaccountingBondLockChanged)
+				if err := _Csaccounting.contract.UnpackLog(event, "BondLockChanged", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseBondLockChanged is a log parse operation binding the contract event 0x69a153d448f54b17f05cf3b268a2efab87c94a4727d108c4ca4aa3e5d65113de.
+//
+// Solidity: event BondLockChanged(uint256 indexed nodeOperatorId, uint256 newAmount, uint256 retentionUntil)
+func (_Csaccounting *CsaccountingFilterer) ParseBondLockChanged(log types.Log) (*CsaccountingBondLockChanged, error) {
+	event := new(CsaccountingBondLockChanged)
+	if err := _Csaccounting.contract.UnpackLog(event, "BondLockChanged", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// CsaccountingBondLockCompensatedIterator is returned from FilterBondLockCompensated and is used to iterate over the raw logs and unpacked data for BondLockCompensated events raised by the Csaccounting contract.
+type CsaccountingBondLockCompensatedIterator struct {
+	Event *CsaccountingBondLockCompensated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *CsaccountingBondLockCompensatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(CsaccountingBondLockCompensated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(CsaccountingBondLockCompensated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *CsaccountingBondLockCompensatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *CsaccountingBondLockCompensatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// CsaccountingBondLockCompensated represents a BondLockCompensated event raised by the Csaccounting contract.
+type CsaccountingBondLockCompensated struct {
+	NodeOperatorId *big.Int
+	Amount         *big.Int
+	Raw            types.Log // Blockchain specific contextual infos
+}
+
+// FilterBondLockCompensated is a free log retrieval operation binding the contract event 0xb6ee6e3aae6776519627b46786a622b642c38cabfe4c97cb34054fd63fc11a23.
+//
+// Solidity: event BondLockCompensated(uint256 indexed nodeOperatorId, uint256 amount)
+func (_Csaccounting *CsaccountingFilterer) FilterBondLockCompensated(opts *bind.FilterOpts, nodeOperatorId []*big.Int) (*CsaccountingBondLockCompensatedIterator, error) {
+
+	var nodeOperatorIdRule []interface{}
+	for _, nodeOperatorIdItem := range nodeOperatorId {
+		nodeOperatorIdRule = append(nodeOperatorIdRule, nodeOperatorIdItem)
+	}
+
+	logs, sub, err := _Csaccounting.contract.FilterLogs(opts, "BondLockCompensated", nodeOperatorIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return &CsaccountingBondLockCompensatedIterator{contract: _Csaccounting.contract, event: "BondLockCompensated", logs: logs, sub: sub}, nil
+}
+
+// WatchBondLockCompensated is a free log subscription operation binding the contract event 0xb6ee6e3aae6776519627b46786a622b642c38cabfe4c97cb34054fd63fc11a23.
+//
+// Solidity: event BondLockCompensated(uint256 indexed nodeOperatorId, uint256 amount)
+func (_Csaccounting *CsaccountingFilterer) WatchBondLockCompensated(opts *bind.WatchOpts, sink chan<- *CsaccountingBondLockCompensated, nodeOperatorId []*big.Int) (event.Subscription, error) {
+
+	var nodeOperatorIdRule []interface{}
+	for _, nodeOperatorIdItem := range nodeOperatorId {
+		nodeOperatorIdRule = append(nodeOperatorIdRule, nodeOperatorIdItem)
+	}
+
+	logs, sub, err := _Csaccounting.contract.WatchLogs(opts, "BondLockCompensated", nodeOperatorIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(CsaccountingBondLockCompensated)
+				if err := _Csaccounting.contract.UnpackLog(event, "BondLockCompensated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseBondLockCompensated is a log parse operation binding the contract event 0xb6ee6e3aae6776519627b46786a622b642c38cabfe4c97cb34054fd63fc11a23.
+//
+// Solidity: event BondLockCompensated(uint256 indexed nodeOperatorId, uint256 amount)
+func (_Csaccounting *CsaccountingFilterer) ParseBondLockCompensated(log types.Log) (*CsaccountingBondLockCompensated, error) {
+	event := new(CsaccountingBondLockCompensated)
+	if err := _Csaccounting.contract.UnpackLog(event, "BondLockCompensated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// CsaccountingBondLockRemovedIterator is returned from FilterBondLockRemoved and is used to iterate over the raw logs and unpacked data for BondLockRemoved events raised by the Csaccounting contract.
+type CsaccountingBondLockRemovedIterator struct {
+	Event *CsaccountingBondLockRemoved // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *CsaccountingBondLockRemovedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(CsaccountingBondLockRemoved)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(CsaccountingBondLockRemoved)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *CsaccountingBondLockRemovedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *CsaccountingBondLockRemovedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// CsaccountingBondLockRemoved represents a BondLockRemoved event raised by the Csaccounting contract.
+type CsaccountingBondLockRemoved struct {
+	NodeOperatorId *big.Int
+	Raw            types.Log // Blockchain specific contextual infos
+}
+
+// FilterBondLockRemoved is a free log retrieval operation binding the contract event 0x844ae6b00e8a437dcdde1a634feab3273e08bb5c274a4be3b195b308ae0ba20a.
+//
+// Solidity: event BondLockRemoved(uint256 indexed nodeOperatorId)
+func (_Csaccounting *CsaccountingFilterer) FilterBondLockRemoved(opts *bind.FilterOpts, nodeOperatorId []*big.Int) (*CsaccountingBondLockRemovedIterator, error) {
+
+	var nodeOperatorIdRule []interface{}
+	for _, nodeOperatorIdItem := range nodeOperatorId {
+		nodeOperatorIdRule = append(nodeOperatorIdRule, nodeOperatorIdItem)
+	}
+
+	logs, sub, err := _Csaccounting.contract.FilterLogs(opts, "BondLockRemoved", nodeOperatorIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return &CsaccountingBondLockRemovedIterator{contract: _Csaccounting.contract, event: "BondLockRemoved", logs: logs, sub: sub}, nil
+}
+
+// WatchBondLockRemoved is a free log subscription operation binding the contract event 0x844ae6b00e8a437dcdde1a634feab3273e08bb5c274a4be3b195b308ae0ba20a.
+//
+// Solidity: event BondLockRemoved(uint256 indexed nodeOperatorId)
+func (_Csaccounting *CsaccountingFilterer) WatchBondLockRemoved(opts *bind.WatchOpts, sink chan<- *CsaccountingBondLockRemoved, nodeOperatorId []*big.Int) (event.Subscription, error) {
+
+	var nodeOperatorIdRule []interface{}
+	for _, nodeOperatorIdItem := range nodeOperatorId {
+		nodeOperatorIdRule = append(nodeOperatorIdRule, nodeOperatorIdItem)
+	}
+
+	logs, sub, err := _Csaccounting.contract.WatchLogs(opts, "BondLockRemoved", nodeOperatorIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(CsaccountingBondLockRemoved)
+				if err := _Csaccounting.contract.UnpackLog(event, "BondLockRemoved", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseBondLockRemoved is a log parse operation binding the contract event 0x844ae6b00e8a437dcdde1a634feab3273e08bb5c274a4be3b195b308ae0ba20a.
+//
+// Solidity: event BondLockRemoved(uint256 indexed nodeOperatorId)
+func (_Csaccounting *CsaccountingFilterer) ParseBondLockRemoved(log types.Log) (*CsaccountingBondLockRemoved, error) {
+	event := new(CsaccountingBondLockRemoved)
+	if err := _Csaccounting.contract.UnpackLog(event, "BondLockRemoved", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// CsaccountingBondLockRetentionPeriodChangedIterator is returned from FilterBondLockRetentionPeriodChanged and is used to iterate over the raw logs and unpacked data for BondLockRetentionPeriodChanged events raised by the Csaccounting contract.
+type CsaccountingBondLockRetentionPeriodChangedIterator struct {
+	Event *CsaccountingBondLockRetentionPeriodChanged // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *CsaccountingBondLockRetentionPeriodChangedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(CsaccountingBondLockRetentionPeriodChanged)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(CsaccountingBondLockRetentionPeriodChanged)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *CsaccountingBondLockRetentionPeriodChangedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *CsaccountingBondLockRetentionPeriodChangedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// CsaccountingBondLockRetentionPeriodChanged represents a BondLockRetentionPeriodChanged event raised by the Csaccounting contract.
+type CsaccountingBondLockRetentionPeriodChanged struct {
+	RetentionPeriod *big.Int
+	Raw             types.Log // Blockchain specific contextual infos
+}
+
+// FilterBondLockRetentionPeriodChanged is a free log retrieval operation binding the contract event 0xdaf5eddbe9ed0768e54cc8f739a9cb86c57fc70da07eff01d9ba886f21a7a4b3.
+//
+// Solidity: event BondLockRetentionPeriodChanged(uint256 retentionPeriod)
+func (_Csaccounting *CsaccountingFilterer) FilterBondLockRetentionPeriodChanged(opts *bind.FilterOpts) (*CsaccountingBondLockRetentionPeriodChangedIterator, error) {
+
+	logs, sub, err := _Csaccounting.contract.FilterLogs(opts, "BondLockRetentionPeriodChanged")
+	if err != nil {
+		return nil, err
+	}
+	return &CsaccountingBondLockRetentionPeriodChangedIterator{contract: _Csaccounting.contract, event: "BondLockRetentionPeriodChanged", logs: logs, sub: sub}, nil
+}
+
+// WatchBondLockRetentionPeriodChanged is a free log subscription operation binding the contract event 0xdaf5eddbe9ed0768e54cc8f739a9cb86c57fc70da07eff01d9ba886f21a7a4b3.
+//
+// Solidity: event BondLockRetentionPeriodChanged(uint256 retentionPeriod)
+func (_Csaccounting *CsaccountingFilterer) WatchBondLockRetentionPeriodChanged(opts *bind.WatchOpts, sink chan<- *CsaccountingBondLockRetentionPeriodChanged) (event.Subscription, error) {
+
+	logs, sub, err := _Csaccounting.contract.WatchLogs(opts, "BondLockRetentionPeriodChanged")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(CsaccountingBondLockRetentionPeriodChanged)
+				if err := _Csaccounting.contract.UnpackLog(event, "BondLockRetentionPeriodChanged", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseBondLockRetentionPeriodChanged is a log parse operation binding the contract event 0xdaf5eddbe9ed0768e54cc8f739a9cb86c57fc70da07eff01d9ba886f21a7a4b3.
+//
+// Solidity: event BondLockRetentionPeriodChanged(uint256 retentionPeriod)
+func (_Csaccounting *CsaccountingFilterer) ParseBondLockRetentionPeriodChanged(log types.Log) (*CsaccountingBondLockRetentionPeriodChanged, error) {
+	event := new(CsaccountingBondLockRetentionPeriodChanged)
+	if err := _Csaccounting.contract.UnpackLog(event, "BondLockRetentionPeriodChanged", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// CsaccountingChargePenaltyRecipientSetIterator is returned from FilterChargePenaltyRecipientSet and is used to iterate over the raw logs and unpacked data for ChargePenaltyRecipientSet events raised by the Csaccounting contract.
+type CsaccountingChargePenaltyRecipientSetIterator struct {
+	Event *CsaccountingChargePenaltyRecipientSet // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *CsaccountingChargePenaltyRecipientSetIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(CsaccountingChargePenaltyRecipientSet)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(CsaccountingChargePenaltyRecipientSet)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *CsaccountingChargePenaltyRecipientSetIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *CsaccountingChargePenaltyRecipientSetIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// CsaccountingChargePenaltyRecipientSet represents a ChargePenaltyRecipientSet event raised by the Csaccounting contract.
+type CsaccountingChargePenaltyRecipientSet struct {
+	ChargePenaltyRecipient common.Address
+	Raw                    types.Log // Blockchain specific contextual infos
+}
+
+// FilterChargePenaltyRecipientSet is a free log retrieval operation binding the contract event 0x4beaaee83871b066b675515d6a53567e76411f60266703cef934a01905a4d832.
+//
+// Solidity: event ChargePenaltyRecipientSet(address chargePenaltyRecipient)
+func (_Csaccounting *CsaccountingFilterer) FilterChargePenaltyRecipientSet(opts *bind.FilterOpts) (*CsaccountingChargePenaltyRecipientSetIterator, error) {
+
+	logs, sub, err := _Csaccounting.contract.FilterLogs(opts, "ChargePenaltyRecipientSet")
+	if err != nil {
+		return nil, err
+	}
+	return &CsaccountingChargePenaltyRecipientSetIterator{contract: _Csaccounting.contract, event: "ChargePenaltyRecipientSet", logs: logs, sub: sub}, nil
+}
+
+// WatchChargePenaltyRecipientSet is a free log subscription operation binding the contract event 0x4beaaee83871b066b675515d6a53567e76411f60266703cef934a01905a4d832.
+//
+// Solidity: event ChargePenaltyRecipientSet(address chargePenaltyRecipient)
+func (_Csaccounting *CsaccountingFilterer) WatchChargePenaltyRecipientSet(opts *bind.WatchOpts, sink chan<- *CsaccountingChargePenaltyRecipientSet) (event.Subscription, error) {
+
+	logs, sub, err := _Csaccounting.contract.WatchLogs(opts, "ChargePenaltyRecipientSet")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(CsaccountingChargePenaltyRecipientSet)
+				if err := _Csaccounting.contract.UnpackLog(event, "ChargePenaltyRecipientSet", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseChargePenaltyRecipientSet is a log parse operation binding the contract event 0x4beaaee83871b066b675515d6a53567e76411f60266703cef934a01905a4d832.
+//
+// Solidity: event ChargePenaltyRecipientSet(address chargePenaltyRecipient)
+func (_Csaccounting *CsaccountingFilterer) ParseChargePenaltyRecipientSet(log types.Log) (*CsaccountingChargePenaltyRecipientSet, error) {
+	event := new(CsaccountingChargePenaltyRecipientSet)
+	if err := _Csaccounting.contract.UnpackLog(event, "ChargePenaltyRecipientSet", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// CsaccountingERC1155RecoveredIterator is returned from FilterERC1155Recovered and is used to iterate over the raw logs and unpacked data for ERC1155Recovered events raised by the Csaccounting contract.
+type CsaccountingERC1155RecoveredIterator struct {
+	Event *CsaccountingERC1155Recovered // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *CsaccountingERC1155RecoveredIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(CsaccountingERC1155Recovered)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(CsaccountingERC1155Recovered)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *CsaccountingERC1155RecoveredIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *CsaccountingERC1155RecoveredIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// CsaccountingERC1155Recovered represents a ERC1155Recovered event raised by the Csaccounting contract.
+type CsaccountingERC1155Recovered struct {
+	Token     common.Address
+	TokenId   *big.Int
+	Recipient common.Address
+	Amount    *big.Int
+	Raw       types.Log // Blockchain specific contextual infos
+}
+
+// FilterERC1155Recovered is a free log retrieval operation binding the contract event 0x5cf02e753b3eb0f4bee4460a72817d8e5e3c75cd4d65c1d0b06dca88b8032936.
+//
+// Solidity: event ERC1155Recovered(address indexed token, uint256 tokenId, address indexed recipient, uint256 amount)
+func (_Csaccounting *CsaccountingFilterer) FilterERC1155Recovered(opts *bind.FilterOpts, token []common.Address, recipient []common.Address) (*CsaccountingERC1155RecoveredIterator, error) {
+
+	var tokenRule []interface{}
+	for _, tokenItem := range token {
+		tokenRule = append(tokenRule, tokenItem)
+	}
+
+	var recipientRule []interface{}
+	for _, recipientItem := range recipient {
+		recipientRule = append(recipientRule, recipientItem)
+	}
+
+	logs, sub, err := _Csaccounting.contract.FilterLogs(opts, "ERC1155Recovered", tokenRule, recipientRule)
+	if err != nil {
+		return nil, err
+	}
+	return &CsaccountingERC1155RecoveredIterator{contract: _Csaccounting.contract, event: "ERC1155Recovered", logs: logs, sub: sub}, nil
+}
+
+// WatchERC1155Recovered is a free log subscription operation binding the contract event 0x5cf02e753b3eb0f4bee4460a72817d8e5e3c75cd4d65c1d0b06dca88b8032936.
+//
+// Solidity: event ERC1155Recovered(address indexed token, uint256 tokenId, address indexed recipient, uint256 amount)
+func (_Csaccounting *CsaccountingFilterer) WatchERC1155Recovered(opts *bind.WatchOpts, sink chan<- *CsaccountingERC1155Recovered, token []common.Address, recipient []common.Address) (event.Subscription, error) {
+
+	var tokenRule []interface{}
+	for _, tokenItem := range token {
+		tokenRule = append(tokenRule, tokenItem)
+	}
+
+	var recipientRule []interface{}
+	for _, recipientItem := range recipient {
+		recipientRule = append(recipientRule, recipientItem)
+	}
+
+	logs, sub, err := _Csaccounting.contract.WatchLogs(opts, "ERC1155Recovered", tokenRule, recipientRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(CsaccountingERC1155Recovered)
+				if err := _Csaccounting.contract.UnpackLog(event, "ERC1155Recovered", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseERC1155Recovered is a log parse operation binding the contract event 0x5cf02e753b3eb0f4bee4460a72817d8e5e3c75cd4d65c1d0b06dca88b8032936.
+//
+// Solidity: event ERC1155Recovered(address indexed token, uint256 tokenId, address indexed recipient, uint256 amount)
+func (_Csaccounting *CsaccountingFilterer) ParseERC1155Recovered(log types.Log) (*CsaccountingERC1155Recovered, error) {
+	event := new(CsaccountingERC1155Recovered)
+	if err := _Csaccounting.contract.UnpackLog(event, "ERC1155Recovered", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// CsaccountingERC20RecoveredIterator is returned from FilterERC20Recovered and is used to iterate over the raw logs and unpacked data for ERC20Recovered events raised by the Csaccounting contract.
+type CsaccountingERC20RecoveredIterator struct {
+	Event *CsaccountingERC20Recovered // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *CsaccountingERC20RecoveredIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(CsaccountingERC20Recovered)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(CsaccountingERC20Recovered)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *CsaccountingERC20RecoveredIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *CsaccountingERC20RecoveredIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// CsaccountingERC20Recovered represents a ERC20Recovered event raised by the Csaccounting contract.
+type CsaccountingERC20Recovered struct {
+	Token     common.Address
+	Recipient common.Address
+	Amount    *big.Int
+	Raw       types.Log // Blockchain specific contextual infos
+}
+
+// FilterERC20Recovered is a free log retrieval operation binding the contract event 0xaca8fb252cde442184e5f10e0f2e6e4029e8cd7717cae63559079610702436aa.
+//
+// Solidity: event ERC20Recovered(address indexed token, address indexed recipient, uint256 amount)
+func (_Csaccounting *CsaccountingFilterer) FilterERC20Recovered(opts *bind.FilterOpts, token []common.Address, recipient []common.Address) (*CsaccountingERC20RecoveredIterator, error) {
+
+	var tokenRule []interface{}
+	for _, tokenItem := range token {
+		tokenRule = append(tokenRule, tokenItem)
+	}
+	var recipientRule []interface{}
+	for _, recipientItem := range recipient {
+		recipientRule = append(recipientRule, recipientItem)
+	}
+
+	logs, sub, err := _Csaccounting.contract.FilterLogs(opts, "ERC20Recovered", tokenRule, recipientRule)
+	if err != nil {
+		return nil, err
+	}
+	return &CsaccountingERC20RecoveredIterator{contract: _Csaccounting.contract, event: "ERC20Recovered", logs: logs, sub: sub}, nil
+}
+
+// WatchERC20Recovered is a free log subscription operation binding the contract event 0xaca8fb252cde442184e5f10e0f2e6e4029e8cd7717cae63559079610702436aa.
+//
+// Solidity: event ERC20Recovered(address indexed token, address indexed recipient, uint256 amount)
+func (_Csaccounting *CsaccountingFilterer) WatchERC20Recovered(opts *bind.WatchOpts, sink chan<- *CsaccountingERC20Recovered, token []common.Address, recipient []common.Address) (event.Subscription, error) {
+
+	var tokenRule []interface{}
+	for _, tokenItem := range token {
+		tokenRule = append(tokenRule, tokenItem)
+	}
+	var recipientRule []interface{}
+	for _, recipientItem := range recipient {
+		recipientRule = append(recipientRule, recipientItem)
+	}
+
+	logs, sub, err := _Csaccounting.contract.WatchLogs(opts, "ERC20Recovered", tokenRule, recipientRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(CsaccountingERC20Recovered)
+				if err := _Csaccounting.contract.UnpackLog(event, "ERC20Recovered", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseERC20Recovered is a log parse operation binding the contract event 0xaca8fb252cde442184e5f10e0f2e6e4029e8cd7717cae63559079610702436aa.
+//
+// Solidity: event ERC20Recovered(address indexed token, address indexed recipient, uint256 amount)
+func (_Csaccounting *CsaccountingFilterer) ParseERC20Recovered(log types.Log) (*CsaccountingERC20Recovered, error) {
+	event := new(CsaccountingERC20Recovered)
+	if err := _Csaccounting.contract.UnpackLog(event, "ERC20Recovered", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// CsaccountingERC721RecoveredIterator is returned from FilterERC721Recovered and is used to iterate over the raw logs and unpacked data for ERC721Recovered events raised by the Csaccounting contract.
+type CsaccountingERC721RecoveredIterator struct {
+	Event *CsaccountingERC721Recovered // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *CsaccountingERC721RecoveredIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(CsaccountingERC721Recovered)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(CsaccountingERC721Recovered)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *CsaccountingERC721RecoveredIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *CsaccountingERC721RecoveredIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// CsaccountingERC721Recovered represents a ERC721Recovered event raised by the Csaccounting contract.
+type CsaccountingERC721Recovered struct {
+	Token     common.Address
+	TokenId   *big.Int
+	Recipient common.Address
+	Raw       types.Log // Blockchain specific contextual infos
+}
+
+// FilterERC721Recovered is a free log retrieval operation binding the contract event 0x8166bf75d2ff2fa3c8f3c44410540bf42e9a5359b48409e8d660291dc9f788c8.
+//
+// Solidity: event ERC721Recovered(address indexed token, uint256 tokenId, address indexed recipient)
+func (_Csaccounting *CsaccountingFilterer) FilterERC721Recovered(opts *bind.FilterOpts, token []common.Address, recipient []common.Address) (*CsaccountingERC721RecoveredIterator, error) {
+
+	var tokenRule []interface{}
+	for _, tokenItem := range token {
+		tokenRule = append(tokenRule, tokenItem)
+	}
+
+	var recipientRule []interface{}
+	for _, recipientItem := range recipient {
+		recipientRule = append(recipientRule, recipientItem)
+	}
+
+	logs, sub, err := _Csaccounting.contract.FilterLogs(opts, "ERC721Recovered", tokenRule, recipientRule)
+	if err != nil {
+		return nil, err
+	}
+	return &CsaccountingERC721RecoveredIterator{contract: _Csaccounting.contract, event: "ERC721Recovered", logs: logs, sub: sub}, nil
+}
+
+// WatchERC721Recovered is a free log subscription operation binding the contract event 0x8166bf75d2ff2fa3c8f3c44410540bf42e9a5359b48409e8d660291dc9f788c8.
+//
+// Solidity: event ERC721Recovered(address indexed token, uint256 tokenId, address indexed recipient)
+func (_Csaccounting *CsaccountingFilterer) WatchERC721Recovered(opts *bind.WatchOpts, sink chan<- *CsaccountingERC721Recovered, token []common.Address, recipient []common.Address) (event.Subscription, error) {
+
+	var tokenRule []interface{}
+	for _, tokenItem := range token {
+		tokenRule = append(tokenRule, tokenItem)
+	}
+
+	var recipientRule []interface{}
+	for _, recipientItem := range recipient {
+		recipientRule = append(recipientRule, recipientItem)
+	}
+
+	logs, sub, err := _Csaccounting.contract.WatchLogs(opts, "ERC721Recovered", tokenRule, recipientRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(CsaccountingERC721Recovered)
+				if err := _Csaccounting.contract.UnpackLog(event, "ERC721Recovered", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseERC721Recovered is a log parse operation binding the contract event 0x8166bf75d2ff2fa3c8f3c44410540bf42e9a5359b48409e8d660291dc9f788c8.
+//
+// Solidity: event ERC721Recovered(address indexed token, uint256 tokenId, address indexed recipient)
+func (_Csaccounting *CsaccountingFilterer) ParseERC721Recovered(log types.Log) (*CsaccountingERC721Recovered, error) {
+	event := new(CsaccountingERC721Recovered)
+	if err := _Csaccounting.contract.UnpackLog(event, "ERC721Recovered", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// CsaccountingEtherRecoveredIterator is returned from FilterEtherRecovered and is used to iterate over the raw logs and unpacked data for EtherRecovered events raised by the Csaccounting contract.
+type CsaccountingEtherRecoveredIterator struct {
+	Event *CsaccountingEtherRecovered // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *CsaccountingEtherRecoveredIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(CsaccountingEtherRecovered)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(CsaccountingEtherRecovered)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *CsaccountingEtherRecoveredIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *CsaccountingEtherRecoveredIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// CsaccountingEtherRecovered represents a EtherRecovered event raised by the Csaccounting contract.
+type CsaccountingEtherRecovered struct {
+	Recipient common.Address
+	Amount    *big.Int
+	Raw       types.Log // Blockchain specific contextual infos
+}
+
+// FilterEtherRecovered is a free log retrieval operation binding the contract event 0x8e274e42262a7f013b700b35c2b4629ccce1702f8fe83f8dfb7eacbb26a4382c.
+//
+// Solidity: event EtherRecovered(address indexed recipient, uint256 amount)
+func (_Csaccounting *CsaccountingFilterer) FilterEtherRecovered(opts *bind.FilterOpts, recipient []common.Address) (*CsaccountingEtherRecoveredIterator, error) {
+
+	var recipientRule []interface{}
+	for _, recipientItem := range recipient {
+		recipientRule = append(recipientRule, recipientItem)
+	}
+
+	logs, sub, err := _Csaccounting.contract.FilterLogs(opts, "EtherRecovered", recipientRule)
+	if err != nil {
+		return nil, err
+	}
+	return &CsaccountingEtherRecoveredIterator{contract: _Csaccounting.contract, event: "EtherRecovered", logs: logs, sub: sub}, nil
+}
+
+// WatchEtherRecovered is a free log subscription operation binding the contract event 0x8e274e42262a7f013b700b35c2b4629ccce1702f8fe83f8dfb7eacbb26a4382c.
+//
+// Solidity: event EtherRecovered(address indexed recipient, uint256 amount)
+func (_Csaccounting *CsaccountingFilterer) WatchEtherRecovered(opts *bind.WatchOpts, sink chan<- *CsaccountingEtherRecovered, recipient []common.Address) (event.Subscription, error) {
+
+	var recipientRule []interface{}
+	for _, recipientItem := range recipient {
+		recipientRule = append(recipientRule, recipientItem)
+	}
+
+	logs, sub, err := _Csaccounting.contract.WatchLogs(opts, "EtherRecovered", recipientRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(CsaccountingEtherRecovered)
+				if err := _Csaccounting.contract.UnpackLog(event, "EtherRecovered", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseEtherRecovered is a log parse operation binding the contract event 0x8e274e42262a7f013b700b35c2b4629ccce1702f8fe83f8dfb7eacbb26a4382c.
+//
+// Solidity: event EtherRecovered(address indexed recipient, uint256 amount)
+func (_Csaccounting *CsaccountingFilterer) ParseEtherRecovered(log types.Log) (*CsaccountingEtherRecovered, error) {
+	event := new(CsaccountingEtherRecovered)
+	if err := _Csaccounting.contract.UnpackLog(event, "EtherRecovered", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// CsaccountingInitializedIterator is returned from FilterInitialized and is used to iterate over the raw logs and unpacked data for Initialized events raised by the Csaccounting contract.
+type CsaccountingInitializedIterator struct {
+	Event *CsaccountingInitialized // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *CsaccountingInitializedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(CsaccountingInitialized)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(CsaccountingInitialized)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *CsaccountingInitializedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *CsaccountingInitializedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// CsaccountingInitialized represents a Initialized event raised by the Csaccounting contract.
+type CsaccountingInitialized struct {
+	Version uint64
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterInitialized is a free log retrieval operation binding the contract event 0xc7f505b2f371ae2175ee4913f4499e1f2633a7b5936321eed1cdaeb6115181d2.
+//
+// Solidity: event Initialized(uint64 version)
+func (_Csaccounting *CsaccountingFilterer) FilterInitialized(opts *bind.FilterOpts) (*CsaccountingInitializedIterator, error) {
+
+	logs, sub, err := _Csaccounting.contract.FilterLogs(opts, "Initialized")
+	if err != nil {
+		return nil, err
+	}
+	return &CsaccountingInitializedIterator{contract: _Csaccounting.contract, event: "Initialized", logs: logs, sub: sub}, nil
+}
+
+// WatchInitialized is a free log subscription operation binding the contract event 0xc7f505b2f371ae2175ee4913f4499e1f2633a7b5936321eed1cdaeb6115181d2.
+//
+// Solidity: event Initialized(uint64 version)
+func (_Csaccounting *CsaccountingFilterer) WatchInitialized(opts *bind.WatchOpts, sink chan<- *CsaccountingInitialized) (event.Subscription, error) {
+
+	logs, sub, err := _Csaccounting.contract.WatchLogs(opts, "Initialized")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(CsaccountingInitialized)
+				if err := _Csaccounting.contract.UnpackLog(event, "Initialized", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseInitialized is a log parse operation binding the contract event 0xc7f505b2f371ae2175ee4913f4499e1f2633a7b5936321eed1cdaeb6115181d2.
+//
+// Solidity: event Initialized(uint64 version)
+func (_Csaccounting *CsaccountingFilterer) ParseInitialized(log types.Log) (*CsaccountingInitialized, error) {
+	event := new(CsaccountingInitialized)
+	if err := _Csaccounting.contract.UnpackLog(event, "Initialized", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// CsaccountingPausedIterator is returned from FilterPaused and is used to iterate over the raw logs and unpacked data for Paused events raised by the Csaccounting contract.
+type CsaccountingPausedIterator struct {
+	Event *CsaccountingPaused // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *CsaccountingPausedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(CsaccountingPaused)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(CsaccountingPaused)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *CsaccountingPausedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *CsaccountingPausedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// CsaccountingPaused represents a Paused event raised by the Csaccounting contract.
+type CsaccountingPaused struct {
+	Duration *big.Int
+	Raw      types.Log // Blockchain specific contextual infos
+}
+
+// FilterPaused is a free log retrieval operation binding the contract event 0x32fb7c9891bc4f963c7de9f1186d2a7755c7d6e9f4604dabe1d8bb3027c2f49e.
+//
+// Solidity: event Paused(uint256 duration)
+func (_Csaccounting *CsaccountingFilterer) FilterPaused(opts *bind.FilterOpts) (*CsaccountingPausedIterator, error) {
+
+	logs, sub, err := _Csaccounting.contract.FilterLogs(opts, "Paused")
+	if err != nil {
+		return nil, err
+	}
+	return &CsaccountingPausedIterator{contract: _Csaccounting.contract, event: "Paused", logs: logs, sub: sub}, nil
+}
+
+// WatchPaused is a free log subscription operation binding the contract event 0x32fb7c9891bc4f963c7de9f1186d2a7755c7d6e9f4604dabe1d8bb3027c2f49e.
+//
+// Solidity: event Paused(uint256 duration)
+func (_Csaccounting *CsaccountingFilterer) WatchPaused(opts *bind.WatchOpts, sink chan<- *CsaccountingPaused) (event.Subscription, error) {
+
+	logs, sub, err := _Csaccounting.contract.WatchLogs(opts, "Paused")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(CsaccountingPaused)
+				if err := _Csaccounting.contract.UnpackLog(event, "Paused", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParsePaused is a log parse operation binding the contract event 0x32fb7c9891bc4f963c7de9f1186d2a7755c7d6e9f4604dabe1d8bb3027c2f49e.
+//
+// Solidity: event Paused(uint256 duration)
+func (_Csaccounting *CsaccountingFilterer) ParsePaused(log types.Log) (*CsaccountingPaused, error) {
+	event := new(CsaccountingPaused)
+	if err := _Csaccounting.contract.UnpackLog(event, "Paused", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// CsaccountingResumedIterator is returned from FilterResumed and is used to iterate over the raw logs and unpacked data for Resumed events raised by the Csaccounting contract.
+type CsaccountingResumedIterator struct {
+	Event *CsaccountingResumed // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *CsaccountingResumedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(CsaccountingResumed)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(CsaccountingResumed)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *CsaccountingResumedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *CsaccountingResumedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// CsaccountingResumed represents a Resumed event raised by the Csaccounting contract.
+type CsaccountingResumed struct {
+	Raw types.Log // Blockchain specific contextual infos
+}
+
+// FilterResumed is a free log retrieval operation binding the contract event 0x62451d457bc659158be6e6247f56ec1df424a5c7597f71c20c2bc44e0965c8f9.
+//
+// Solidity: event Resumed()
+func (_Csaccounting *CsaccountingFilterer) FilterResumed(opts *bind.FilterOpts) (*CsaccountingResumedIterator, error) {
+
+	logs, sub, err := _Csaccounting.contract.FilterLogs(opts, "Resumed")
+	if err != nil {
+		return nil, err
+	}
+	return &CsaccountingResumedIterator{contract: _Csaccounting.contract, event: "Resumed", logs: logs, sub: sub}, nil
+}
+
+// WatchResumed is a free log subscription operation binding the contract event 0x62451d457bc659158be6e6247f56ec1df424a5c7597f71c20c2bc44e0965c8f9.
+//
+// Solidity: event Resumed()
+func (_Csaccounting *CsaccountingFilterer) WatchResumed(opts *bind.WatchOpts, sink chan<- *CsaccountingResumed) (event.Subscription, error) {
+
+	logs, sub, err := _Csaccounting.contract.WatchLogs(opts, "Resumed")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(CsaccountingResumed)
+				if err := _Csaccounting.contract.UnpackLog(event, "Resumed", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseResumed is a log parse operation binding the contract event 0x62451d457bc659158be6e6247f56ec1df424a5c7597f71c20c2bc44e0965c8f9.
+//
+// Solidity: event Resumed()
+func (_Csaccounting *CsaccountingFilterer) ParseResumed(log types.Log) (*CsaccountingResumed, error) {
+	event := new(CsaccountingResumed)
+	if err := _Csaccounting.contract.UnpackLog(event, "Resumed", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// CsaccountingRoleAdminChangedIterator is returned from FilterRoleAdminChanged and is used to iterate over the raw logs and unpacked data for RoleAdminChanged events raised by the Csaccounting contract.
+type CsaccountingRoleAdminChangedIterator struct {
+	Event *CsaccountingRoleAdminChanged // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *CsaccountingRoleAdminChangedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(CsaccountingRoleAdminChanged)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(CsaccountingRoleAdminChanged)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *CsaccountingRoleAdminChangedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *CsaccountingRoleAdminChangedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// CsaccountingRoleAdminChanged represents a RoleAdminChanged event raised by the Csaccounting contract.
+type CsaccountingRoleAdminChanged struct {
+	Role              [32]byte
+	PreviousAdminRole [32]byte
+	NewAdminRole      [32]byte
+	Raw               types.Log // Blockchain specific contextual infos
+}
+
+// FilterRoleAdminChanged is a free log retrieval operation binding the contract event 0xbd79b86ffe0ab8e8776151514217cd7cacd52c909f66475c3af44e129f0b00ff.
+//
+// Solidity: event RoleAdminChanged(bytes32 indexed role, bytes32 indexed previousAdminRole, bytes32 indexed newAdminRole)
+func (_Csaccounting *CsaccountingFilterer) FilterRoleAdminChanged(opts *bind.FilterOpts, role [][32]byte, previousAdminRole [][32]byte, newAdminRole [][32]byte) (*CsaccountingRoleAdminChangedIterator, error) {
+
+	var roleRule []interface{}
+	for _, roleItem := range role {
+		roleRule = append(roleRule, roleItem)
+	}
+	var previousAdminRoleRule []interface{}
+	for _, previousAdminRoleItem := range previousAdminRole {
+		previousAdminRoleRule = append(previousAdminRoleRule, previousAdminRoleItem)
+	}
+	var newAdminRoleRule []interface{}
+	for _, newAdminRoleItem := range newAdminRole {
+		newAdminRoleRule = append(newAdminRoleRule, newAdminRoleItem)
+	}
+
+	logs, sub, err := _Csaccounting.contract.FilterLogs(opts, "RoleAdminChanged", roleRule, previousAdminRoleRule, newAdminRoleRule)
+	if err != nil {
+		return nil, err
+	}
+	return &CsaccountingRoleAdminChangedIterator{contract: _Csaccounting.contract, event: "RoleAdminChanged", logs: logs, sub: sub}, nil
+}
+
+// WatchRoleAdminChanged is a free log subscription operation binding the contract event 0xbd79b86ffe0ab8e8776151514217cd7cacd52c909f66475c3af44e129f0b00ff.
+//
+// Solidity: event RoleAdminChanged(bytes32 indexed role, bytes32 indexed previousAdminRole, bytes32 indexed newAdminRole)
+func (_Csaccounting *CsaccountingFilterer) WatchRoleAdminChanged(opts *bind.WatchOpts, sink chan<- *CsaccountingRoleAdminChanged, role [][32]byte, previousAdminRole [][32]byte, newAdminRole [][32]byte) (event.Subscription, error) {
+
+	var roleRule []interface{}
+	for _, roleItem := range role {
+		roleRule = append(roleRule, roleItem)
+	}
+	var previousAdminRoleRule []interface{}
+	for _, previousAdminRoleItem := range previousAdminRole {
+		previousAdminRoleRule = append(previousAdminRoleRule, previousAdminRoleItem)
+	}
+	var newAdminRoleRule []interface{}
+	for _, newAdminRoleItem := range newAdminRole {
+		newAdminRoleRule = append(newAdminRoleRule, newAdminRoleItem)
+	}
+
+	logs, sub, err := _Csaccounting.contract.WatchLogs(opts, "RoleAdminChanged", roleRule, previousAdminRoleRule, newAdminRoleRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(CsaccountingRoleAdminChanged)
+				if err := _Csaccounting.contract.UnpackLog(event, "RoleAdminChanged", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseRoleAdminChanged is a log parse operation binding the contract event 0xbd79b86ffe0ab8e8776151514217cd7cacd52c909f66475c3af44e129f0b00ff.
+//
+// Solidity: event RoleAdminChanged(bytes32 indexed role, bytes32 indexed previousAdminRole, bytes32 indexed newAdminRole)
+func (_Csaccounting *CsaccountingFilterer) ParseRoleAdminChanged(log types.Log) (*CsaccountingRoleAdminChanged, error) {
+	event := new(CsaccountingRoleAdminChanged)
+	if err := _Csaccounting.contract.UnpackLog(event, "RoleAdminChanged", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// CsaccountingRoleGrantedIterator is returned from FilterRoleGranted and is used to iterate over the raw logs and unpacked data for RoleGranted events raised by the Csaccounting contract.
+type CsaccountingRoleGrantedIterator struct {
+	Event *CsaccountingRoleGranted // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *CsaccountingRoleGrantedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(CsaccountingRoleGranted)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(CsaccountingRoleGranted)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *CsaccountingRoleGrantedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *CsaccountingRoleGrantedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// CsaccountingRoleGranted represents a RoleGranted event raised by the Csaccounting contract.
+type CsaccountingRoleGranted struct {
+	Role    [32]byte
+	Account common.Address
+	Sender  common.Address
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterRoleGranted is a free log retrieval operation binding the contract event 0x2f8788117e7eff1d82e926ec794901d17c78024a50270940304540a733656f0d.
+//
+// Solidity: event RoleGranted(bytes32 indexed role, address indexed account, address indexed sender)
+func (_Csaccounting *CsaccountingFilterer) FilterRoleGranted(opts *bind.FilterOpts, role [][32]byte, account []common.Address, sender []common.Address) (*CsaccountingRoleGrantedIterator, error) {
+
+	var roleRule []interface{}
+	for _, roleItem := range role {
+		roleRule = append(roleRule, roleItem)
+	}
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var senderRule []interface{}
+	for _, senderItem := range sender {
+		senderRule = append(senderRule, senderItem)
+	}
+
+	logs, sub, err := _Csaccounting.contract.FilterLogs(opts, "RoleGranted", roleRule, accountRule, senderRule)
+	if err != nil {
+		return nil, err
+	}
+	return &CsaccountingRoleGrantedIterator{contract: _Csaccounting.contract, event: "RoleGranted", logs: logs, sub: sub}, nil
+}
+
+// WatchRoleGranted is a free log subscription operation binding the contract event 0x2f8788117e7eff1d82e926ec794901d17c78024a50270940304540a733656f0d.
+//
+// Solidity: event RoleGranted(bytes32 indexed role, address indexed account, address indexed sender)
+func (_Csaccounting *CsaccountingFilterer) WatchRoleGranted(opts *bind.WatchOpts, sink chan<- *CsaccountingRoleGranted, role [][32]byte, account []common.Address, sender []common.Address) (event.Subscription, error) {
+
+	var roleRule []interface{}
+	for _, roleItem := range role {
+		roleRule = append(roleRule, roleItem)
+	}
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var senderRule []interface{}
+	for _, senderItem := range sender {
+		senderRule = append(senderRule, senderItem)
+	}
+
+	logs, sub, err := _Csaccounting.contract.WatchLogs(opts, "RoleGranted", roleRule, accountRule, senderRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(CsaccountingRoleGranted)
+				if err := _Csaccounting.contract.UnpackLog(event, "RoleGranted", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseRoleGranted is a log parse operation binding the contract event 0x2f8788117e7eff1d82e926ec794901d17c78024a50270940304540a733656f0d.
+//
+// Solidity: event RoleGranted(bytes32 indexed role, address indexed account, address indexed sender)
+func (_Csaccounting *CsaccountingFilterer) ParseRoleGranted(log types.Log) (*CsaccountingRoleGranted, error) {
+	event := new(CsaccountingRoleGranted)
+	if err := _Csaccounting.contract.UnpackLog(event, "RoleGranted", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// CsaccountingRoleRevokedIterator is returned from FilterRoleRevoked and is used to iterate over the raw logs and unpacked data for RoleRevoked events raised by the Csaccounting contract.
+type CsaccountingRoleRevokedIterator struct {
+	Event *CsaccountingRoleRevoked // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *CsaccountingRoleRevokedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(CsaccountingRoleRevoked)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(CsaccountingRoleRevoked)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *CsaccountingRoleRevokedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *CsaccountingRoleRevokedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// CsaccountingRoleRevoked represents a RoleRevoked event raised by the Csaccounting contract.
+type CsaccountingRoleRevoked struct {
+	Role    [32]byte
+	Account common.Address
+	Sender  common.Address
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterRoleRevoked is a free log retrieval operation binding the contract event 0xf6391f5c32d9c69d2a47ea670b442974b53935d1edc7fd64eb21e047a839171b.
+//
+// Solidity: event RoleRevoked(bytes32 indexed role, address indexed account, address indexed sender)
+func (_Csaccounting *CsaccountingFilterer) FilterRoleRevoked(opts *bind.FilterOpts, role [][32]byte, account []common.Address, sender []common.Address) (*CsaccountingRoleRevokedIterator, error) {
+
+	var roleRule []interface{}
+	for _, roleItem := range role {
+		roleRule = append(roleRule, roleItem)
+	}
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var senderRule []interface{}
+	for _, senderItem := range sender {
+		senderRule = append(senderRule, senderItem)
+	}
+
+	logs, sub, err := _Csaccounting.contract.FilterLogs(opts, "RoleRevoked", roleRule, accountRule, senderRule)
+	if err != nil {
+		return nil, err
+	}
+	return &CsaccountingRoleRevokedIterator{contract: _Csaccounting.contract, event: "RoleRevoked", logs: logs, sub: sub}, nil
+}
+
+// WatchRoleRevoked is a free log subscription operation binding the contract event 0xf6391f5c32d9c69d2a47ea670b442974b53935d1edc7fd64eb21e047a839171b.
+//
+// Solidity: event RoleRevoked(bytes32 indexed role, address indexed account, address indexed sender)
+func (_Csaccounting *CsaccountingFilterer) WatchRoleRevoked(opts *bind.WatchOpts, sink chan<- *CsaccountingRoleRevoked, role [][32]byte, account []common.Address, sender []common.Address) (event.Subscription, error) {
+
+	var roleRule []interface{}
+	for _, roleItem := range role {
+		roleRule = append(roleRule, roleItem)
+	}
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var senderRule []interface{}
+	for _, senderItem := range sender {
+		senderRule = append(senderRule, senderItem)
+	}
+
+	logs, sub, err := _Csaccounting.contract.WatchLogs(opts, "RoleRevoked", roleRule, accountRule, senderRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(CsaccountingRoleRevoked)
+				if err := _Csaccounting.contract.UnpackLog(event, "RoleRevoked", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseRoleRevoked is a log parse operation binding the contract event 0xf6391f5c32d9c69d2a47ea670b442974b53935d1edc7fd64eb21e047a839171b.
+//
+// Solidity: event RoleRevoked(bytes32 indexed role, address indexed account, address indexed sender)
+func (_Csaccounting *CsaccountingFilterer) ParseRoleRevoked(log types.Log) (*CsaccountingRoleRevoked, error) {
+	event := new(CsaccountingRoleRevoked)
+	if err := _Csaccounting.contract.UnpackLog(event, "RoleRevoked", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// CsaccountingStETHSharesRecoveredIterator is returned from FilterStETHSharesRecovered and is used to iterate over the raw logs and unpacked data for StETHSharesRecovered events raised by the Csaccounting contract.
+type CsaccountingStETHSharesRecoveredIterator struct {
+	Event *CsaccountingStETHSharesRecovered // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *CsaccountingStETHSharesRecoveredIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(CsaccountingStETHSharesRecovered)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(CsaccountingStETHSharesRecovered)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *CsaccountingStETHSharesRecoveredIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *CsaccountingStETHSharesRecoveredIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// CsaccountingStETHSharesRecovered represents a StETHSharesRecovered event raised by the Csaccounting contract.
+type CsaccountingStETHSharesRecovered struct {
+	Recipient common.Address
+	Shares    *big.Int
+	Raw       types.Log // Blockchain specific contextual infos
+}
+
+// FilterStETHSharesRecovered is a free log retrieval operation binding the contract event 0x426e7e0100db57255d4af4a46cd49552ef74f5f002bbdc8d4ebb6371c0070a02.
+//
+// Solidity: event StETHSharesRecovered(address indexed recipient, uint256 shares)
+func (_Csaccounting *CsaccountingFilterer) FilterStETHSharesRecovered(opts *bind.FilterOpts, recipient []common.Address) (*CsaccountingStETHSharesRecoveredIterator, error) {
+
+	var recipientRule []interface{}
+	for _, recipientItem := range recipient {
+		recipientRule = append(recipientRule, recipientItem)
+	}
+
+	logs, sub, err := _Csaccounting.contract.FilterLogs(opts, "StETHSharesRecovered", recipientRule)
+	if err != nil {
+		return nil, err
+	}
+	return &CsaccountingStETHSharesRecoveredIterator{contract: _Csaccounting.contract, event: "StETHSharesRecovered", logs: logs, sub: sub}, nil
+}
+
+// WatchStETHSharesRecovered is a free log subscription operation binding the contract event 0x426e7e0100db57255d4af4a46cd49552ef74f5f002bbdc8d4ebb6371c0070a02.
+//
+// Solidity: event StETHSharesRecovered(address indexed recipient, uint256 shares)
+func (_Csaccounting *CsaccountingFilterer) WatchStETHSharesRecovered(opts *bind.WatchOpts, sink chan<- *CsaccountingStETHSharesRecovered, recipient []common.Address) (event.Subscription, error) {
+
+	var recipientRule []interface{}
+	for _, recipientItem := range recipient {
+		recipientRule = append(recipientRule, recipientItem)
+	}
+
+	logs, sub, err := _Csaccounting.contract.WatchLogs(opts, "StETHSharesRecovered", recipientRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(CsaccountingStETHSharesRecovered)
+				if err := _Csaccounting.contract.UnpackLog(event, "StETHSharesRecovered", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseStETHSharesRecovered is a log parse operation binding the contract event 0x426e7e0100db57255d4af4a46cd49552ef74f5f002bbdc8d4ebb6371c0070a02.
+//
+// Solidity: event StETHSharesRecovered(address indexed recipient, uint256 shares)
+func (_Csaccounting *CsaccountingFilterer) ParseStETHSharesRecovered(log types.Log) (*CsaccountingStETHSharesRecovered, error) {
+	event := new(CsaccountingStETHSharesRecovered)
+	if err := _Csaccounting.contract.UnpackLog(event, "StETHSharesRecovered", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}

--- a/internal/lido/contracts/csfeedistributor/CSFeeDistributor.go
+++ b/internal/lido/contracts/csfeedistributor/CSFeeDistributor.go
@@ -1,0 +1,2598 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package csfeedistributor
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// CsfeedistributorMetaData contains all meta data concerning the Csfeedistributor contract.
+var CsfeedistributorMetaData = &bind.MetaData{
+	ABI: "[{\"inputs\":[{\"internalType\":\"address\",\"name\":\"stETH\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"accounting\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"oracle\",\"type\":\"address\"}],\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"},{\"inputs\":[],\"name\":\"AccessControlBadConfirmation\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"},{\"internalType\":\"bytes32\",\"name\":\"neededRole\",\"type\":\"bytes32\"}],\"name\":\"AccessControlUnauthorizedAccount\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"FailedToSendEther\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"FeeSharesDecrease\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidInitialization\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidProof\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidShares\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidTreeCID\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidTreeRoot\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"NotAccounting\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"NotAllowedToRecover\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"NotEnoughShares\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"NotInitializing\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"NotOracle\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"ZeroAccountingAddress\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"ZeroAdminAddress\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"ZeroOracleAddress\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"ZeroStEthAddress\",\"type\":\"error\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"totalClaimableShares\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"bytes32\",\"name\":\"treeRoot\",\"type\":\"bytes32\"},{\"indexed\":false,\"internalType\":\"string\",\"name\":\"treeCid\",\"type\":\"string\"}],\"name\":\"DistributionDataUpdated\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"token\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"tokenId\",\"type\":\"uint256\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"recipient\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"ERC1155Recovered\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"token\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"recipient\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"ERC20Recovered\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"token\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"tokenId\",\"type\":\"uint256\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"recipient\",\"type\":\"address\"}],\"name\":\"ERC721Recovered\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"recipient\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"EtherRecovered\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"shares\",\"type\":\"uint256\"}],\"name\":\"FeeDistributed\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint64\",\"name\":\"version\",\"type\":\"uint64\"}],\"name\":\"Initialized\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"role\",\"type\":\"bytes32\"},{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"previousAdminRole\",\"type\":\"bytes32\"},{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"newAdminRole\",\"type\":\"bytes32\"}],\"name\":\"RoleAdminChanged\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"role\",\"type\":\"bytes32\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"sender\",\"type\":\"address\"}],\"name\":\"RoleGranted\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"role\",\"type\":\"bytes32\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"sender\",\"type\":\"address\"}],\"name\":\"RoleRevoked\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"recipient\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"shares\",\"type\":\"uint256\"}],\"name\":\"StETHSharesRecovered\",\"type\":\"event\"},{\"inputs\":[],\"name\":\"ACCOUNTING\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"DEFAULT_ADMIN_ROLE\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"ORACLE\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"RECOVERER_ROLE\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"STETH\",\"outputs\":[{\"internalType\":\"contractIStETH\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"shares\",\"type\":\"uint256\"},{\"internalType\":\"bytes32[]\",\"name\":\"proof\",\"type\":\"bytes32[]\"}],\"name\":\"distributeFees\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"sharesToDistribute\",\"type\":\"uint256\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"distributedShares\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"shares\",\"type\":\"uint256\"},{\"internalType\":\"bytes32[]\",\"name\":\"proof\",\"type\":\"bytes32[]\"}],\"name\":\"getFeesToDistribute\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"sharesToDistribute\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"role\",\"type\":\"bytes32\"}],\"name\":\"getRoleAdmin\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"role\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"index\",\"type\":\"uint256\"}],\"name\":\"getRoleMember\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"role\",\"type\":\"bytes32\"}],\"name\":\"getRoleMemberCount\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"role\",\"type\":\"bytes32\"},{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"}],\"name\":\"grantRole\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"role\",\"type\":\"bytes32\"},{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"}],\"name\":\"hasRole\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"shares\",\"type\":\"uint256\"}],\"name\":\"hashLeaf\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"pure\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"admin\",\"type\":\"address\"}],\"name\":\"initialize\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"pendingSharesToDistribute\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"_treeRoot\",\"type\":\"bytes32\"},{\"internalType\":\"string\",\"name\":\"_treeCid\",\"type\":\"string\"},{\"internalType\":\"uint256\",\"name\":\"distributed\",\"type\":\"uint256\"}],\"name\":\"processOracleReport\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"token\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"tokenId\",\"type\":\"uint256\"}],\"name\":\"recoverERC1155\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"token\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"recoverERC20\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"token\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"tokenId\",\"type\":\"uint256\"}],\"name\":\"recoverERC721\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"recoverEther\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"role\",\"type\":\"bytes32\"},{\"internalType\":\"address\",\"name\":\"callerConfirmation\",\"type\":\"address\"}],\"name\":\"renounceRole\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"role\",\"type\":\"bytes32\"},{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"}],\"name\":\"revokeRole\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes4\",\"name\":\"interfaceId\",\"type\":\"bytes4\"}],\"name\":\"supportsInterface\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"totalClaimableShares\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"treeCid\",\"outputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"treeRoot\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"}]",
+	Bin: "0x608060405234801561000f575f80fd5b50600436106101a1575f3560e01c8063819d4cc6116100f3578063c4d66de811610093578063d547741f1161006e578063d547741f146103b7578063e00bfe50146103ca578063ea6301ab146103f1578063fe3c9b9b14610410575f80fd5b8063c4d66de814610389578063ca15c8731461039c578063d257cf2a146103af575f80fd5b806391d14854116100ce57806391d1485414610335578063a217fddf14610348578063acf1c9481461034f578063b66cf05814610376575f80fd5b8063819d4cc6146102fc5780638980f11f1461030f5780639010d07c14610322575f80fd5b806338013f021161015e5780635c654ad9116101395780635c654ad91461029c5780635e8e8f6f146102af5780636dc3f2bd146102c25780637e9f27ad146102e9575f80fd5b806338013f021461024c57806347d17d9d1461028b57806352d8bfc214610294575f80fd5b806301ffc9a7146101a557806314dc6c14146101cd57806321893f7b146101e3578063248a9ca3146101f65780632f2ff15d1461022457806336568abe14610239575b5f80fd5b6101b86101b336600461129e565b610425565b60405190151581526020015b60405180910390f35b6101d55f5481565b6040519081526020016101c4565b6101d56101f13660046112c5565b61044f565b6101d5610204366004611341565b5f9081525f805160206116cc833981519152602052604090206001015490565b610237610232366004611373565b6105e8565b005b610237610247366004611373565b61061e565b6102737f000000000000000000000000af57326c7d513085051b50912d51809ecc5d98ee81565b6040516001600160a01b0390911681526020016101c4565b6101d560035481565b610237610656565b6102376102aa36600461139d565b6106b2565b6101d56102bd3660046112c5565b61072d565b6102737f000000000000000000000000c093e53e8f4b55a223c18a2da6fa00e60dd5efe181565b6101d56102f73660046113c5565b6107a0565b61023761030a36600461139d565b6107f1565b61023761031d36600461139d565b610840565b6102736103303660046113c5565b6108e1565b6101b8610343366004611373565b610919565b6101d55f81565b6101d57fb3e25b5404b87e5a838579cb5d7481d61ad96ee284d38ec1e97c07ba64e7f6fc81565b6102376103843660046113e5565b61094f565b610237610397366004611460565b610b0f565b6101d56103aa366004611341565b610c4d565b6101d5610c8b565b6102376103c5366004611373565b610d26565b6102737f0000000000000000000000003f1c547b21f65e10480de3ad8e19faac46c9503481565b6101d56103ff366004611341565b60026020525f908152604090205481565b610418610d56565b6040516101c49190611479565b5f6001600160e01b03198216635a05180f60e01b1480610449575061044982610de2565b92915050565b5f336001600160a01b037f000000000000000000000000c093e53e8f4b55a223c18a2da6fa00e60dd5efe11614610499576040516318d9f40960e31b815260040160405180910390fd5b6104a58585858561072d565b9050805f036104b557505f6105e0565b8060035410156104d857604051633c57b48560e21b815260040160405180910390fd5b6003805482900390555f858152600260205260409081902080548301905551638fcb4e5b60e01b81526001600160a01b037f000000000000000000000000c093e53e8f4b55a223c18a2da6fa00e60dd5efe181166004830152602482018390527f0000000000000000000000003f1c547b21f65e10480de3ad8e19faac46c950341690638fcb4e5b906044016020604051808303815f875af1158015610580573d5f803e3d5ffd5b505050506040513d601f19601f820116820180604052508101906105a491906114c5565b50847f61930a6c1553eab59d5766da6e1bab8eba982aec848ae7683452f4a6423b6e4a826040516105d791815260200190565b60405180910390a25b949350505050565b5f8281525f805160206116cc833981519152602052604090206001015461060e81610e16565b6106188383610e23565b50505050565b6001600160a01b03811633146106475760405163334bd91960e11b815260040160405180910390fd5b6106518282610e78565b505050565b61065e610ec4565b73a74528edc289b1a597faf83fcff7eff871cc01d96352d8bfc26040518163ffffffff1660e01b81526004015f6040518083038186803b1580156106a0575f80fd5b505af4158015610618573d5f803e3d5ffd5b6106ba610ec4565b604051635c654ad960e01b81526001600160a01b03831660048201526024810182905273a74528edc289b1a597faf83fcff7eff871cc01d990635c654ad9906044015b5f6040518083038186803b158015610713575f80fd5b505af4158015610725573d5f803e3d5ffd5b505050505050565b5f8061074584845f546107408a8a6107a0565b610eef565b905080610765576040516309bde33960e01b815260040160405180910390fd5b5f868152600260205260409020548581111561079457604051636096ce8160e11b815260040160405180910390fd5b90940395945050505050565b60408051602081018490529081018290525f9060600160408051601f198184030181528282528051602091820120908301520160405160208183030381529060405280519060200120905092915050565b6107f9610ec4565b6040516340cea66360e11b81526001600160a01b03831660048201526024810182905273a74528edc289b1a597faf83fcff7eff871cc01d99063819d4cc6906044016106fd565b610848610ec4565b7f0000000000000000000000003f1c547b21f65e10480de3ad8e19faac46c950346001600160a01b0316826001600160a01b03160361089a576040516319efe5d760e21b815260040160405180910390fd5b604051638980f11f60e01b81526001600160a01b03831660048201526024810182905273a74528edc289b1a597faf83fcff7eff871cc01d990638980f11f906044016106fd565b5f8281527fc1f6fe24621ce81ec5827caf0253cadb74709b061630e6b55e823717059320006020819052604082206105e09084610f06565b5f9182525f805160206116cc833981519152602090815260408084206001600160a01b0393909316845291905290205460ff1690565b336001600160a01b037f000000000000000000000000af57326c7d513085051b50912d51809ecc5d98ee161461099857604051631bc2178f60e01b815260040160405180910390fd5b604051633d7ad0b760e21b81523060048201527f0000000000000000000000003f1c547b21f65e10480de3ad8e19faac46c950346001600160a01b03169063f5eb42dc90602401602060405180830381865afa1580156109fa573d5f803e3d5ffd5b505050506040513d601f19601f82011682018060405250810190610a1e91906114c5565b81600354610a2c91906114f0565b1115610a4b57604051636edcc52360e01b815260040160405180910390fd5b8015610618575f829003610a71576040516272916d60e51b815260040160405180910390fd5b83610a8f576040516357e86a3360e01b815260040160405180910390fd5b5f548403610ab0576040516357e86a3360e01b815260040160405180910390fd5b60038054820190555f8490556001610ac983858361159a565b507f26dec7cc117e9b3907dc1f90d2dc5f6e04dbb9f285f5898be2c82ec524dcd424600354858585604051610b019493929190611654565b60405180910390a150505050565b7ff0c57e16840df040f15088dc2f81fe391c3923bec73e23a9662efc9c229c6a008054600160401b810460ff16159067ffffffffffffffff165f81158015610b545750825b90505f8267ffffffffffffffff166001148015610b705750303b155b905081158015610b7e575080155b15610b9c5760405163f92ee8a960e01b815260040160405180910390fd5b845467ffffffffffffffff191660011785558315610bc657845460ff60401b1916600160401b1785555b610bce610f11565b6001600160a01b038616610bf557604051633ef39b8160e01b815260040160405180910390fd5b610bff5f87610e23565b50831561072557845460ff60401b19168555604051600181527fc7f505b2f371ae2175ee4913f4499e1f2633a7b5936321eed1cdaeb6115181d29060200160405180910390a1505050505050565b5f8181527fc1f6fe24621ce81ec5827caf0253cadb74709b061630e6b55e82371705932000602081905260408220610c8490610f19565b9392505050565b600354604051633d7ad0b760e21b81523060048201525f91906001600160a01b037f0000000000000000000000003f1c547b21f65e10480de3ad8e19faac46c95034169063f5eb42dc90602401602060405180830381865afa158015610cf3573d5f803e3d5ffd5b505050506040513d601f19601f82011682018060405250810190610d1791906114c5565b610d219190611690565b905090565b5f8281525f805160206116cc8339815191526020526040902060010154610d4c81610e16565b6106188383610e78565b60018054610d6390611517565b80601f0160208091040260200160405190810160405280929190818152602001828054610d8f90611517565b8015610dda5780601f10610db157610100808354040283529160200191610dda565b820191905f5260205f20905b815481529060010190602001808311610dbd57829003601f168201915b505050505081565b5f6001600160e01b03198216637965db0b60e01b148061044957506301ffc9a760e01b6001600160e01b0319831614610449565b610e208133610f22565b50565b5f7fc1f6fe24621ce81ec5827caf0253cadb74709b061630e6b55e8237170593200081610e508585610f63565b905080156105e0575f858152602083905260409020610e6f9085611004565b50949350505050565b5f7fc1f6fe24621ce81ec5827caf0253cadb74709b061630e6b55e8237170593200081610ea58585611018565b905080156105e0575f858152602083905260409020610e6f9085611091565b610eed7fb3e25b5404b87e5a838579cb5d7481d61ad96ee284d38ec1e97c07ba64e7f6fc610e16565b565b5f82610efc8686856110a5565b1495945050505050565b5f610c8483836110dd565b610eed611103565b5f610449825490565b610f2c8282610919565b610f5f5760405163e2517d3f60e01b81526001600160a01b03821660048201526024810183905260440160405180910390fd5b5050565b5f5f805160206116cc833981519152610f7c8484610919565b610ffb575f848152602082815260408083206001600160a01b03871684529091529020805460ff19166001179055610fb13390565b6001600160a01b0316836001600160a01b0316857f2f8788117e7eff1d82e926ec794901d17c78024a50270940304540a733656f0d60405160405180910390a46001915050610449565b5f915050610449565b5f610c84836001600160a01b03841661114c565b5f5f805160206116cc8339815191526110318484610919565b15610ffb575f848152602082815260408083206001600160a01b0387168085529252808320805460ff1916905551339287917ff6391f5c32d9c69d2a47ea670b442974b53935d1edc7fd64eb21e047a839171b9190a46001915050610449565b5f610c84836001600160a01b038416611198565b5f81815b84811015610e6f576110d3828787848181106110c7576110c76116a3565b90506020020135611272565b91506001016110a9565b5f825f0182815481106110f2576110f26116a3565b905f5260205f200154905092915050565b7ff0c57e16840df040f15088dc2f81fe391c3923bec73e23a9662efc9c229c6a0054600160401b900460ff16610eed57604051631afcd79f60e31b815260040160405180910390fd5b5f81815260018301602052604081205461119157508154600181810184555f848152602080822090930184905584548482528286019093526040902091909155610449565b505f610449565b5f8181526001830160205260408120548015610ffb575f6111ba600183611690565b85549091505f906111cd90600190611690565b905080821461122c575f865f0182815481106111eb576111eb6116a3565b905f5260205f200154905080875f01848154811061120b5761120b6116a3565b5f918252602080832090910192909255918252600188019052604090208390555b855486908061123d5761123d6116b7565b600190038181905f5260205f20015f90559055856001015f8681526020019081526020015f205f905560019350505050610449565b5f81831061128c575f828152602084905260409020610c84565b5f838152602083905260409020610c84565b5f602082840312156112ae575f80fd5b81356001600160e01b031981168114610c84575f80fd5b5f805f80606085870312156112d8575f80fd5b8435935060208501359250604085013567ffffffffffffffff808211156112fd575f80fd5b818701915087601f830112611310575f80fd5b81358181111561131e575f80fd5b8860208260051b8501011115611332575f80fd5b95989497505060200194505050565b5f60208284031215611351575f80fd5b5035919050565b80356001600160a01b038116811461136e575f80fd5b919050565b5f8060408385031215611384575f80fd5b8235915061139460208401611358565b90509250929050565b5f80604083850312156113ae575f80fd5b6113b783611358565b946020939093013593505050565b5f80604083850312156113d6575f80fd5b50508035926020909101359150565b5f805f80606085870312156113f8575f80fd5b84359350602085013567ffffffffffffffff80821115611416575f80fd5b818701915087601f830112611429575f80fd5b813581811115611437575f80fd5b886020828501011115611448575f80fd5b95986020929092019750949560400135945092505050565b5f60208284031215611470575f80fd5b610c8482611358565b5f602080835283518060208501525f5b818110156114a557858101830151858201604001528201611489565b505f604082860101526040601f19601f8301168501019250505092915050565b5f602082840312156114d5575f80fd5b5051919050565b634e487b7160e01b5f52601160045260245ffd5b80820180821115610449576104496114dc565b634e487b7160e01b5f52604160045260245ffd5b600181811c9082168061152b57607f821691505b60208210810361154957634e487b7160e01b5f52602260045260245ffd5b50919050565b601f82111561065157805f5260205f20601f840160051c810160208510156115745750805b601f840160051c820191505b81811015611593575f8155600101611580565b5050505050565b67ffffffffffffffff8311156115b2576115b2611503565b6115c6836115c08354611517565b8361154f565b5f601f8411600181146115f7575f85156115e05750838201355b5f19600387901b1c1916600186901b178355611593565b5f83815260208120601f198716915b828110156116265786850135825560209485019460019092019101611606565b5086821015611642575f1960f88860031b161c19848701351681555b505060018560011b0183555050505050565b84815283602082015260606040820152816060820152818360808301375f818301608090810191909152601f909201601f191601019392505050565b81810381811115610449576104496114dc565b634e487b7160e01b5f52603260045260245ffd5b634e487b7160e01b5f52603160045260245ffdfe02dd7bc7dec4dceedda775e58dd541e08a116c6c53815c0bd028192f7b626800a164736f6c6343000818000a",
+}
+
+// CsfeedistributorABI is the input ABI used to generate the binding from.
+// Deprecated: Use CsfeedistributorMetaData.ABI instead.
+var CsfeedistributorABI = CsfeedistributorMetaData.ABI
+
+// CsfeedistributorBin is the compiled bytecode used for deploying new contracts.
+// Deprecated: Use CsfeedistributorMetaData.Bin instead.
+var CsfeedistributorBin = CsfeedistributorMetaData.Bin
+
+// DeployCsfeedistributor deploys a new Ethereum contract, binding an instance of Csfeedistributor to it.
+func DeployCsfeedistributor(auth *bind.TransactOpts, backend bind.ContractBackend, stETH common.Address, accounting common.Address, oracle common.Address) (common.Address, *types.Transaction, *Csfeedistributor, error) {
+	parsed, err := CsfeedistributorMetaData.GetAbi()
+	if err != nil {
+		return common.Address{}, nil, nil, err
+	}
+	if parsed == nil {
+		return common.Address{}, nil, nil, errors.New("GetABI returned nil")
+	}
+
+	address, tx, contract, err := bind.DeployContract(auth, *parsed, common.FromHex(CsfeedistributorBin), backend, stETH, accounting, oracle)
+	if err != nil {
+		return common.Address{}, nil, nil, err
+	}
+	return address, tx, &Csfeedistributor{CsfeedistributorCaller: CsfeedistributorCaller{contract: contract}, CsfeedistributorTransactor: CsfeedistributorTransactor{contract: contract}, CsfeedistributorFilterer: CsfeedistributorFilterer{contract: contract}}, nil
+}
+
+// Csfeedistributor is an auto generated Go binding around an Ethereum contract.
+type Csfeedistributor struct {
+	CsfeedistributorCaller     // Read-only binding to the contract
+	CsfeedistributorTransactor // Write-only binding to the contract
+	CsfeedistributorFilterer   // Log filterer for contract events
+}
+
+// CsfeedistributorCaller is an auto generated read-only Go binding around an Ethereum contract.
+type CsfeedistributorCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// CsfeedistributorTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type CsfeedistributorTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// CsfeedistributorFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type CsfeedistributorFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// CsfeedistributorSession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type CsfeedistributorSession struct {
+	Contract     *Csfeedistributor // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// CsfeedistributorCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type CsfeedistributorCallerSession struct {
+	Contract *CsfeedistributorCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts           // Call options to use throughout this session
+}
+
+// CsfeedistributorTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type CsfeedistributorTransactorSession struct {
+	Contract     *CsfeedistributorTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts           // Transaction auth options to use throughout this session
+}
+
+// CsfeedistributorRaw is an auto generated low-level Go binding around an Ethereum contract.
+type CsfeedistributorRaw struct {
+	Contract *Csfeedistributor // Generic contract binding to access the raw methods on
+}
+
+// CsfeedistributorCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type CsfeedistributorCallerRaw struct {
+	Contract *CsfeedistributorCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// CsfeedistributorTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type CsfeedistributorTransactorRaw struct {
+	Contract *CsfeedistributorTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewCsfeedistributor creates a new instance of Csfeedistributor, bound to a specific deployed contract.
+func NewCsfeedistributor(address common.Address, backend bind.ContractBackend) (*Csfeedistributor, error) {
+	contract, err := bindCsfeedistributor(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &Csfeedistributor{CsfeedistributorCaller: CsfeedistributorCaller{contract: contract}, CsfeedistributorTransactor: CsfeedistributorTransactor{contract: contract}, CsfeedistributorFilterer: CsfeedistributorFilterer{contract: contract}}, nil
+}
+
+// NewCsfeedistributorCaller creates a new read-only instance of Csfeedistributor, bound to a specific deployed contract.
+func NewCsfeedistributorCaller(address common.Address, caller bind.ContractCaller) (*CsfeedistributorCaller, error) {
+	contract, err := bindCsfeedistributor(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &CsfeedistributorCaller{contract: contract}, nil
+}
+
+// NewCsfeedistributorTransactor creates a new write-only instance of Csfeedistributor, bound to a specific deployed contract.
+func NewCsfeedistributorTransactor(address common.Address, transactor bind.ContractTransactor) (*CsfeedistributorTransactor, error) {
+	contract, err := bindCsfeedistributor(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &CsfeedistributorTransactor{contract: contract}, nil
+}
+
+// NewCsfeedistributorFilterer creates a new log filterer instance of Csfeedistributor, bound to a specific deployed contract.
+func NewCsfeedistributorFilterer(address common.Address, filterer bind.ContractFilterer) (*CsfeedistributorFilterer, error) {
+	contract, err := bindCsfeedistributor(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &CsfeedistributorFilterer{contract: contract}, nil
+}
+
+// bindCsfeedistributor binds a generic wrapper to an already deployed contract.
+func bindCsfeedistributor(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := CsfeedistributorMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_Csfeedistributor *CsfeedistributorRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _Csfeedistributor.Contract.CsfeedistributorCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_Csfeedistributor *CsfeedistributorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Csfeedistributor.Contract.CsfeedistributorTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_Csfeedistributor *CsfeedistributorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _Csfeedistributor.Contract.CsfeedistributorTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_Csfeedistributor *CsfeedistributorCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _Csfeedistributor.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_Csfeedistributor *CsfeedistributorTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Csfeedistributor.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_Csfeedistributor *CsfeedistributorTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _Csfeedistributor.Contract.contract.Transact(opts, method, params...)
+}
+
+// ACCOUNTING is a free data retrieval call binding the contract method 0x6dc3f2bd.
+//
+// Solidity: function ACCOUNTING() view returns(address)
+func (_Csfeedistributor *CsfeedistributorCaller) ACCOUNTING(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _Csfeedistributor.contract.Call(opts, &out, "ACCOUNTING")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// ACCOUNTING is a free data retrieval call binding the contract method 0x6dc3f2bd.
+//
+// Solidity: function ACCOUNTING() view returns(address)
+func (_Csfeedistributor *CsfeedistributorSession) ACCOUNTING() (common.Address, error) {
+	return _Csfeedistributor.Contract.ACCOUNTING(&_Csfeedistributor.CallOpts)
+}
+
+// ACCOUNTING is a free data retrieval call binding the contract method 0x6dc3f2bd.
+//
+// Solidity: function ACCOUNTING() view returns(address)
+func (_Csfeedistributor *CsfeedistributorCallerSession) ACCOUNTING() (common.Address, error) {
+	return _Csfeedistributor.Contract.ACCOUNTING(&_Csfeedistributor.CallOpts)
+}
+
+// DEFAULTADMINROLE is a free data retrieval call binding the contract method 0xa217fddf.
+//
+// Solidity: function DEFAULT_ADMIN_ROLE() view returns(bytes32)
+func (_Csfeedistributor *CsfeedistributorCaller) DEFAULTADMINROLE(opts *bind.CallOpts) ([32]byte, error) {
+	var out []interface{}
+	err := _Csfeedistributor.contract.Call(opts, &out, "DEFAULT_ADMIN_ROLE")
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// DEFAULTADMINROLE is a free data retrieval call binding the contract method 0xa217fddf.
+//
+// Solidity: function DEFAULT_ADMIN_ROLE() view returns(bytes32)
+func (_Csfeedistributor *CsfeedistributorSession) DEFAULTADMINROLE() ([32]byte, error) {
+	return _Csfeedistributor.Contract.DEFAULTADMINROLE(&_Csfeedistributor.CallOpts)
+}
+
+// DEFAULTADMINROLE is a free data retrieval call binding the contract method 0xa217fddf.
+//
+// Solidity: function DEFAULT_ADMIN_ROLE() view returns(bytes32)
+func (_Csfeedistributor *CsfeedistributorCallerSession) DEFAULTADMINROLE() ([32]byte, error) {
+	return _Csfeedistributor.Contract.DEFAULTADMINROLE(&_Csfeedistributor.CallOpts)
+}
+
+// ORACLE is a free data retrieval call binding the contract method 0x38013f02.
+//
+// Solidity: function ORACLE() view returns(address)
+func (_Csfeedistributor *CsfeedistributorCaller) ORACLE(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _Csfeedistributor.contract.Call(opts, &out, "ORACLE")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// ORACLE is a free data retrieval call binding the contract method 0x38013f02.
+//
+// Solidity: function ORACLE() view returns(address)
+func (_Csfeedistributor *CsfeedistributorSession) ORACLE() (common.Address, error) {
+	return _Csfeedistributor.Contract.ORACLE(&_Csfeedistributor.CallOpts)
+}
+
+// ORACLE is a free data retrieval call binding the contract method 0x38013f02.
+//
+// Solidity: function ORACLE() view returns(address)
+func (_Csfeedistributor *CsfeedistributorCallerSession) ORACLE() (common.Address, error) {
+	return _Csfeedistributor.Contract.ORACLE(&_Csfeedistributor.CallOpts)
+}
+
+// RECOVERERROLE is a free data retrieval call binding the contract method 0xacf1c948.
+//
+// Solidity: function RECOVERER_ROLE() view returns(bytes32)
+func (_Csfeedistributor *CsfeedistributorCaller) RECOVERERROLE(opts *bind.CallOpts) ([32]byte, error) {
+	var out []interface{}
+	err := _Csfeedistributor.contract.Call(opts, &out, "RECOVERER_ROLE")
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// RECOVERERROLE is a free data retrieval call binding the contract method 0xacf1c948.
+//
+// Solidity: function RECOVERER_ROLE() view returns(bytes32)
+func (_Csfeedistributor *CsfeedistributorSession) RECOVERERROLE() ([32]byte, error) {
+	return _Csfeedistributor.Contract.RECOVERERROLE(&_Csfeedistributor.CallOpts)
+}
+
+// RECOVERERROLE is a free data retrieval call binding the contract method 0xacf1c948.
+//
+// Solidity: function RECOVERER_ROLE() view returns(bytes32)
+func (_Csfeedistributor *CsfeedistributorCallerSession) RECOVERERROLE() ([32]byte, error) {
+	return _Csfeedistributor.Contract.RECOVERERROLE(&_Csfeedistributor.CallOpts)
+}
+
+// STETH is a free data retrieval call binding the contract method 0xe00bfe50.
+//
+// Solidity: function STETH() view returns(address)
+func (_Csfeedistributor *CsfeedistributorCaller) STETH(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _Csfeedistributor.contract.Call(opts, &out, "STETH")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// STETH is a free data retrieval call binding the contract method 0xe00bfe50.
+//
+// Solidity: function STETH() view returns(address)
+func (_Csfeedistributor *CsfeedistributorSession) STETH() (common.Address, error) {
+	return _Csfeedistributor.Contract.STETH(&_Csfeedistributor.CallOpts)
+}
+
+// STETH is a free data retrieval call binding the contract method 0xe00bfe50.
+//
+// Solidity: function STETH() view returns(address)
+func (_Csfeedistributor *CsfeedistributorCallerSession) STETH() (common.Address, error) {
+	return _Csfeedistributor.Contract.STETH(&_Csfeedistributor.CallOpts)
+}
+
+// DistributedShares is a free data retrieval call binding the contract method 0xea6301ab.
+//
+// Solidity: function distributedShares(uint256 ) view returns(uint256)
+func (_Csfeedistributor *CsfeedistributorCaller) DistributedShares(opts *bind.CallOpts, arg0 *big.Int) (*big.Int, error) {
+	var out []interface{}
+	err := _Csfeedistributor.contract.Call(opts, &out, "distributedShares", arg0)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// DistributedShares is a free data retrieval call binding the contract method 0xea6301ab.
+//
+// Solidity: function distributedShares(uint256 ) view returns(uint256)
+func (_Csfeedistributor *CsfeedistributorSession) DistributedShares(arg0 *big.Int) (*big.Int, error) {
+	return _Csfeedistributor.Contract.DistributedShares(&_Csfeedistributor.CallOpts, arg0)
+}
+
+// DistributedShares is a free data retrieval call binding the contract method 0xea6301ab.
+//
+// Solidity: function distributedShares(uint256 ) view returns(uint256)
+func (_Csfeedistributor *CsfeedistributorCallerSession) DistributedShares(arg0 *big.Int) (*big.Int, error) {
+	return _Csfeedistributor.Contract.DistributedShares(&_Csfeedistributor.CallOpts, arg0)
+}
+
+// GetFeesToDistribute is a free data retrieval call binding the contract method 0x5e8e8f6f.
+//
+// Solidity: function getFeesToDistribute(uint256 nodeOperatorId, uint256 shares, bytes32[] proof) view returns(uint256 sharesToDistribute)
+func (_Csfeedistributor *CsfeedistributorCaller) GetFeesToDistribute(opts *bind.CallOpts, nodeOperatorId *big.Int, shares *big.Int, proof [][32]byte) (*big.Int, error) {
+	var out []interface{}
+	err := _Csfeedistributor.contract.Call(opts, &out, "getFeesToDistribute", nodeOperatorId, shares, proof)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// GetFeesToDistribute is a free data retrieval call binding the contract method 0x5e8e8f6f.
+//
+// Solidity: function getFeesToDistribute(uint256 nodeOperatorId, uint256 shares, bytes32[] proof) view returns(uint256 sharesToDistribute)
+func (_Csfeedistributor *CsfeedistributorSession) GetFeesToDistribute(nodeOperatorId *big.Int, shares *big.Int, proof [][32]byte) (*big.Int, error) {
+	return _Csfeedistributor.Contract.GetFeesToDistribute(&_Csfeedistributor.CallOpts, nodeOperatorId, shares, proof)
+}
+
+// GetFeesToDistribute is a free data retrieval call binding the contract method 0x5e8e8f6f.
+//
+// Solidity: function getFeesToDistribute(uint256 nodeOperatorId, uint256 shares, bytes32[] proof) view returns(uint256 sharesToDistribute)
+func (_Csfeedistributor *CsfeedistributorCallerSession) GetFeesToDistribute(nodeOperatorId *big.Int, shares *big.Int, proof [][32]byte) (*big.Int, error) {
+	return _Csfeedistributor.Contract.GetFeesToDistribute(&_Csfeedistributor.CallOpts, nodeOperatorId, shares, proof)
+}
+
+// GetRoleAdmin is a free data retrieval call binding the contract method 0x248a9ca3.
+//
+// Solidity: function getRoleAdmin(bytes32 role) view returns(bytes32)
+func (_Csfeedistributor *CsfeedistributorCaller) GetRoleAdmin(opts *bind.CallOpts, role [32]byte) ([32]byte, error) {
+	var out []interface{}
+	err := _Csfeedistributor.contract.Call(opts, &out, "getRoleAdmin", role)
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// GetRoleAdmin is a free data retrieval call binding the contract method 0x248a9ca3.
+//
+// Solidity: function getRoleAdmin(bytes32 role) view returns(bytes32)
+func (_Csfeedistributor *CsfeedistributorSession) GetRoleAdmin(role [32]byte) ([32]byte, error) {
+	return _Csfeedistributor.Contract.GetRoleAdmin(&_Csfeedistributor.CallOpts, role)
+}
+
+// GetRoleAdmin is a free data retrieval call binding the contract method 0x248a9ca3.
+//
+// Solidity: function getRoleAdmin(bytes32 role) view returns(bytes32)
+func (_Csfeedistributor *CsfeedistributorCallerSession) GetRoleAdmin(role [32]byte) ([32]byte, error) {
+	return _Csfeedistributor.Contract.GetRoleAdmin(&_Csfeedistributor.CallOpts, role)
+}
+
+// GetRoleMember is a free data retrieval call binding the contract method 0x9010d07c.
+//
+// Solidity: function getRoleMember(bytes32 role, uint256 index) view returns(address)
+func (_Csfeedistributor *CsfeedistributorCaller) GetRoleMember(opts *bind.CallOpts, role [32]byte, index *big.Int) (common.Address, error) {
+	var out []interface{}
+	err := _Csfeedistributor.contract.Call(opts, &out, "getRoleMember", role, index)
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// GetRoleMember is a free data retrieval call binding the contract method 0x9010d07c.
+//
+// Solidity: function getRoleMember(bytes32 role, uint256 index) view returns(address)
+func (_Csfeedistributor *CsfeedistributorSession) GetRoleMember(role [32]byte, index *big.Int) (common.Address, error) {
+	return _Csfeedistributor.Contract.GetRoleMember(&_Csfeedistributor.CallOpts, role, index)
+}
+
+// GetRoleMember is a free data retrieval call binding the contract method 0x9010d07c.
+//
+// Solidity: function getRoleMember(bytes32 role, uint256 index) view returns(address)
+func (_Csfeedistributor *CsfeedistributorCallerSession) GetRoleMember(role [32]byte, index *big.Int) (common.Address, error) {
+	return _Csfeedistributor.Contract.GetRoleMember(&_Csfeedistributor.CallOpts, role, index)
+}
+
+// GetRoleMemberCount is a free data retrieval call binding the contract method 0xca15c873.
+//
+// Solidity: function getRoleMemberCount(bytes32 role) view returns(uint256)
+func (_Csfeedistributor *CsfeedistributorCaller) GetRoleMemberCount(opts *bind.CallOpts, role [32]byte) (*big.Int, error) {
+	var out []interface{}
+	err := _Csfeedistributor.contract.Call(opts, &out, "getRoleMemberCount", role)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// GetRoleMemberCount is a free data retrieval call binding the contract method 0xca15c873.
+//
+// Solidity: function getRoleMemberCount(bytes32 role) view returns(uint256)
+func (_Csfeedistributor *CsfeedistributorSession) GetRoleMemberCount(role [32]byte) (*big.Int, error) {
+	return _Csfeedistributor.Contract.GetRoleMemberCount(&_Csfeedistributor.CallOpts, role)
+}
+
+// GetRoleMemberCount is a free data retrieval call binding the contract method 0xca15c873.
+//
+// Solidity: function getRoleMemberCount(bytes32 role) view returns(uint256)
+func (_Csfeedistributor *CsfeedistributorCallerSession) GetRoleMemberCount(role [32]byte) (*big.Int, error) {
+	return _Csfeedistributor.Contract.GetRoleMemberCount(&_Csfeedistributor.CallOpts, role)
+}
+
+// HasRole is a free data retrieval call binding the contract method 0x91d14854.
+//
+// Solidity: function hasRole(bytes32 role, address account) view returns(bool)
+func (_Csfeedistributor *CsfeedistributorCaller) HasRole(opts *bind.CallOpts, role [32]byte, account common.Address) (bool, error) {
+	var out []interface{}
+	err := _Csfeedistributor.contract.Call(opts, &out, "hasRole", role, account)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// HasRole is a free data retrieval call binding the contract method 0x91d14854.
+//
+// Solidity: function hasRole(bytes32 role, address account) view returns(bool)
+func (_Csfeedistributor *CsfeedistributorSession) HasRole(role [32]byte, account common.Address) (bool, error) {
+	return _Csfeedistributor.Contract.HasRole(&_Csfeedistributor.CallOpts, role, account)
+}
+
+// HasRole is a free data retrieval call binding the contract method 0x91d14854.
+//
+// Solidity: function hasRole(bytes32 role, address account) view returns(bool)
+func (_Csfeedistributor *CsfeedistributorCallerSession) HasRole(role [32]byte, account common.Address) (bool, error) {
+	return _Csfeedistributor.Contract.HasRole(&_Csfeedistributor.CallOpts, role, account)
+}
+
+// HashLeaf is a free data retrieval call binding the contract method 0x7e9f27ad.
+//
+// Solidity: function hashLeaf(uint256 nodeOperatorId, uint256 shares) pure returns(bytes32)
+func (_Csfeedistributor *CsfeedistributorCaller) HashLeaf(opts *bind.CallOpts, nodeOperatorId *big.Int, shares *big.Int) ([32]byte, error) {
+	var out []interface{}
+	err := _Csfeedistributor.contract.Call(opts, &out, "hashLeaf", nodeOperatorId, shares)
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// HashLeaf is a free data retrieval call binding the contract method 0x7e9f27ad.
+//
+// Solidity: function hashLeaf(uint256 nodeOperatorId, uint256 shares) pure returns(bytes32)
+func (_Csfeedistributor *CsfeedistributorSession) HashLeaf(nodeOperatorId *big.Int, shares *big.Int) ([32]byte, error) {
+	return _Csfeedistributor.Contract.HashLeaf(&_Csfeedistributor.CallOpts, nodeOperatorId, shares)
+}
+
+// HashLeaf is a free data retrieval call binding the contract method 0x7e9f27ad.
+//
+// Solidity: function hashLeaf(uint256 nodeOperatorId, uint256 shares) pure returns(bytes32)
+func (_Csfeedistributor *CsfeedistributorCallerSession) HashLeaf(nodeOperatorId *big.Int, shares *big.Int) ([32]byte, error) {
+	return _Csfeedistributor.Contract.HashLeaf(&_Csfeedistributor.CallOpts, nodeOperatorId, shares)
+}
+
+// PendingSharesToDistribute is a free data retrieval call binding the contract method 0xd257cf2a.
+//
+// Solidity: function pendingSharesToDistribute() view returns(uint256)
+func (_Csfeedistributor *CsfeedistributorCaller) PendingSharesToDistribute(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _Csfeedistributor.contract.Call(opts, &out, "pendingSharesToDistribute")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// PendingSharesToDistribute is a free data retrieval call binding the contract method 0xd257cf2a.
+//
+// Solidity: function pendingSharesToDistribute() view returns(uint256)
+func (_Csfeedistributor *CsfeedistributorSession) PendingSharesToDistribute() (*big.Int, error) {
+	return _Csfeedistributor.Contract.PendingSharesToDistribute(&_Csfeedistributor.CallOpts)
+}
+
+// PendingSharesToDistribute is a free data retrieval call binding the contract method 0xd257cf2a.
+//
+// Solidity: function pendingSharesToDistribute() view returns(uint256)
+func (_Csfeedistributor *CsfeedistributorCallerSession) PendingSharesToDistribute() (*big.Int, error) {
+	return _Csfeedistributor.Contract.PendingSharesToDistribute(&_Csfeedistributor.CallOpts)
+}
+
+// SupportsInterface is a free data retrieval call binding the contract method 0x01ffc9a7.
+//
+// Solidity: function supportsInterface(bytes4 interfaceId) view returns(bool)
+func (_Csfeedistributor *CsfeedistributorCaller) SupportsInterface(opts *bind.CallOpts, interfaceId [4]byte) (bool, error) {
+	var out []interface{}
+	err := _Csfeedistributor.contract.Call(opts, &out, "supportsInterface", interfaceId)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// SupportsInterface is a free data retrieval call binding the contract method 0x01ffc9a7.
+//
+// Solidity: function supportsInterface(bytes4 interfaceId) view returns(bool)
+func (_Csfeedistributor *CsfeedistributorSession) SupportsInterface(interfaceId [4]byte) (bool, error) {
+	return _Csfeedistributor.Contract.SupportsInterface(&_Csfeedistributor.CallOpts, interfaceId)
+}
+
+// SupportsInterface is a free data retrieval call binding the contract method 0x01ffc9a7.
+//
+// Solidity: function supportsInterface(bytes4 interfaceId) view returns(bool)
+func (_Csfeedistributor *CsfeedistributorCallerSession) SupportsInterface(interfaceId [4]byte) (bool, error) {
+	return _Csfeedistributor.Contract.SupportsInterface(&_Csfeedistributor.CallOpts, interfaceId)
+}
+
+// TotalClaimableShares is a free data retrieval call binding the contract method 0x47d17d9d.
+//
+// Solidity: function totalClaimableShares() view returns(uint256)
+func (_Csfeedistributor *CsfeedistributorCaller) TotalClaimableShares(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _Csfeedistributor.contract.Call(opts, &out, "totalClaimableShares")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// TotalClaimableShares is a free data retrieval call binding the contract method 0x47d17d9d.
+//
+// Solidity: function totalClaimableShares() view returns(uint256)
+func (_Csfeedistributor *CsfeedistributorSession) TotalClaimableShares() (*big.Int, error) {
+	return _Csfeedistributor.Contract.TotalClaimableShares(&_Csfeedistributor.CallOpts)
+}
+
+// TotalClaimableShares is a free data retrieval call binding the contract method 0x47d17d9d.
+//
+// Solidity: function totalClaimableShares() view returns(uint256)
+func (_Csfeedistributor *CsfeedistributorCallerSession) TotalClaimableShares() (*big.Int, error) {
+	return _Csfeedistributor.Contract.TotalClaimableShares(&_Csfeedistributor.CallOpts)
+}
+
+// TreeCid is a free data retrieval call binding the contract method 0xfe3c9b9b.
+//
+// Solidity: function treeCid() view returns(string)
+func (_Csfeedistributor *CsfeedistributorCaller) TreeCid(opts *bind.CallOpts) (string, error) {
+	var out []interface{}
+	err := _Csfeedistributor.contract.Call(opts, &out, "treeCid")
+
+	if err != nil {
+		return *new(string), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(string)).(*string)
+
+	return out0, err
+
+}
+
+// TreeCid is a free data retrieval call binding the contract method 0xfe3c9b9b.
+//
+// Solidity: function treeCid() view returns(string)
+func (_Csfeedistributor *CsfeedistributorSession) TreeCid() (string, error) {
+	return _Csfeedistributor.Contract.TreeCid(&_Csfeedistributor.CallOpts)
+}
+
+// TreeCid is a free data retrieval call binding the contract method 0xfe3c9b9b.
+//
+// Solidity: function treeCid() view returns(string)
+func (_Csfeedistributor *CsfeedistributorCallerSession) TreeCid() (string, error) {
+	return _Csfeedistributor.Contract.TreeCid(&_Csfeedistributor.CallOpts)
+}
+
+// TreeRoot is a free data retrieval call binding the contract method 0x14dc6c14.
+//
+// Solidity: function treeRoot() view returns(bytes32)
+func (_Csfeedistributor *CsfeedistributorCaller) TreeRoot(opts *bind.CallOpts) ([32]byte, error) {
+	var out []interface{}
+	err := _Csfeedistributor.contract.Call(opts, &out, "treeRoot")
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// TreeRoot is a free data retrieval call binding the contract method 0x14dc6c14.
+//
+// Solidity: function treeRoot() view returns(bytes32)
+func (_Csfeedistributor *CsfeedistributorSession) TreeRoot() ([32]byte, error) {
+	return _Csfeedistributor.Contract.TreeRoot(&_Csfeedistributor.CallOpts)
+}
+
+// TreeRoot is a free data retrieval call binding the contract method 0x14dc6c14.
+//
+// Solidity: function treeRoot() view returns(bytes32)
+func (_Csfeedistributor *CsfeedistributorCallerSession) TreeRoot() ([32]byte, error) {
+	return _Csfeedistributor.Contract.TreeRoot(&_Csfeedistributor.CallOpts)
+}
+
+// DistributeFees is a paid mutator transaction binding the contract method 0x21893f7b.
+//
+// Solidity: function distributeFees(uint256 nodeOperatorId, uint256 shares, bytes32[] proof) returns(uint256 sharesToDistribute)
+func (_Csfeedistributor *CsfeedistributorTransactor) DistributeFees(opts *bind.TransactOpts, nodeOperatorId *big.Int, shares *big.Int, proof [][32]byte) (*types.Transaction, error) {
+	return _Csfeedistributor.contract.Transact(opts, "distributeFees", nodeOperatorId, shares, proof)
+}
+
+// DistributeFees is a paid mutator transaction binding the contract method 0x21893f7b.
+//
+// Solidity: function distributeFees(uint256 nodeOperatorId, uint256 shares, bytes32[] proof) returns(uint256 sharesToDistribute)
+func (_Csfeedistributor *CsfeedistributorSession) DistributeFees(nodeOperatorId *big.Int, shares *big.Int, proof [][32]byte) (*types.Transaction, error) {
+	return _Csfeedistributor.Contract.DistributeFees(&_Csfeedistributor.TransactOpts, nodeOperatorId, shares, proof)
+}
+
+// DistributeFees is a paid mutator transaction binding the contract method 0x21893f7b.
+//
+// Solidity: function distributeFees(uint256 nodeOperatorId, uint256 shares, bytes32[] proof) returns(uint256 sharesToDistribute)
+func (_Csfeedistributor *CsfeedistributorTransactorSession) DistributeFees(nodeOperatorId *big.Int, shares *big.Int, proof [][32]byte) (*types.Transaction, error) {
+	return _Csfeedistributor.Contract.DistributeFees(&_Csfeedistributor.TransactOpts, nodeOperatorId, shares, proof)
+}
+
+// GrantRole is a paid mutator transaction binding the contract method 0x2f2ff15d.
+//
+// Solidity: function grantRole(bytes32 role, address account) returns()
+func (_Csfeedistributor *CsfeedistributorTransactor) GrantRole(opts *bind.TransactOpts, role [32]byte, account common.Address) (*types.Transaction, error) {
+	return _Csfeedistributor.contract.Transact(opts, "grantRole", role, account)
+}
+
+// GrantRole is a paid mutator transaction binding the contract method 0x2f2ff15d.
+//
+// Solidity: function grantRole(bytes32 role, address account) returns()
+func (_Csfeedistributor *CsfeedistributorSession) GrantRole(role [32]byte, account common.Address) (*types.Transaction, error) {
+	return _Csfeedistributor.Contract.GrantRole(&_Csfeedistributor.TransactOpts, role, account)
+}
+
+// GrantRole is a paid mutator transaction binding the contract method 0x2f2ff15d.
+//
+// Solidity: function grantRole(bytes32 role, address account) returns()
+func (_Csfeedistributor *CsfeedistributorTransactorSession) GrantRole(role [32]byte, account common.Address) (*types.Transaction, error) {
+	return _Csfeedistributor.Contract.GrantRole(&_Csfeedistributor.TransactOpts, role, account)
+}
+
+// Initialize is a paid mutator transaction binding the contract method 0xc4d66de8.
+//
+// Solidity: function initialize(address admin) returns()
+func (_Csfeedistributor *CsfeedistributorTransactor) Initialize(opts *bind.TransactOpts, admin common.Address) (*types.Transaction, error) {
+	return _Csfeedistributor.contract.Transact(opts, "initialize", admin)
+}
+
+// Initialize is a paid mutator transaction binding the contract method 0xc4d66de8.
+//
+// Solidity: function initialize(address admin) returns()
+func (_Csfeedistributor *CsfeedistributorSession) Initialize(admin common.Address) (*types.Transaction, error) {
+	return _Csfeedistributor.Contract.Initialize(&_Csfeedistributor.TransactOpts, admin)
+}
+
+// Initialize is a paid mutator transaction binding the contract method 0xc4d66de8.
+//
+// Solidity: function initialize(address admin) returns()
+func (_Csfeedistributor *CsfeedistributorTransactorSession) Initialize(admin common.Address) (*types.Transaction, error) {
+	return _Csfeedistributor.Contract.Initialize(&_Csfeedistributor.TransactOpts, admin)
+}
+
+// ProcessOracleReport is a paid mutator transaction binding the contract method 0xb66cf058.
+//
+// Solidity: function processOracleReport(bytes32 _treeRoot, string _treeCid, uint256 distributed) returns()
+func (_Csfeedistributor *CsfeedistributorTransactor) ProcessOracleReport(opts *bind.TransactOpts, _treeRoot [32]byte, _treeCid string, distributed *big.Int) (*types.Transaction, error) {
+	return _Csfeedistributor.contract.Transact(opts, "processOracleReport", _treeRoot, _treeCid, distributed)
+}
+
+// ProcessOracleReport is a paid mutator transaction binding the contract method 0xb66cf058.
+//
+// Solidity: function processOracleReport(bytes32 _treeRoot, string _treeCid, uint256 distributed) returns()
+func (_Csfeedistributor *CsfeedistributorSession) ProcessOracleReport(_treeRoot [32]byte, _treeCid string, distributed *big.Int) (*types.Transaction, error) {
+	return _Csfeedistributor.Contract.ProcessOracleReport(&_Csfeedistributor.TransactOpts, _treeRoot, _treeCid, distributed)
+}
+
+// ProcessOracleReport is a paid mutator transaction binding the contract method 0xb66cf058.
+//
+// Solidity: function processOracleReport(bytes32 _treeRoot, string _treeCid, uint256 distributed) returns()
+func (_Csfeedistributor *CsfeedistributorTransactorSession) ProcessOracleReport(_treeRoot [32]byte, _treeCid string, distributed *big.Int) (*types.Transaction, error) {
+	return _Csfeedistributor.Contract.ProcessOracleReport(&_Csfeedistributor.TransactOpts, _treeRoot, _treeCid, distributed)
+}
+
+// RecoverERC1155 is a paid mutator transaction binding the contract method 0x5c654ad9.
+//
+// Solidity: function recoverERC1155(address token, uint256 tokenId) returns()
+func (_Csfeedistributor *CsfeedistributorTransactor) RecoverERC1155(opts *bind.TransactOpts, token common.Address, tokenId *big.Int) (*types.Transaction, error) {
+	return _Csfeedistributor.contract.Transact(opts, "recoverERC1155", token, tokenId)
+}
+
+// RecoverERC1155 is a paid mutator transaction binding the contract method 0x5c654ad9.
+//
+// Solidity: function recoverERC1155(address token, uint256 tokenId) returns()
+func (_Csfeedistributor *CsfeedistributorSession) RecoverERC1155(token common.Address, tokenId *big.Int) (*types.Transaction, error) {
+	return _Csfeedistributor.Contract.RecoverERC1155(&_Csfeedistributor.TransactOpts, token, tokenId)
+}
+
+// RecoverERC1155 is a paid mutator transaction binding the contract method 0x5c654ad9.
+//
+// Solidity: function recoverERC1155(address token, uint256 tokenId) returns()
+func (_Csfeedistributor *CsfeedistributorTransactorSession) RecoverERC1155(token common.Address, tokenId *big.Int) (*types.Transaction, error) {
+	return _Csfeedistributor.Contract.RecoverERC1155(&_Csfeedistributor.TransactOpts, token, tokenId)
+}
+
+// RecoverERC20 is a paid mutator transaction binding the contract method 0x8980f11f.
+//
+// Solidity: function recoverERC20(address token, uint256 amount) returns()
+func (_Csfeedistributor *CsfeedistributorTransactor) RecoverERC20(opts *bind.TransactOpts, token common.Address, amount *big.Int) (*types.Transaction, error) {
+	return _Csfeedistributor.contract.Transact(opts, "recoverERC20", token, amount)
+}
+
+// RecoverERC20 is a paid mutator transaction binding the contract method 0x8980f11f.
+//
+// Solidity: function recoverERC20(address token, uint256 amount) returns()
+func (_Csfeedistributor *CsfeedistributorSession) RecoverERC20(token common.Address, amount *big.Int) (*types.Transaction, error) {
+	return _Csfeedistributor.Contract.RecoverERC20(&_Csfeedistributor.TransactOpts, token, amount)
+}
+
+// RecoverERC20 is a paid mutator transaction binding the contract method 0x8980f11f.
+//
+// Solidity: function recoverERC20(address token, uint256 amount) returns()
+func (_Csfeedistributor *CsfeedistributorTransactorSession) RecoverERC20(token common.Address, amount *big.Int) (*types.Transaction, error) {
+	return _Csfeedistributor.Contract.RecoverERC20(&_Csfeedistributor.TransactOpts, token, amount)
+}
+
+// RecoverERC721 is a paid mutator transaction binding the contract method 0x819d4cc6.
+//
+// Solidity: function recoverERC721(address token, uint256 tokenId) returns()
+func (_Csfeedistributor *CsfeedistributorTransactor) RecoverERC721(opts *bind.TransactOpts, token common.Address, tokenId *big.Int) (*types.Transaction, error) {
+	return _Csfeedistributor.contract.Transact(opts, "recoverERC721", token, tokenId)
+}
+
+// RecoverERC721 is a paid mutator transaction binding the contract method 0x819d4cc6.
+//
+// Solidity: function recoverERC721(address token, uint256 tokenId) returns()
+func (_Csfeedistributor *CsfeedistributorSession) RecoverERC721(token common.Address, tokenId *big.Int) (*types.Transaction, error) {
+	return _Csfeedistributor.Contract.RecoverERC721(&_Csfeedistributor.TransactOpts, token, tokenId)
+}
+
+// RecoverERC721 is a paid mutator transaction binding the contract method 0x819d4cc6.
+//
+// Solidity: function recoverERC721(address token, uint256 tokenId) returns()
+func (_Csfeedistributor *CsfeedistributorTransactorSession) RecoverERC721(token common.Address, tokenId *big.Int) (*types.Transaction, error) {
+	return _Csfeedistributor.Contract.RecoverERC721(&_Csfeedistributor.TransactOpts, token, tokenId)
+}
+
+// RecoverEther is a paid mutator transaction binding the contract method 0x52d8bfc2.
+//
+// Solidity: function recoverEther() returns()
+func (_Csfeedistributor *CsfeedistributorTransactor) RecoverEther(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Csfeedistributor.contract.Transact(opts, "recoverEther")
+}
+
+// RecoverEther is a paid mutator transaction binding the contract method 0x52d8bfc2.
+//
+// Solidity: function recoverEther() returns()
+func (_Csfeedistributor *CsfeedistributorSession) RecoverEther() (*types.Transaction, error) {
+	return _Csfeedistributor.Contract.RecoverEther(&_Csfeedistributor.TransactOpts)
+}
+
+// RecoverEther is a paid mutator transaction binding the contract method 0x52d8bfc2.
+//
+// Solidity: function recoverEther() returns()
+func (_Csfeedistributor *CsfeedistributorTransactorSession) RecoverEther() (*types.Transaction, error) {
+	return _Csfeedistributor.Contract.RecoverEther(&_Csfeedistributor.TransactOpts)
+}
+
+// RenounceRole is a paid mutator transaction binding the contract method 0x36568abe.
+//
+// Solidity: function renounceRole(bytes32 role, address callerConfirmation) returns()
+func (_Csfeedistributor *CsfeedistributorTransactor) RenounceRole(opts *bind.TransactOpts, role [32]byte, callerConfirmation common.Address) (*types.Transaction, error) {
+	return _Csfeedistributor.contract.Transact(opts, "renounceRole", role, callerConfirmation)
+}
+
+// RenounceRole is a paid mutator transaction binding the contract method 0x36568abe.
+//
+// Solidity: function renounceRole(bytes32 role, address callerConfirmation) returns()
+func (_Csfeedistributor *CsfeedistributorSession) RenounceRole(role [32]byte, callerConfirmation common.Address) (*types.Transaction, error) {
+	return _Csfeedistributor.Contract.RenounceRole(&_Csfeedistributor.TransactOpts, role, callerConfirmation)
+}
+
+// RenounceRole is a paid mutator transaction binding the contract method 0x36568abe.
+//
+// Solidity: function renounceRole(bytes32 role, address callerConfirmation) returns()
+func (_Csfeedistributor *CsfeedistributorTransactorSession) RenounceRole(role [32]byte, callerConfirmation common.Address) (*types.Transaction, error) {
+	return _Csfeedistributor.Contract.RenounceRole(&_Csfeedistributor.TransactOpts, role, callerConfirmation)
+}
+
+// RevokeRole is a paid mutator transaction binding the contract method 0xd547741f.
+//
+// Solidity: function revokeRole(bytes32 role, address account) returns()
+func (_Csfeedistributor *CsfeedistributorTransactor) RevokeRole(opts *bind.TransactOpts, role [32]byte, account common.Address) (*types.Transaction, error) {
+	return _Csfeedistributor.contract.Transact(opts, "revokeRole", role, account)
+}
+
+// RevokeRole is a paid mutator transaction binding the contract method 0xd547741f.
+//
+// Solidity: function revokeRole(bytes32 role, address account) returns()
+func (_Csfeedistributor *CsfeedistributorSession) RevokeRole(role [32]byte, account common.Address) (*types.Transaction, error) {
+	return _Csfeedistributor.Contract.RevokeRole(&_Csfeedistributor.TransactOpts, role, account)
+}
+
+// RevokeRole is a paid mutator transaction binding the contract method 0xd547741f.
+//
+// Solidity: function revokeRole(bytes32 role, address account) returns()
+func (_Csfeedistributor *CsfeedistributorTransactorSession) RevokeRole(role [32]byte, account common.Address) (*types.Transaction, error) {
+	return _Csfeedistributor.Contract.RevokeRole(&_Csfeedistributor.TransactOpts, role, account)
+}
+
+// CsfeedistributorDistributionDataUpdatedIterator is returned from FilterDistributionDataUpdated and is used to iterate over the raw logs and unpacked data for DistributionDataUpdated events raised by the Csfeedistributor contract.
+type CsfeedistributorDistributionDataUpdatedIterator struct {
+	Event *CsfeedistributorDistributionDataUpdated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *CsfeedistributorDistributionDataUpdatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(CsfeedistributorDistributionDataUpdated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(CsfeedistributorDistributionDataUpdated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *CsfeedistributorDistributionDataUpdatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *CsfeedistributorDistributionDataUpdatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// CsfeedistributorDistributionDataUpdated represents a DistributionDataUpdated event raised by the Csfeedistributor contract.
+type CsfeedistributorDistributionDataUpdated struct {
+	TotalClaimableShares *big.Int
+	TreeRoot             [32]byte
+	TreeCid              string
+	Raw                  types.Log // Blockchain specific contextual infos
+}
+
+// FilterDistributionDataUpdated is a free log retrieval operation binding the contract event 0x26dec7cc117e9b3907dc1f90d2dc5f6e04dbb9f285f5898be2c82ec524dcd424.
+//
+// Solidity: event DistributionDataUpdated(uint256 totalClaimableShares, bytes32 treeRoot, string treeCid)
+func (_Csfeedistributor *CsfeedistributorFilterer) FilterDistributionDataUpdated(opts *bind.FilterOpts) (*CsfeedistributorDistributionDataUpdatedIterator, error) {
+
+	logs, sub, err := _Csfeedistributor.contract.FilterLogs(opts, "DistributionDataUpdated")
+	if err != nil {
+		return nil, err
+	}
+	return &CsfeedistributorDistributionDataUpdatedIterator{contract: _Csfeedistributor.contract, event: "DistributionDataUpdated", logs: logs, sub: sub}, nil
+}
+
+// WatchDistributionDataUpdated is a free log subscription operation binding the contract event 0x26dec7cc117e9b3907dc1f90d2dc5f6e04dbb9f285f5898be2c82ec524dcd424.
+//
+// Solidity: event DistributionDataUpdated(uint256 totalClaimableShares, bytes32 treeRoot, string treeCid)
+func (_Csfeedistributor *CsfeedistributorFilterer) WatchDistributionDataUpdated(opts *bind.WatchOpts, sink chan<- *CsfeedistributorDistributionDataUpdated) (event.Subscription, error) {
+
+	logs, sub, err := _Csfeedistributor.contract.WatchLogs(opts, "DistributionDataUpdated")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(CsfeedistributorDistributionDataUpdated)
+				if err := _Csfeedistributor.contract.UnpackLog(event, "DistributionDataUpdated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseDistributionDataUpdated is a log parse operation binding the contract event 0x26dec7cc117e9b3907dc1f90d2dc5f6e04dbb9f285f5898be2c82ec524dcd424.
+//
+// Solidity: event DistributionDataUpdated(uint256 totalClaimableShares, bytes32 treeRoot, string treeCid)
+func (_Csfeedistributor *CsfeedistributorFilterer) ParseDistributionDataUpdated(log types.Log) (*CsfeedistributorDistributionDataUpdated, error) {
+	event := new(CsfeedistributorDistributionDataUpdated)
+	if err := _Csfeedistributor.contract.UnpackLog(event, "DistributionDataUpdated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// CsfeedistributorERC1155RecoveredIterator is returned from FilterERC1155Recovered and is used to iterate over the raw logs and unpacked data for ERC1155Recovered events raised by the Csfeedistributor contract.
+type CsfeedistributorERC1155RecoveredIterator struct {
+	Event *CsfeedistributorERC1155Recovered // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *CsfeedistributorERC1155RecoveredIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(CsfeedistributorERC1155Recovered)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(CsfeedistributorERC1155Recovered)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *CsfeedistributorERC1155RecoveredIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *CsfeedistributorERC1155RecoveredIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// CsfeedistributorERC1155Recovered represents a ERC1155Recovered event raised by the Csfeedistributor contract.
+type CsfeedistributorERC1155Recovered struct {
+	Token     common.Address
+	TokenId   *big.Int
+	Recipient common.Address
+	Amount    *big.Int
+	Raw       types.Log // Blockchain specific contextual infos
+}
+
+// FilterERC1155Recovered is a free log retrieval operation binding the contract event 0x5cf02e753b3eb0f4bee4460a72817d8e5e3c75cd4d65c1d0b06dca88b8032936.
+//
+// Solidity: event ERC1155Recovered(address indexed token, uint256 tokenId, address indexed recipient, uint256 amount)
+func (_Csfeedistributor *CsfeedistributorFilterer) FilterERC1155Recovered(opts *bind.FilterOpts, token []common.Address, recipient []common.Address) (*CsfeedistributorERC1155RecoveredIterator, error) {
+
+	var tokenRule []interface{}
+	for _, tokenItem := range token {
+		tokenRule = append(tokenRule, tokenItem)
+	}
+
+	var recipientRule []interface{}
+	for _, recipientItem := range recipient {
+		recipientRule = append(recipientRule, recipientItem)
+	}
+
+	logs, sub, err := _Csfeedistributor.contract.FilterLogs(opts, "ERC1155Recovered", tokenRule, recipientRule)
+	if err != nil {
+		return nil, err
+	}
+	return &CsfeedistributorERC1155RecoveredIterator{contract: _Csfeedistributor.contract, event: "ERC1155Recovered", logs: logs, sub: sub}, nil
+}
+
+// WatchERC1155Recovered is a free log subscription operation binding the contract event 0x5cf02e753b3eb0f4bee4460a72817d8e5e3c75cd4d65c1d0b06dca88b8032936.
+//
+// Solidity: event ERC1155Recovered(address indexed token, uint256 tokenId, address indexed recipient, uint256 amount)
+func (_Csfeedistributor *CsfeedistributorFilterer) WatchERC1155Recovered(opts *bind.WatchOpts, sink chan<- *CsfeedistributorERC1155Recovered, token []common.Address, recipient []common.Address) (event.Subscription, error) {
+
+	var tokenRule []interface{}
+	for _, tokenItem := range token {
+		tokenRule = append(tokenRule, tokenItem)
+	}
+
+	var recipientRule []interface{}
+	for _, recipientItem := range recipient {
+		recipientRule = append(recipientRule, recipientItem)
+	}
+
+	logs, sub, err := _Csfeedistributor.contract.WatchLogs(opts, "ERC1155Recovered", tokenRule, recipientRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(CsfeedistributorERC1155Recovered)
+				if err := _Csfeedistributor.contract.UnpackLog(event, "ERC1155Recovered", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseERC1155Recovered is a log parse operation binding the contract event 0x5cf02e753b3eb0f4bee4460a72817d8e5e3c75cd4d65c1d0b06dca88b8032936.
+//
+// Solidity: event ERC1155Recovered(address indexed token, uint256 tokenId, address indexed recipient, uint256 amount)
+func (_Csfeedistributor *CsfeedistributorFilterer) ParseERC1155Recovered(log types.Log) (*CsfeedistributorERC1155Recovered, error) {
+	event := new(CsfeedistributorERC1155Recovered)
+	if err := _Csfeedistributor.contract.UnpackLog(event, "ERC1155Recovered", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// CsfeedistributorERC20RecoveredIterator is returned from FilterERC20Recovered and is used to iterate over the raw logs and unpacked data for ERC20Recovered events raised by the Csfeedistributor contract.
+type CsfeedistributorERC20RecoveredIterator struct {
+	Event *CsfeedistributorERC20Recovered // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *CsfeedistributorERC20RecoveredIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(CsfeedistributorERC20Recovered)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(CsfeedistributorERC20Recovered)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *CsfeedistributorERC20RecoveredIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *CsfeedistributorERC20RecoveredIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// CsfeedistributorERC20Recovered represents a ERC20Recovered event raised by the Csfeedistributor contract.
+type CsfeedistributorERC20Recovered struct {
+	Token     common.Address
+	Recipient common.Address
+	Amount    *big.Int
+	Raw       types.Log // Blockchain specific contextual infos
+}
+
+// FilterERC20Recovered is a free log retrieval operation binding the contract event 0xaca8fb252cde442184e5f10e0f2e6e4029e8cd7717cae63559079610702436aa.
+//
+// Solidity: event ERC20Recovered(address indexed token, address indexed recipient, uint256 amount)
+func (_Csfeedistributor *CsfeedistributorFilterer) FilterERC20Recovered(opts *bind.FilterOpts, token []common.Address, recipient []common.Address) (*CsfeedistributorERC20RecoveredIterator, error) {
+
+	var tokenRule []interface{}
+	for _, tokenItem := range token {
+		tokenRule = append(tokenRule, tokenItem)
+	}
+	var recipientRule []interface{}
+	for _, recipientItem := range recipient {
+		recipientRule = append(recipientRule, recipientItem)
+	}
+
+	logs, sub, err := _Csfeedistributor.contract.FilterLogs(opts, "ERC20Recovered", tokenRule, recipientRule)
+	if err != nil {
+		return nil, err
+	}
+	return &CsfeedistributorERC20RecoveredIterator{contract: _Csfeedistributor.contract, event: "ERC20Recovered", logs: logs, sub: sub}, nil
+}
+
+// WatchERC20Recovered is a free log subscription operation binding the contract event 0xaca8fb252cde442184e5f10e0f2e6e4029e8cd7717cae63559079610702436aa.
+//
+// Solidity: event ERC20Recovered(address indexed token, address indexed recipient, uint256 amount)
+func (_Csfeedistributor *CsfeedistributorFilterer) WatchERC20Recovered(opts *bind.WatchOpts, sink chan<- *CsfeedistributorERC20Recovered, token []common.Address, recipient []common.Address) (event.Subscription, error) {
+
+	var tokenRule []interface{}
+	for _, tokenItem := range token {
+		tokenRule = append(tokenRule, tokenItem)
+	}
+	var recipientRule []interface{}
+	for _, recipientItem := range recipient {
+		recipientRule = append(recipientRule, recipientItem)
+	}
+
+	logs, sub, err := _Csfeedistributor.contract.WatchLogs(opts, "ERC20Recovered", tokenRule, recipientRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(CsfeedistributorERC20Recovered)
+				if err := _Csfeedistributor.contract.UnpackLog(event, "ERC20Recovered", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseERC20Recovered is a log parse operation binding the contract event 0xaca8fb252cde442184e5f10e0f2e6e4029e8cd7717cae63559079610702436aa.
+//
+// Solidity: event ERC20Recovered(address indexed token, address indexed recipient, uint256 amount)
+func (_Csfeedistributor *CsfeedistributorFilterer) ParseERC20Recovered(log types.Log) (*CsfeedistributorERC20Recovered, error) {
+	event := new(CsfeedistributorERC20Recovered)
+	if err := _Csfeedistributor.contract.UnpackLog(event, "ERC20Recovered", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// CsfeedistributorERC721RecoveredIterator is returned from FilterERC721Recovered and is used to iterate over the raw logs and unpacked data for ERC721Recovered events raised by the Csfeedistributor contract.
+type CsfeedistributorERC721RecoveredIterator struct {
+	Event *CsfeedistributorERC721Recovered // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *CsfeedistributorERC721RecoveredIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(CsfeedistributorERC721Recovered)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(CsfeedistributorERC721Recovered)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *CsfeedistributorERC721RecoveredIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *CsfeedistributorERC721RecoveredIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// CsfeedistributorERC721Recovered represents a ERC721Recovered event raised by the Csfeedistributor contract.
+type CsfeedistributorERC721Recovered struct {
+	Token     common.Address
+	TokenId   *big.Int
+	Recipient common.Address
+	Raw       types.Log // Blockchain specific contextual infos
+}
+
+// FilterERC721Recovered is a free log retrieval operation binding the contract event 0x8166bf75d2ff2fa3c8f3c44410540bf42e9a5359b48409e8d660291dc9f788c8.
+//
+// Solidity: event ERC721Recovered(address indexed token, uint256 tokenId, address indexed recipient)
+func (_Csfeedistributor *CsfeedistributorFilterer) FilterERC721Recovered(opts *bind.FilterOpts, token []common.Address, recipient []common.Address) (*CsfeedistributorERC721RecoveredIterator, error) {
+
+	var tokenRule []interface{}
+	for _, tokenItem := range token {
+		tokenRule = append(tokenRule, tokenItem)
+	}
+
+	var recipientRule []interface{}
+	for _, recipientItem := range recipient {
+		recipientRule = append(recipientRule, recipientItem)
+	}
+
+	logs, sub, err := _Csfeedistributor.contract.FilterLogs(opts, "ERC721Recovered", tokenRule, recipientRule)
+	if err != nil {
+		return nil, err
+	}
+	return &CsfeedistributorERC721RecoveredIterator{contract: _Csfeedistributor.contract, event: "ERC721Recovered", logs: logs, sub: sub}, nil
+}
+
+// WatchERC721Recovered is a free log subscription operation binding the contract event 0x8166bf75d2ff2fa3c8f3c44410540bf42e9a5359b48409e8d660291dc9f788c8.
+//
+// Solidity: event ERC721Recovered(address indexed token, uint256 tokenId, address indexed recipient)
+func (_Csfeedistributor *CsfeedistributorFilterer) WatchERC721Recovered(opts *bind.WatchOpts, sink chan<- *CsfeedistributorERC721Recovered, token []common.Address, recipient []common.Address) (event.Subscription, error) {
+
+	var tokenRule []interface{}
+	for _, tokenItem := range token {
+		tokenRule = append(tokenRule, tokenItem)
+	}
+
+	var recipientRule []interface{}
+	for _, recipientItem := range recipient {
+		recipientRule = append(recipientRule, recipientItem)
+	}
+
+	logs, sub, err := _Csfeedistributor.contract.WatchLogs(opts, "ERC721Recovered", tokenRule, recipientRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(CsfeedistributorERC721Recovered)
+				if err := _Csfeedistributor.contract.UnpackLog(event, "ERC721Recovered", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseERC721Recovered is a log parse operation binding the contract event 0x8166bf75d2ff2fa3c8f3c44410540bf42e9a5359b48409e8d660291dc9f788c8.
+//
+// Solidity: event ERC721Recovered(address indexed token, uint256 tokenId, address indexed recipient)
+func (_Csfeedistributor *CsfeedistributorFilterer) ParseERC721Recovered(log types.Log) (*CsfeedistributorERC721Recovered, error) {
+	event := new(CsfeedistributorERC721Recovered)
+	if err := _Csfeedistributor.contract.UnpackLog(event, "ERC721Recovered", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// CsfeedistributorEtherRecoveredIterator is returned from FilterEtherRecovered and is used to iterate over the raw logs and unpacked data for EtherRecovered events raised by the Csfeedistributor contract.
+type CsfeedistributorEtherRecoveredIterator struct {
+	Event *CsfeedistributorEtherRecovered // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *CsfeedistributorEtherRecoveredIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(CsfeedistributorEtherRecovered)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(CsfeedistributorEtherRecovered)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *CsfeedistributorEtherRecoveredIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *CsfeedistributorEtherRecoveredIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// CsfeedistributorEtherRecovered represents a EtherRecovered event raised by the Csfeedistributor contract.
+type CsfeedistributorEtherRecovered struct {
+	Recipient common.Address
+	Amount    *big.Int
+	Raw       types.Log // Blockchain specific contextual infos
+}
+
+// FilterEtherRecovered is a free log retrieval operation binding the contract event 0x8e274e42262a7f013b700b35c2b4629ccce1702f8fe83f8dfb7eacbb26a4382c.
+//
+// Solidity: event EtherRecovered(address indexed recipient, uint256 amount)
+func (_Csfeedistributor *CsfeedistributorFilterer) FilterEtherRecovered(opts *bind.FilterOpts, recipient []common.Address) (*CsfeedistributorEtherRecoveredIterator, error) {
+
+	var recipientRule []interface{}
+	for _, recipientItem := range recipient {
+		recipientRule = append(recipientRule, recipientItem)
+	}
+
+	logs, sub, err := _Csfeedistributor.contract.FilterLogs(opts, "EtherRecovered", recipientRule)
+	if err != nil {
+		return nil, err
+	}
+	return &CsfeedistributorEtherRecoveredIterator{contract: _Csfeedistributor.contract, event: "EtherRecovered", logs: logs, sub: sub}, nil
+}
+
+// WatchEtherRecovered is a free log subscription operation binding the contract event 0x8e274e42262a7f013b700b35c2b4629ccce1702f8fe83f8dfb7eacbb26a4382c.
+//
+// Solidity: event EtherRecovered(address indexed recipient, uint256 amount)
+func (_Csfeedistributor *CsfeedistributorFilterer) WatchEtherRecovered(opts *bind.WatchOpts, sink chan<- *CsfeedistributorEtherRecovered, recipient []common.Address) (event.Subscription, error) {
+
+	var recipientRule []interface{}
+	for _, recipientItem := range recipient {
+		recipientRule = append(recipientRule, recipientItem)
+	}
+
+	logs, sub, err := _Csfeedistributor.contract.WatchLogs(opts, "EtherRecovered", recipientRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(CsfeedistributorEtherRecovered)
+				if err := _Csfeedistributor.contract.UnpackLog(event, "EtherRecovered", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseEtherRecovered is a log parse operation binding the contract event 0x8e274e42262a7f013b700b35c2b4629ccce1702f8fe83f8dfb7eacbb26a4382c.
+//
+// Solidity: event EtherRecovered(address indexed recipient, uint256 amount)
+func (_Csfeedistributor *CsfeedistributorFilterer) ParseEtherRecovered(log types.Log) (*CsfeedistributorEtherRecovered, error) {
+	event := new(CsfeedistributorEtherRecovered)
+	if err := _Csfeedistributor.contract.UnpackLog(event, "EtherRecovered", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// CsfeedistributorFeeDistributedIterator is returned from FilterFeeDistributed and is used to iterate over the raw logs and unpacked data for FeeDistributed events raised by the Csfeedistributor contract.
+type CsfeedistributorFeeDistributedIterator struct {
+	Event *CsfeedistributorFeeDistributed // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *CsfeedistributorFeeDistributedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(CsfeedistributorFeeDistributed)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(CsfeedistributorFeeDistributed)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *CsfeedistributorFeeDistributedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *CsfeedistributorFeeDistributedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// CsfeedistributorFeeDistributed represents a FeeDistributed event raised by the Csfeedistributor contract.
+type CsfeedistributorFeeDistributed struct {
+	NodeOperatorId *big.Int
+	Shares         *big.Int
+	Raw            types.Log // Blockchain specific contextual infos
+}
+
+// FilterFeeDistributed is a free log retrieval operation binding the contract event 0x61930a6c1553eab59d5766da6e1bab8eba982aec848ae7683452f4a6423b6e4a.
+//
+// Solidity: event FeeDistributed(uint256 indexed nodeOperatorId, uint256 shares)
+func (_Csfeedistributor *CsfeedistributorFilterer) FilterFeeDistributed(opts *bind.FilterOpts, nodeOperatorId []*big.Int) (*CsfeedistributorFeeDistributedIterator, error) {
+
+	var nodeOperatorIdRule []interface{}
+	for _, nodeOperatorIdItem := range nodeOperatorId {
+		nodeOperatorIdRule = append(nodeOperatorIdRule, nodeOperatorIdItem)
+	}
+
+	logs, sub, err := _Csfeedistributor.contract.FilterLogs(opts, "FeeDistributed", nodeOperatorIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return &CsfeedistributorFeeDistributedIterator{contract: _Csfeedistributor.contract, event: "FeeDistributed", logs: logs, sub: sub}, nil
+}
+
+// WatchFeeDistributed is a free log subscription operation binding the contract event 0x61930a6c1553eab59d5766da6e1bab8eba982aec848ae7683452f4a6423b6e4a.
+//
+// Solidity: event FeeDistributed(uint256 indexed nodeOperatorId, uint256 shares)
+func (_Csfeedistributor *CsfeedistributorFilterer) WatchFeeDistributed(opts *bind.WatchOpts, sink chan<- *CsfeedistributorFeeDistributed, nodeOperatorId []*big.Int) (event.Subscription, error) {
+
+	var nodeOperatorIdRule []interface{}
+	for _, nodeOperatorIdItem := range nodeOperatorId {
+		nodeOperatorIdRule = append(nodeOperatorIdRule, nodeOperatorIdItem)
+	}
+
+	logs, sub, err := _Csfeedistributor.contract.WatchLogs(opts, "FeeDistributed", nodeOperatorIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(CsfeedistributorFeeDistributed)
+				if err := _Csfeedistributor.contract.UnpackLog(event, "FeeDistributed", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseFeeDistributed is a log parse operation binding the contract event 0x61930a6c1553eab59d5766da6e1bab8eba982aec848ae7683452f4a6423b6e4a.
+//
+// Solidity: event FeeDistributed(uint256 indexed nodeOperatorId, uint256 shares)
+func (_Csfeedistributor *CsfeedistributorFilterer) ParseFeeDistributed(log types.Log) (*CsfeedistributorFeeDistributed, error) {
+	event := new(CsfeedistributorFeeDistributed)
+	if err := _Csfeedistributor.contract.UnpackLog(event, "FeeDistributed", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// CsfeedistributorInitializedIterator is returned from FilterInitialized and is used to iterate over the raw logs and unpacked data for Initialized events raised by the Csfeedistributor contract.
+type CsfeedistributorInitializedIterator struct {
+	Event *CsfeedistributorInitialized // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *CsfeedistributorInitializedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(CsfeedistributorInitialized)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(CsfeedistributorInitialized)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *CsfeedistributorInitializedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *CsfeedistributorInitializedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// CsfeedistributorInitialized represents a Initialized event raised by the Csfeedistributor contract.
+type CsfeedistributorInitialized struct {
+	Version uint64
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterInitialized is a free log retrieval operation binding the contract event 0xc7f505b2f371ae2175ee4913f4499e1f2633a7b5936321eed1cdaeb6115181d2.
+//
+// Solidity: event Initialized(uint64 version)
+func (_Csfeedistributor *CsfeedistributorFilterer) FilterInitialized(opts *bind.FilterOpts) (*CsfeedistributorInitializedIterator, error) {
+
+	logs, sub, err := _Csfeedistributor.contract.FilterLogs(opts, "Initialized")
+	if err != nil {
+		return nil, err
+	}
+	return &CsfeedistributorInitializedIterator{contract: _Csfeedistributor.contract, event: "Initialized", logs: logs, sub: sub}, nil
+}
+
+// WatchInitialized is a free log subscription operation binding the contract event 0xc7f505b2f371ae2175ee4913f4499e1f2633a7b5936321eed1cdaeb6115181d2.
+//
+// Solidity: event Initialized(uint64 version)
+func (_Csfeedistributor *CsfeedistributorFilterer) WatchInitialized(opts *bind.WatchOpts, sink chan<- *CsfeedistributorInitialized) (event.Subscription, error) {
+
+	logs, sub, err := _Csfeedistributor.contract.WatchLogs(opts, "Initialized")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(CsfeedistributorInitialized)
+				if err := _Csfeedistributor.contract.UnpackLog(event, "Initialized", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseInitialized is a log parse operation binding the contract event 0xc7f505b2f371ae2175ee4913f4499e1f2633a7b5936321eed1cdaeb6115181d2.
+//
+// Solidity: event Initialized(uint64 version)
+func (_Csfeedistributor *CsfeedistributorFilterer) ParseInitialized(log types.Log) (*CsfeedistributorInitialized, error) {
+	event := new(CsfeedistributorInitialized)
+	if err := _Csfeedistributor.contract.UnpackLog(event, "Initialized", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// CsfeedistributorRoleAdminChangedIterator is returned from FilterRoleAdminChanged and is used to iterate over the raw logs and unpacked data for RoleAdminChanged events raised by the Csfeedistributor contract.
+type CsfeedistributorRoleAdminChangedIterator struct {
+	Event *CsfeedistributorRoleAdminChanged // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *CsfeedistributorRoleAdminChangedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(CsfeedistributorRoleAdminChanged)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(CsfeedistributorRoleAdminChanged)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *CsfeedistributorRoleAdminChangedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *CsfeedistributorRoleAdminChangedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// CsfeedistributorRoleAdminChanged represents a RoleAdminChanged event raised by the Csfeedistributor contract.
+type CsfeedistributorRoleAdminChanged struct {
+	Role              [32]byte
+	PreviousAdminRole [32]byte
+	NewAdminRole      [32]byte
+	Raw               types.Log // Blockchain specific contextual infos
+}
+
+// FilterRoleAdminChanged is a free log retrieval operation binding the contract event 0xbd79b86ffe0ab8e8776151514217cd7cacd52c909f66475c3af44e129f0b00ff.
+//
+// Solidity: event RoleAdminChanged(bytes32 indexed role, bytes32 indexed previousAdminRole, bytes32 indexed newAdminRole)
+func (_Csfeedistributor *CsfeedistributorFilterer) FilterRoleAdminChanged(opts *bind.FilterOpts, role [][32]byte, previousAdminRole [][32]byte, newAdminRole [][32]byte) (*CsfeedistributorRoleAdminChangedIterator, error) {
+
+	var roleRule []interface{}
+	for _, roleItem := range role {
+		roleRule = append(roleRule, roleItem)
+	}
+	var previousAdminRoleRule []interface{}
+	for _, previousAdminRoleItem := range previousAdminRole {
+		previousAdminRoleRule = append(previousAdminRoleRule, previousAdminRoleItem)
+	}
+	var newAdminRoleRule []interface{}
+	for _, newAdminRoleItem := range newAdminRole {
+		newAdminRoleRule = append(newAdminRoleRule, newAdminRoleItem)
+	}
+
+	logs, sub, err := _Csfeedistributor.contract.FilterLogs(opts, "RoleAdminChanged", roleRule, previousAdminRoleRule, newAdminRoleRule)
+	if err != nil {
+		return nil, err
+	}
+	return &CsfeedistributorRoleAdminChangedIterator{contract: _Csfeedistributor.contract, event: "RoleAdminChanged", logs: logs, sub: sub}, nil
+}
+
+// WatchRoleAdminChanged is a free log subscription operation binding the contract event 0xbd79b86ffe0ab8e8776151514217cd7cacd52c909f66475c3af44e129f0b00ff.
+//
+// Solidity: event RoleAdminChanged(bytes32 indexed role, bytes32 indexed previousAdminRole, bytes32 indexed newAdminRole)
+func (_Csfeedistributor *CsfeedistributorFilterer) WatchRoleAdminChanged(opts *bind.WatchOpts, sink chan<- *CsfeedistributorRoleAdminChanged, role [][32]byte, previousAdminRole [][32]byte, newAdminRole [][32]byte) (event.Subscription, error) {
+
+	var roleRule []interface{}
+	for _, roleItem := range role {
+		roleRule = append(roleRule, roleItem)
+	}
+	var previousAdminRoleRule []interface{}
+	for _, previousAdminRoleItem := range previousAdminRole {
+		previousAdminRoleRule = append(previousAdminRoleRule, previousAdminRoleItem)
+	}
+	var newAdminRoleRule []interface{}
+	for _, newAdminRoleItem := range newAdminRole {
+		newAdminRoleRule = append(newAdminRoleRule, newAdminRoleItem)
+	}
+
+	logs, sub, err := _Csfeedistributor.contract.WatchLogs(opts, "RoleAdminChanged", roleRule, previousAdminRoleRule, newAdminRoleRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(CsfeedistributorRoleAdminChanged)
+				if err := _Csfeedistributor.contract.UnpackLog(event, "RoleAdminChanged", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseRoleAdminChanged is a log parse operation binding the contract event 0xbd79b86ffe0ab8e8776151514217cd7cacd52c909f66475c3af44e129f0b00ff.
+//
+// Solidity: event RoleAdminChanged(bytes32 indexed role, bytes32 indexed previousAdminRole, bytes32 indexed newAdminRole)
+func (_Csfeedistributor *CsfeedistributorFilterer) ParseRoleAdminChanged(log types.Log) (*CsfeedistributorRoleAdminChanged, error) {
+	event := new(CsfeedistributorRoleAdminChanged)
+	if err := _Csfeedistributor.contract.UnpackLog(event, "RoleAdminChanged", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// CsfeedistributorRoleGrantedIterator is returned from FilterRoleGranted and is used to iterate over the raw logs and unpacked data for RoleGranted events raised by the Csfeedistributor contract.
+type CsfeedistributorRoleGrantedIterator struct {
+	Event *CsfeedistributorRoleGranted // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *CsfeedistributorRoleGrantedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(CsfeedistributorRoleGranted)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(CsfeedistributorRoleGranted)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *CsfeedistributorRoleGrantedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *CsfeedistributorRoleGrantedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// CsfeedistributorRoleGranted represents a RoleGranted event raised by the Csfeedistributor contract.
+type CsfeedistributorRoleGranted struct {
+	Role    [32]byte
+	Account common.Address
+	Sender  common.Address
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterRoleGranted is a free log retrieval operation binding the contract event 0x2f8788117e7eff1d82e926ec794901d17c78024a50270940304540a733656f0d.
+//
+// Solidity: event RoleGranted(bytes32 indexed role, address indexed account, address indexed sender)
+func (_Csfeedistributor *CsfeedistributorFilterer) FilterRoleGranted(opts *bind.FilterOpts, role [][32]byte, account []common.Address, sender []common.Address) (*CsfeedistributorRoleGrantedIterator, error) {
+
+	var roleRule []interface{}
+	for _, roleItem := range role {
+		roleRule = append(roleRule, roleItem)
+	}
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var senderRule []interface{}
+	for _, senderItem := range sender {
+		senderRule = append(senderRule, senderItem)
+	}
+
+	logs, sub, err := _Csfeedistributor.contract.FilterLogs(opts, "RoleGranted", roleRule, accountRule, senderRule)
+	if err != nil {
+		return nil, err
+	}
+	return &CsfeedistributorRoleGrantedIterator{contract: _Csfeedistributor.contract, event: "RoleGranted", logs: logs, sub: sub}, nil
+}
+
+// WatchRoleGranted is a free log subscription operation binding the contract event 0x2f8788117e7eff1d82e926ec794901d17c78024a50270940304540a733656f0d.
+//
+// Solidity: event RoleGranted(bytes32 indexed role, address indexed account, address indexed sender)
+func (_Csfeedistributor *CsfeedistributorFilterer) WatchRoleGranted(opts *bind.WatchOpts, sink chan<- *CsfeedistributorRoleGranted, role [][32]byte, account []common.Address, sender []common.Address) (event.Subscription, error) {
+
+	var roleRule []interface{}
+	for _, roleItem := range role {
+		roleRule = append(roleRule, roleItem)
+	}
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var senderRule []interface{}
+	for _, senderItem := range sender {
+		senderRule = append(senderRule, senderItem)
+	}
+
+	logs, sub, err := _Csfeedistributor.contract.WatchLogs(opts, "RoleGranted", roleRule, accountRule, senderRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(CsfeedistributorRoleGranted)
+				if err := _Csfeedistributor.contract.UnpackLog(event, "RoleGranted", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseRoleGranted is a log parse operation binding the contract event 0x2f8788117e7eff1d82e926ec794901d17c78024a50270940304540a733656f0d.
+//
+// Solidity: event RoleGranted(bytes32 indexed role, address indexed account, address indexed sender)
+func (_Csfeedistributor *CsfeedistributorFilterer) ParseRoleGranted(log types.Log) (*CsfeedistributorRoleGranted, error) {
+	event := new(CsfeedistributorRoleGranted)
+	if err := _Csfeedistributor.contract.UnpackLog(event, "RoleGranted", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// CsfeedistributorRoleRevokedIterator is returned from FilterRoleRevoked and is used to iterate over the raw logs and unpacked data for RoleRevoked events raised by the Csfeedistributor contract.
+type CsfeedistributorRoleRevokedIterator struct {
+	Event *CsfeedistributorRoleRevoked // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *CsfeedistributorRoleRevokedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(CsfeedistributorRoleRevoked)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(CsfeedistributorRoleRevoked)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *CsfeedistributorRoleRevokedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *CsfeedistributorRoleRevokedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// CsfeedistributorRoleRevoked represents a RoleRevoked event raised by the Csfeedistributor contract.
+type CsfeedistributorRoleRevoked struct {
+	Role    [32]byte
+	Account common.Address
+	Sender  common.Address
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterRoleRevoked is a free log retrieval operation binding the contract event 0xf6391f5c32d9c69d2a47ea670b442974b53935d1edc7fd64eb21e047a839171b.
+//
+// Solidity: event RoleRevoked(bytes32 indexed role, address indexed account, address indexed sender)
+func (_Csfeedistributor *CsfeedistributorFilterer) FilterRoleRevoked(opts *bind.FilterOpts, role [][32]byte, account []common.Address, sender []common.Address) (*CsfeedistributorRoleRevokedIterator, error) {
+
+	var roleRule []interface{}
+	for _, roleItem := range role {
+		roleRule = append(roleRule, roleItem)
+	}
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var senderRule []interface{}
+	for _, senderItem := range sender {
+		senderRule = append(senderRule, senderItem)
+	}
+
+	logs, sub, err := _Csfeedistributor.contract.FilterLogs(opts, "RoleRevoked", roleRule, accountRule, senderRule)
+	if err != nil {
+		return nil, err
+	}
+	return &CsfeedistributorRoleRevokedIterator{contract: _Csfeedistributor.contract, event: "RoleRevoked", logs: logs, sub: sub}, nil
+}
+
+// WatchRoleRevoked is a free log subscription operation binding the contract event 0xf6391f5c32d9c69d2a47ea670b442974b53935d1edc7fd64eb21e047a839171b.
+//
+// Solidity: event RoleRevoked(bytes32 indexed role, address indexed account, address indexed sender)
+func (_Csfeedistributor *CsfeedistributorFilterer) WatchRoleRevoked(opts *bind.WatchOpts, sink chan<- *CsfeedistributorRoleRevoked, role [][32]byte, account []common.Address, sender []common.Address) (event.Subscription, error) {
+
+	var roleRule []interface{}
+	for _, roleItem := range role {
+		roleRule = append(roleRule, roleItem)
+	}
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var senderRule []interface{}
+	for _, senderItem := range sender {
+		senderRule = append(senderRule, senderItem)
+	}
+
+	logs, sub, err := _Csfeedistributor.contract.WatchLogs(opts, "RoleRevoked", roleRule, accountRule, senderRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(CsfeedistributorRoleRevoked)
+				if err := _Csfeedistributor.contract.UnpackLog(event, "RoleRevoked", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseRoleRevoked is a log parse operation binding the contract event 0xf6391f5c32d9c69d2a47ea670b442974b53935d1edc7fd64eb21e047a839171b.
+//
+// Solidity: event RoleRevoked(bytes32 indexed role, address indexed account, address indexed sender)
+func (_Csfeedistributor *CsfeedistributorFilterer) ParseRoleRevoked(log types.Log) (*CsfeedistributorRoleRevoked, error) {
+	event := new(CsfeedistributorRoleRevoked)
+	if err := _Csfeedistributor.contract.UnpackLog(event, "RoleRevoked", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// CsfeedistributorStETHSharesRecoveredIterator is returned from FilterStETHSharesRecovered and is used to iterate over the raw logs and unpacked data for StETHSharesRecovered events raised by the Csfeedistributor contract.
+type CsfeedistributorStETHSharesRecoveredIterator struct {
+	Event *CsfeedistributorStETHSharesRecovered // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *CsfeedistributorStETHSharesRecoveredIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(CsfeedistributorStETHSharesRecovered)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(CsfeedistributorStETHSharesRecovered)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *CsfeedistributorStETHSharesRecoveredIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *CsfeedistributorStETHSharesRecoveredIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// CsfeedistributorStETHSharesRecovered represents a StETHSharesRecovered event raised by the Csfeedistributor contract.
+type CsfeedistributorStETHSharesRecovered struct {
+	Recipient common.Address
+	Shares    *big.Int
+	Raw       types.Log // Blockchain specific contextual infos
+}
+
+// FilterStETHSharesRecovered is a free log retrieval operation binding the contract event 0x426e7e0100db57255d4af4a46cd49552ef74f5f002bbdc8d4ebb6371c0070a02.
+//
+// Solidity: event StETHSharesRecovered(address indexed recipient, uint256 shares)
+func (_Csfeedistributor *CsfeedistributorFilterer) FilterStETHSharesRecovered(opts *bind.FilterOpts, recipient []common.Address) (*CsfeedistributorStETHSharesRecoveredIterator, error) {
+
+	var recipientRule []interface{}
+	for _, recipientItem := range recipient {
+		recipientRule = append(recipientRule, recipientItem)
+	}
+
+	logs, sub, err := _Csfeedistributor.contract.FilterLogs(opts, "StETHSharesRecovered", recipientRule)
+	if err != nil {
+		return nil, err
+	}
+	return &CsfeedistributorStETHSharesRecoveredIterator{contract: _Csfeedistributor.contract, event: "StETHSharesRecovered", logs: logs, sub: sub}, nil
+}
+
+// WatchStETHSharesRecovered is a free log subscription operation binding the contract event 0x426e7e0100db57255d4af4a46cd49552ef74f5f002bbdc8d4ebb6371c0070a02.
+//
+// Solidity: event StETHSharesRecovered(address indexed recipient, uint256 shares)
+func (_Csfeedistributor *CsfeedistributorFilterer) WatchStETHSharesRecovered(opts *bind.WatchOpts, sink chan<- *CsfeedistributorStETHSharesRecovered, recipient []common.Address) (event.Subscription, error) {
+
+	var recipientRule []interface{}
+	for _, recipientItem := range recipient {
+		recipientRule = append(recipientRule, recipientItem)
+	}
+
+	logs, sub, err := _Csfeedistributor.contract.WatchLogs(opts, "StETHSharesRecovered", recipientRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(CsfeedistributorStETHSharesRecovered)
+				if err := _Csfeedistributor.contract.UnpackLog(event, "StETHSharesRecovered", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseStETHSharesRecovered is a log parse operation binding the contract event 0x426e7e0100db57255d4af4a46cd49552ef74f5f002bbdc8d4ebb6371c0070a02.
+//
+// Solidity: event StETHSharesRecovered(address indexed recipient, uint256 shares)
+func (_Csfeedistributor *CsfeedistributorFilterer) ParseStETHSharesRecovered(log types.Log) (*CsfeedistributorStETHSharesRecovered, error) {
+	event := new(CsfeedistributorStETHSharesRecovered)
+	if err := _Csfeedistributor.contract.UnpackLog(event, "StETHSharesRecovered", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}

--- a/internal/lido/contracts/csmodule/CSModule.go
+++ b/internal/lido/contracts/csmodule/CSModule.go
@@ -1,0 +1,8154 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package csmodule
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// ICSAccountingPermitInput is an auto generated low-level Go binding around an user-defined struct.
+type ICSAccountingPermitInput struct {
+	Value    *big.Int
+	Deadline *big.Int
+	V        uint8
+	R        [32]byte
+	S        [32]byte
+}
+
+// NodeOperator is an auto generated low-level Go binding around an user-defined struct.
+type NodeOperator struct {
+	TotalAddedKeys             uint32
+	TotalWithdrawnKeys         uint32
+	TotalDepositedKeys         uint32
+	TotalVettedKeys            uint32
+	StuckValidatorsCount       uint32
+	DepositableValidatorsCount uint32
+	TargetLimit                uint32
+	TargetLimitMode            uint8
+	TotalExitedKeys            uint32
+	EnqueuedCount              uint32
+	ManagerAddress             common.Address
+	ProposedManagerAddress     common.Address
+	RewardAddress              common.Address
+	ProposedRewardAddress      common.Address
+	ExtendedManagerPermissions bool
+}
+
+// NodeOperatorManagementProperties is an auto generated low-level Go binding around an user-defined struct.
+type NodeOperatorManagementProperties struct {
+	ManagerAddress             common.Address
+	RewardAddress              common.Address
+	ExtendedManagerPermissions bool
+}
+
+// CsmoduleMetaData contains all meta data concerning the Csmodule contract.
+var CsmoduleMetaData = &bind.MetaData{
+	ABI: "[{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"moduleType\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"minSlashingPenaltyQuotient\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"elRewardsStealingFine\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxKeysPerOperatorEA\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"lidoLocator\",\"type\":\"address\"}],\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"},{\"inputs\":[],\"name\":\"AccessControlBadConfirmation\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"},{\"internalType\":\"bytes32\",\"name\":\"neededRole\",\"type\":\"bytes32\"}],\"name\":\"AccessControlUnauthorizedAccount\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"AlreadyActivated\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"AlreadyProposed\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"AlreadySubmitted\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"AlreadyWithdrawn\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"EmptyKey\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"ExitedKeysDecrease\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"ExitedKeysHigherThanTotalDeposited\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"FailedToSendEther\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidAmount\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidInitialization\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidInput\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidKeysCount\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidLength\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidReportData\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidVetKeysPointer\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"MaxSigningKeysCountExceeded\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"MethodCallIsNotAllowed\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"NodeOperatorDoesNotExist\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"NotAllowedToJoinYet\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"NotAllowedToRecover\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"NotEnoughKeys\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"NotInitializing\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"NotSupported\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"PauseUntilMustBeInFuture\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"PausedExpected\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"QueueIsEmpty\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"QueueLookupNoLimit\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"ResumedExpected\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"SameAddress\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"SenderIsNotEligible\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"SenderIsNotManagerAddress\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"SenderIsNotProposedAddress\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"SenderIsNotRewardAddress\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"SigningKeysInvalidOffset\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"StuckKeysHigherThanNonExited\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"ZeroAccountingAddress\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"ZeroAdminAddress\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"ZeroLocatorAddress\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"ZeroPauseDuration\",\"type\":\"error\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"count\",\"type\":\"uint256\"}],\"name\":\"BatchEnqueued\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"depositableKeysCount\",\"type\":\"uint256\"}],\"name\":\"DepositableSigningKeysCountChanged\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"depositedKeysCount\",\"type\":\"uint256\"}],\"name\":\"DepositedSigningKeysCountChanged\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"ELRewardsStealingPenaltyCancelled\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"bytes32\",\"name\":\"proposedBlockHash\",\"type\":\"bytes32\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"stolenAmount\",\"type\":\"uint256\"}],\"name\":\"ELRewardsStealingPenaltyReported\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"}],\"name\":\"ELRewardsStealingPenaltySettled\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"token\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"tokenId\",\"type\":\"uint256\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"recipient\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"ERC1155Recovered\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"token\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"recipient\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"ERC20Recovered\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"token\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"tokenId\",\"type\":\"uint256\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"recipient\",\"type\":\"address\"}],\"name\":\"ERC721Recovered\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"recipient\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"EtherRecovered\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"exitedKeysCount\",\"type\":\"uint256\"}],\"name\":\"ExitedSigningKeysCountChanged\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"keyIndex\",\"type\":\"uint256\"}],\"name\":\"InitialSlashingSubmitted\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint64\",\"name\":\"version\",\"type\":\"uint64\"}],\"name\":\"Initialized\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"}],\"name\":\"KeyRemovalChargeApplied\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"KeyRemovalChargeSet\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"managerAddress\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"rewardAddress\",\"type\":\"address\"}],\"name\":\"NodeOperatorAdded\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"oldProposedAddress\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"newProposedAddress\",\"type\":\"address\"}],\"name\":\"NodeOperatorManagerAddressChangeProposed\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"oldAddress\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"newAddress\",\"type\":\"address\"}],\"name\":\"NodeOperatorManagerAddressChanged\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"oldProposedAddress\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"newProposedAddress\",\"type\":\"address\"}],\"name\":\"NodeOperatorRewardAddressChangeProposed\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"oldAddress\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"newAddress\",\"type\":\"address\"}],\"name\":\"NodeOperatorRewardAddressChanged\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"nonce\",\"type\":\"uint256\"}],\"name\":\"NonceChanged\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"duration\",\"type\":\"uint256\"}],\"name\":\"Paused\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[],\"name\":\"PublicRelease\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"referrer\",\"type\":\"address\"}],\"name\":\"ReferrerSet\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[],\"name\":\"Resumed\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"role\",\"type\":\"bytes32\"},{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"previousAdminRole\",\"type\":\"bytes32\"},{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"newAdminRole\",\"type\":\"bytes32\"}],\"name\":\"RoleAdminChanged\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"role\",\"type\":\"bytes32\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"sender\",\"type\":\"address\"}],\"name\":\"RoleGranted\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"role\",\"type\":\"bytes32\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"sender\",\"type\":\"address\"}],\"name\":\"RoleRevoked\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"bytes\",\"name\":\"pubkey\",\"type\":\"bytes\"}],\"name\":\"SigningKeyAdded\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"bytes\",\"name\":\"pubkey\",\"type\":\"bytes\"}],\"name\":\"SigningKeyRemoved\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"recipient\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"shares\",\"type\":\"uint256\"}],\"name\":\"StETHSharesRecovered\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"stuckKeysCount\",\"type\":\"uint256\"}],\"name\":\"StuckSigningKeysCountChanged\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"targetLimitMode\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"targetValidatorsCount\",\"type\":\"uint256\"}],\"name\":\"TargetValidatorsCountChanged\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"totalKeysCount\",\"type\":\"uint256\"}],\"name\":\"TotalSigningKeysCountChanged\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"vettedKeysCount\",\"type\":\"uint256\"}],\"name\":\"VettedSigningKeysCountChanged\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"}],\"name\":\"VettedSigningKeysCountDecreased\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"keyIndex\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"WithdrawalSubmitted\",\"type\":\"event\"},{\"inputs\":[],\"name\":\"DEFAULT_ADMIN_ROLE\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"EL_REWARDS_STEALING_FINE\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"INITIAL_SLASHING_PENALTY\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"LIDO_LOCATOR\",\"outputs\":[{\"internalType\":\"contractILidoLocator\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"MAX_SIGNING_KEYS_PER_OPERATOR_BEFORE_PUBLIC_RELEASE\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"MODULE_MANAGER_ROLE\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"PAUSE_INFINITELY\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"PAUSE_ROLE\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"RECOVERER_ROLE\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"REPORT_EL_REWARDS_STEALING_PENALTY_ROLE\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"RESUME_ROLE\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"SETTLE_EL_REWARDS_STEALING_PENALTY_ROLE\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"STAKING_ROUTER_ROLE\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"STETH\",\"outputs\":[{\"internalType\":\"contractIStETH\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"VERIFIER_ROLE\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"accounting\",\"outputs\":[{\"internalType\":\"contractICSAccounting\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"activatePublicRelease\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"keysCount\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"publicKeys\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"signatures\",\"type\":\"bytes\"},{\"components\":[{\"internalType\":\"address\",\"name\":\"managerAddress\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"rewardAddress\",\"type\":\"address\"},{\"internalType\":\"bool\",\"name\":\"extendedManagerPermissions\",\"type\":\"bool\"}],\"internalType\":\"structNodeOperatorManagementProperties\",\"name\":\"managementProperties\",\"type\":\"tuple\"},{\"internalType\":\"bytes32[]\",\"name\":\"eaProof\",\"type\":\"bytes32[]\"},{\"internalType\":\"address\",\"name\":\"referrer\",\"type\":\"address\"}],\"name\":\"addNodeOperatorETH\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"keysCount\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"publicKeys\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"signatures\",\"type\":\"bytes\"},{\"components\":[{\"internalType\":\"address\",\"name\":\"managerAddress\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"rewardAddress\",\"type\":\"address\"},{\"internalType\":\"bool\",\"name\":\"extendedManagerPermissions\",\"type\":\"bool\"}],\"internalType\":\"structNodeOperatorManagementProperties\",\"name\":\"managementProperties\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"deadline\",\"type\":\"uint256\"},{\"internalType\":\"uint8\",\"name\":\"v\",\"type\":\"uint8\"},{\"internalType\":\"bytes32\",\"name\":\"r\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"s\",\"type\":\"bytes32\"}],\"internalType\":\"structICSAccounting.PermitInput\",\"name\":\"permit\",\"type\":\"tuple\"},{\"internalType\":\"bytes32[]\",\"name\":\"eaProof\",\"type\":\"bytes32[]\"},{\"internalType\":\"address\",\"name\":\"referrer\",\"type\":\"address\"}],\"name\":\"addNodeOperatorStETH\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"keysCount\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"publicKeys\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"signatures\",\"type\":\"bytes\"},{\"components\":[{\"internalType\":\"address\",\"name\":\"managerAddress\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"rewardAddress\",\"type\":\"address\"},{\"internalType\":\"bool\",\"name\":\"extendedManagerPermissions\",\"type\":\"bool\"}],\"internalType\":\"structNodeOperatorManagementProperties\",\"name\":\"managementProperties\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"deadline\",\"type\":\"uint256\"},{\"internalType\":\"uint8\",\"name\":\"v\",\"type\":\"uint8\"},{\"internalType\":\"bytes32\",\"name\":\"r\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"s\",\"type\":\"bytes32\"}],\"internalType\":\"structICSAccounting.PermitInput\",\"name\":\"permit\",\"type\":\"tuple\"},{\"internalType\":\"bytes32[]\",\"name\":\"eaProof\",\"type\":\"bytes32[]\"},{\"internalType\":\"address\",\"name\":\"referrer\",\"type\":\"address\"}],\"name\":\"addNodeOperatorWstETH\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"keysCount\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"publicKeys\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"signatures\",\"type\":\"bytes\"}],\"name\":\"addValidatorKeysETH\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"keysCount\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"publicKeys\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"signatures\",\"type\":\"bytes\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"deadline\",\"type\":\"uint256\"},{\"internalType\":\"uint8\",\"name\":\"v\",\"type\":\"uint8\"},{\"internalType\":\"bytes32\",\"name\":\"r\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"s\",\"type\":\"bytes32\"}],\"internalType\":\"structICSAccounting.PermitInput\",\"name\":\"permit\",\"type\":\"tuple\"}],\"name\":\"addValidatorKeysStETH\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"keysCount\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"publicKeys\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"signatures\",\"type\":\"bytes\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"deadline\",\"type\":\"uint256\"},{\"internalType\":\"uint8\",\"name\":\"v\",\"type\":\"uint8\"},{\"internalType\":\"bytes32\",\"name\":\"r\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"s\",\"type\":\"bytes32\"}],\"internalType\":\"structICSAccounting.PermitInput\",\"name\":\"permit\",\"type\":\"tuple\"}],\"name\":\"addValidatorKeysWstETH\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"cancelELRewardsStealingPenalty\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"newAddress\",\"type\":\"address\"}],\"name\":\"changeNodeOperatorRewardAddress\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"stETHAmount\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"cumulativeFeeShares\",\"type\":\"uint256\"},{\"internalType\":\"bytes32[]\",\"name\":\"rewardsProof\",\"type\":\"bytes32[]\"}],\"name\":\"claimRewardsStETH\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"stEthAmount\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"cumulativeFeeShares\",\"type\":\"uint256\"},{\"internalType\":\"bytes32[]\",\"name\":\"rewardsProof\",\"type\":\"bytes32[]\"}],\"name\":\"claimRewardsUnstETH\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"wstETHAmount\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"cumulativeFeeShares\",\"type\":\"uint256\"},{\"internalType\":\"bytes32[]\",\"name\":\"rewardsProof\",\"type\":\"bytes32[]\"}],\"name\":\"claimRewardsWstETH\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"maxItems\",\"type\":\"uint256\"}],\"name\":\"cleanDepositQueue\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"}],\"name\":\"compensateELRewardsStealingPenalty\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"}],\"name\":\"confirmNodeOperatorManagerAddressChange\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"}],\"name\":\"confirmNodeOperatorRewardAddressChange\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes\",\"name\":\"nodeOperatorIds\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"vettedSigningKeysCounts\",\"type\":\"bytes\"}],\"name\":\"decreaseVettedSigningKeysCount\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"}],\"name\":\"depositETH\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"depositQueue\",\"outputs\":[{\"internalType\":\"uint128\",\"name\":\"head\",\"type\":\"uint128\"},{\"internalType\":\"uint128\",\"name\":\"tail\",\"type\":\"uint128\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint128\",\"name\":\"index\",\"type\":\"uint128\"}],\"name\":\"depositQueueItem\",\"outputs\":[{\"internalType\":\"Batch\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"stETHAmount\",\"type\":\"uint256\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"deadline\",\"type\":\"uint256\"},{\"internalType\":\"uint8\",\"name\":\"v\",\"type\":\"uint8\"},{\"internalType\":\"bytes32\",\"name\":\"r\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"s\",\"type\":\"bytes32\"}],\"internalType\":\"structICSAccounting.PermitInput\",\"name\":\"permit\",\"type\":\"tuple\"}],\"name\":\"depositStETH\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"wstETHAmount\",\"type\":\"uint256\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"deadline\",\"type\":\"uint256\"},{\"internalType\":\"uint8\",\"name\":\"v\",\"type\":\"uint8\"},{\"internalType\":\"bytes32\",\"name\":\"r\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"s\",\"type\":\"bytes32\"}],\"internalType\":\"structICSAccounting.PermitInput\",\"name\":\"permit\",\"type\":\"tuple\"}],\"name\":\"depositWstETH\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"earlyAdoption\",\"outputs\":[{\"internalType\":\"contractICSEarlyAdoption\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"getActiveNodeOperatorsCount\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"}],\"name\":\"getNodeOperator\",\"outputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"totalAddedKeys\",\"type\":\"uint32\"},{\"internalType\":\"uint32\",\"name\":\"totalWithdrawnKeys\",\"type\":\"uint32\"},{\"internalType\":\"uint32\",\"name\":\"totalDepositedKeys\",\"type\":\"uint32\"},{\"internalType\":\"uint32\",\"name\":\"totalVettedKeys\",\"type\":\"uint32\"},{\"internalType\":\"uint32\",\"name\":\"stuckValidatorsCount\",\"type\":\"uint32\"},{\"internalType\":\"uint32\",\"name\":\"depositableValidatorsCount\",\"type\":\"uint32\"},{\"internalType\":\"uint32\",\"name\":\"targetLimit\",\"type\":\"uint32\"},{\"internalType\":\"uint8\",\"name\":\"targetLimitMode\",\"type\":\"uint8\"},{\"internalType\":\"uint32\",\"name\":\"totalExitedKeys\",\"type\":\"uint32\"},{\"internalType\":\"uint32\",\"name\":\"enqueuedCount\",\"type\":\"uint32\"},{\"internalType\":\"address\",\"name\":\"managerAddress\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"proposedManagerAddress\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"rewardAddress\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"proposedRewardAddress\",\"type\":\"address\"},{\"internalType\":\"bool\",\"name\":\"extendedManagerPermissions\",\"type\":\"bool\"}],\"internalType\":\"structNodeOperator\",\"name\":\"\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"offset\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"limit\",\"type\":\"uint256\"}],\"name\":\"getNodeOperatorIds\",\"outputs\":[{\"internalType\":\"uint256[]\",\"name\":\"nodeOperatorIds\",\"type\":\"uint256[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"}],\"name\":\"getNodeOperatorIsActive\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"}],\"name\":\"getNodeOperatorNonWithdrawnKeys\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"}],\"name\":\"getNodeOperatorSummary\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"targetLimitMode\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"targetValidatorsCount\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"stuckValidatorsCount\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"refundedValidatorsCount\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"stuckPenaltyEndTimestamp\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"totalExitedValidators\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"totalDepositedValidators\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"depositableValidatorsCount\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"getNodeOperatorsCount\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"getNonce\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"getResumeSinceTimestamp\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"role\",\"type\":\"bytes32\"}],\"name\":\"getRoleAdmin\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"role\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"index\",\"type\":\"uint256\"}],\"name\":\"getRoleMember\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"role\",\"type\":\"bytes32\"}],\"name\":\"getRoleMemberCount\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"startIndex\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"keysCount\",\"type\":\"uint256\"}],\"name\":\"getSigningKeys\",\"outputs\":[{\"internalType\":\"bytes\",\"name\":\"\",\"type\":\"bytes\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"startIndex\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"keysCount\",\"type\":\"uint256\"}],\"name\":\"getSigningKeysWithSignatures\",\"outputs\":[{\"internalType\":\"bytes\",\"name\":\"keys\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"signatures\",\"type\":\"bytes\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"getStakingModuleSummary\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"totalExitedValidators\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"totalDepositedValidators\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"depositableValidatorsCount\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"getType\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"role\",\"type\":\"bytes32\"},{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"}],\"name\":\"grantRole\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"role\",\"type\":\"bytes32\"},{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"}],\"name\":\"hasRole\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_accounting\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"_earlyAdoption\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"_keyRemovalCharge\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"admin\",\"type\":\"address\"}],\"name\":\"initialize\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"isPaused\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"keyIndex\",\"type\":\"uint256\"}],\"name\":\"isValidatorSlashed\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"keyIndex\",\"type\":\"uint256\"}],\"name\":\"isValidatorWithdrawn\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"keyRemovalCharge\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"}],\"name\":\"normalizeQueue\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"depositsCount\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"\",\"type\":\"bytes\"}],\"name\":\"obtainDepositData\",\"outputs\":[{\"internalType\":\"bytes\",\"name\":\"publicKeys\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"signatures\",\"type\":\"bytes\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"onExitedAndStuckValidatorsCountsUpdated\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"totalShares\",\"type\":\"uint256\"}],\"name\":\"onRewardsMinted\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"onWithdrawalCredentialsChanged\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"duration\",\"type\":\"uint256\"}],\"name\":\"pauseFor\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"proposedAddress\",\"type\":\"address\"}],\"name\":\"proposeNodeOperatorManagerAddressChange\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"proposedAddress\",\"type\":\"address\"}],\"name\":\"proposeNodeOperatorRewardAddressChange\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"publicRelease\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"token\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"tokenId\",\"type\":\"uint256\"}],\"name\":\"recoverERC1155\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"token\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"recoverERC20\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"token\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"tokenId\",\"type\":\"uint256\"}],\"name\":\"recoverERC721\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"recoverEther\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"recoverStETHShares\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"startIndex\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"keysCount\",\"type\":\"uint256\"}],\"name\":\"removeKeys\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"role\",\"type\":\"bytes32\"},{\"internalType\":\"address\",\"name\":\"callerConfirmation\",\"type\":\"address\"}],\"name\":\"renounceRole\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"},{\"internalType\":\"bytes32\",\"name\":\"blockHash\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"reportELRewardsStealingPenalty\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"}],\"name\":\"resetNodeOperatorManagerAddress\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"resume\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"role\",\"type\":\"bytes32\"},{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"}],\"name\":\"revokeRole\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"setKeyRemovalCharge\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256[]\",\"name\":\"nodeOperatorIds\",\"type\":\"uint256[]\"}],\"name\":\"settleELRewardsStealingPenalty\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"keyIndex\",\"type\":\"uint256\"}],\"name\":\"submitInitialSlashing\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"keyIndex\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"},{\"internalType\":\"bool\",\"name\":\"isSlashed\",\"type\":\"bool\"}],\"name\":\"submitWithdrawal\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes4\",\"name\":\"interfaceId\",\"type\":\"bytes4\"}],\"name\":\"supportsInterface\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"exitedValidatorsKeysCount\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"stuckValidatorsKeysCount\",\"type\":\"uint256\"}],\"name\":\"unsafeUpdateValidatorsCount\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes\",\"name\":\"nodeOperatorIds\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"exitedValidatorsCounts\",\"type\":\"bytes\"}],\"name\":\"updateExitedValidatorsCount\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"updateRefundedValidatorsCount\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes\",\"name\":\"nodeOperatorIds\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"stuckValidatorsCounts\",\"type\":\"bytes\"}],\"name\":\"updateStuckValidatorsCount\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"nodeOperatorId\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"targetLimitMode\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"targetLimit\",\"type\":\"uint256\"}],\"name\":\"updateTargetValidatorsLimits\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}]",
+	Bin: "0x6080604052600436106104e7575f3560e01c80638b3ac71d11610283578063ba1557ae11610155578063dbba4b48116100c9578063f2e2ca6311610083578063f2e2ca6314611224578063f3f449c714611243578063f408b55114611262578063f617eecc14611281578063f96d3952146112cb578063fe7ed3cd146112ea575f80fd5b8063dbba4b4814611138578063e00bfe501461116b578063e1aa105d1461119e578063e21a430b146111bd578063e7705db6146111dd578063e864299e14611210575f80fd5b8063cb17ed3e1161011a578063cb17ed3e14611077578063d087d288146110aa578063d3931457146110be578063d547741f146110d2578063d6477919146110f1578063d9df8c9214611124575f80fd5b8063ba1557ae14610fc8578063bdac46a214610fe7578063be2030941461101a578063bee41b5814611039578063ca15c87314611058575f80fd5b80639b3d1900116101f7578063acc446eb116101b1578063acc446eb14610eca578063acf1c94814610ee9578063b1520dc514610f1c578063b187bd2614610f3b578063b3076c3c14610f4f578063b643189b14610fa9575f80fd5b80639b3d190014610e465780639ec3c24c14610e65578063a217fddf14610e84578063a2e080f114610e97578063a302ee3814610eb6578063a70c70e414610c3e575f80fd5b806390c09bdb1161024857806390c09bdb14610d7157806391d1485414610d85578063946654ad14610da45780639624e83e14610dc35780639abddf0914610de25780639b00c14614610e27575f80fd5b80638b3ac71d14610cb45780638cabe95914610cd35780638d7e401714610cf25780638ec6902814610d115780639010d07c14610d52575f80fd5b80635204281c116103bc5780636a5f2c4a1161033057806380231f15116102ea57806380231f1514610be0578063819d4cc614610c005780638409d4fe14610c1f5780638469cbd314610c3e5780638573e35114610c625780638980f11f14610c95575f80fd5b80636a5f2c4a14610b325780636a6304cc14610b515780636bb1bfdf14610b705780636efe37a214610b8f578063735dfa2814610ba257806375a401da14610bc1575f80fd5b806359e25c121161038157806359e25c12146108e85780635a73bdc8146109145780635c654ad9146109285780635e169fb8146109475780635e2fb9081461096657806365c14dc714610997575f80fd5b80635204281c1461086f57806352d8bfc21461088e57806353433643146108a25780635358fbda146108c1578063589ff76c146108d4575f80fd5b806337b12b5f1161045e5780633f214bb2116104185780633f214bb21461078657806340044801146107a557806347faf311146107c45780634febc81b146107f757806350388cb6146108235780635097ef5914610850575f80fd5b806337b12b5f146106a4578063388dd1d1146106c3578063389ed267146106e25780633dbe8b5a146107155780633df6c438146107345780633f04f0c814610753575f80fd5b80631b40b231116104af5780631b40b231146105a3578063248a9ca3146105c257806326a666e4146105fc5780632de03aa1146106335780632f2ff15d1461066657806336568abe14610685575f80fd5b806301ffc9a7146104eb578063046f7da21461051f57806308a679ad14610535578063157a039b1461055457806315dae03e14610567575b5f80fd5b3480156104f6575f80fd5b5061050a6105053660046152b6565b6112fd565b60405190151581526020015b60405180910390f35b34801561052a575f80fd5b50610533611327565b005b348015610540575f80fd5b5061053361054f3660046152dd565b61135c565b6105336105623660046153b4565b6114b4565b348015610572575f80fd5b507f636f6d6d756e6974792d6f6e636861696e2d76310000000000000000000000005b604051908152602001610516565b3480156105ae575f80fd5b506105336105bd366004615476565b611638565b3480156105cd575f80fd5b506105956105dc3660046154a4565b5f9081525f80516020615f14833981519152602052604090206001015490565b348015610607575f80fd5b5060045461061b906001600160a01b031681565b6040516001600160a01b039091168152602001610516565b34801561063e575f80fd5b506105957f2fc10cc8ae19568712f7a176fb4978616a610650813c9d05326c34abb62749c781565b348015610671575f80fd5b50610533610680366004615476565b6116b1565b348015610690575f80fd5b5061053361069f366004615476565b6116e1565b3480156106af575f80fd5b506105336106be3660046154bb565b611719565b3480156106ce575f80fd5b506105336106dd3660046152dd565b61187e565b3480156106ed575f80fd5b506105957f139c2898040ef16910dc9f44dc697df79363da767d8bc92f2e310312b816e46d81565b348015610720575f80fd5b5061050a61072f3660046154f9565b611985565b34801561073f575f80fd5b5061053361074e366004615519565b6119ab565b34801561075e575f80fd5b506105957fe85fdec10fe0f93d0792364051df7c3d73e37c17b3a954bffe593960e3cd301281565b348015610791575f80fd5b506105336107a0366004615584565b611a3a565b3480156107b0575f80fd5b506105336107bf3660046154f9565b611ab2565b3480156107cf575f80fd5b506105957f000000000000000000000000000000000000000000000000000000000000000a81565b348015610802575f80fd5b506108166108113660046154f9565b611b8b565b60405161051691906155b7565b34801561082e575f80fd5b5061084261083d3660046152dd565b611c73565b60405161051692919061563d565b34801561085b575f80fd5b5061053361086a366004615519565b611ca5565b34801561087a575f80fd5b506105336108893660046154a4565b611cfb565b348015610899575f80fd5b50610533611d5e565b3480156108ad575f80fd5b5061050a6108bc3660046154f9565b611dba565b6105336108cf3660046154a4565b611dca565b3480156108df575f80fd5b50610595611e42565b3480156108f3575f80fd5b506109076109023660046152dd565b611e70565b6040516105169190615661565b34801561091f575f80fd5b50610533611e90565b348015610933575f80fd5b50610533610942366004615673565b611f7e565b348015610952575f80fd5b5061059561096136600461569d565b611fcd565b348015610971575f80fd5b5061050a6109803660046154a4565b600954600160c01b90046001600160401b03161190565b3480156109a2575f80fd5b50610b256109b13660046154a4565b604080516101e0810182525f80825260208201819052918101829052606081018290526080810182905260a0810182905260c0810182905260e08101829052610100810182905261012081018290526101408101829052610160810182905261018081018290526101a081018290526101c0810191909152505f9081526006602090815260409182902082516101e081018452815463ffffffff8082168352600160201b808304821695840195909552600160401b808304821696840196909652600160601b820481166060840152600160801b820481166080840152600160a01b808304821660a0850152600160c01b8304821660c085015260ff600160e01b909304831660e085015260018501548083166101008601529586049091166101208401526001600160a01b0395909404851661014083015260028301548516610160830152600383015485166101808301526004909201549384166101a08201529190920490911615156101c082015290565b60405161051691906156c3565b348015610b3d575f80fd5b50610533610b4c3660046157f0565b611fea565b348015610b5c575f80fd5b50610533610b6b3660046154a4565b612157565b348015610b7b575f80fd5b50610533610b8a3660046154a4565b612196565b610533610b9d3660046154a4565b6121d5565b348015610bad575f80fd5b50610595610bbc3660046154a4565b612211565b348015610bcc575f80fd5b50610533610bdb366004615476565b612293565b348015610beb575f80fd5b506105955f80516020615ef483398151915281565b348015610c0b575f80fd5b50610533610c1a366004615673565b6122e1565b348015610c2a575f80fd5b50610533610c39366004615519565b612330565b348015610c49575f80fd5b50600954600160c01b90046001600160401b0316610595565b348015610c6d575f80fd5b506105957f59911a6aa08a72fe3824aec4500dc42335c6d0702b6d5c5c72ceb265a0de930281565b348015610ca0575f80fd5b50610533610caf366004615673565b612386565b348015610cbf575f80fd5b50610533610cce3660046152dd565b6123d5565b348015610cde575f80fd5b50610533610ced366004615476565b612583565b348015610cfd575f80fd5b50610533610d0c3660046154a4565b6125d1565b348015610d1c575f80fd5b50610595610d2b3660046154a4565b5f9081526006602052604090205463ffffffff600160201b82048116918116919091031690565b348015610d5d575f80fd5b5061061b610d6c3660046154f9565b6126f9565b348015610d7c575f80fd5b50610533612731565b348015610d90575f80fd5b5061050a610d9f366004615476565b612751565b348015610daf575f80fd5b50610533610dbe3660046158c6565b612787565b348015610dce575f80fd5b5060035461061b906001600160a01b031681565b348015610ded575f80fd5b50600954604080516001600160401b03600160401b8404811682528084166020830152600160801b90930490921690820152606001610516565b348015610e32575f80fd5b50610533610e41366004615954565b612886565b348015610e51575f80fd5b50610533610e60366004615954565b6128e8565b348015610e70575f80fd5b50610533610e7f3660046158c6565b612940565b348015610e8f575f80fd5b506105955f81565b348015610ea2575f80fd5b50610533610eb13660046154f9565b6129fa565b348015610ec1575f80fd5b506105955f1981565b348015610ed5575f80fd5b50610533610ee43660046157f0565b612a2a565b348015610ef4575f80fd5b506105957fb3e25b5404b87e5a838579cb5d7481d61ad96ee284d38ec1e97c07ba64e7f6fc81565b348015610f27575f80fd5b50610533610f363660046154a4565b612b4e565b348015610f46575f80fd5b5061050a612b9d565b348015610f5a575f80fd5b50610f6e610f693660046154a4565b612bcd565b604080519889526020890197909752958701949094526060860192909252608085015260a084015260c083015260e082015261010001610516565b348015610fb4575f80fd5b50610533610fc3366004615954565b612d38565b348015610fd3575f80fd5b50610533610fe23660046154a4565b612e83565b348015610ff2575f80fd5b506105957f000000000000000000000000000000000000000000000000016345785d8a000081565b348015611025575f80fd5b506105336110343660046159ba565b612eba565b348015611044575f80fd5b50610842611053366004615a0a565b6130fb565b348015611063575f80fd5b506105956110723660046154a4565b613413565b348015611082575f80fd5b506105957f79dfcec784e591aafcf60db7db7b029a5c8b12aac4afd4e8c4eb740430405fa681565b3480156110b5575f80fd5b50600554610595565b3480156110c9575f80fd5b50610533613451565b3480156110dd575f80fd5b506105336110ec366004615476565b6134e4565b3480156110fc575f80fd5b506105957f0000000000000000000000000000000000000000000000000de0b6b3a764000081565b34801561112f575f80fd5b506105955f5481565b348015611143575f80fd5b5061061b7f00000000000000000000000028fab2059c713a7f9d8c86db49f9bb0e96af1ef881565b348015611176575f80fd5b5061061b7f0000000000000000000000003f1c547b21f65e10480de3ad8e19faac46c9503481565b3480156111a9575f80fd5b506105336111b8366004615584565b613514565b3480156111c8575f80fd5b5060045461050a90600160a01b900460ff1681565b3480156111e8575f80fd5b506105957f0ce23c3e399818cfee81a7ab0880f714e53d7672b08df0fa62f2843416e1ea0981565b34801561121b575f80fd5b50610533613553565b34801561122f575f80fd5b5061053361123e3660046152dd565b61356a565b34801561124e575f80fd5b5061053361125d3660046154a4565b61359f565b34801561126d575f80fd5b5061053361127c366004615a65565b6135d2565b34801561128c575f80fd5b506001546112ab906001600160801b0380821691600160801b90041682565b604080516001600160801b03938416815292909116602083015201610516565b3480156112d6575f80fd5b506105336112e53660046154f9565b613849565b6105336112f8366004615aa1565b6139cc565b5f6001600160e01b03198216635a05180f60e01b1480611321575061132182613ade565b92915050565b7f2fc10cc8ae19568712f7a176fb4978616a610650813c9d05326c34abb62749c761135181613b12565b611359613b1c565b50565b5f80516020615ef483398151915261137381613b12565b60ff8311156113955760405163b4fa3fb360e01b815260040160405180910390fd5b63ffffffff8211156113ba5760405163b4fa3fb360e01b815260040160405180910390fd5b6113c384613b71565b5f8481526006602052604090208054600160e01b900460ff16841480156113f757508054600160c01b900463ffffffff1683145b1561140257506114ae565b8054600160e01b900460ff16841461142b57805460ff60e01b1916600160e01b60ff8616021781555b8054600160c01b900463ffffffff16831461145d57805463ffffffff60c01b1916600160c01b63ffffffff8516021781555b604080518581526020810185905286917ff92eb109ce5b449e9b121c352c6aeb4319538a90738cb95d84f08e41274e92d2910160405180910390a26114a4855f6001613ba7565b6114ac613e23565b505b50505050565b6114bc613e63565b5f6114c985838686613e8b565b600354604051636e13f09960e01b8152600481018390529192506001600160a01b031690630f23e742908c908390636e13f099906024015f60405180830381865afa15801561151a573d5f803e3d5ffd5b505050506040513d5f823e601f3d908101601f191682016040526115419190810190615b89565b6040518363ffffffff1660e01b815260040161155e929190615c5b565b602060405180830381865afa158015611579573d5f803e3d5ffd5b505050506040513d601f19601f8201168201806040525081019061159d9190615cc3565b34146115bc5760405163162908e360e11b815260040160405180910390fd5b600354604051630b96641560e21b8152336004820152602481018390526001600160a01b0390911690632e5990549034906044015f604051808303818588803b158015611607575f80fd5b505af1158015611619573d5f803e3d5ffd5b505050505061162c818b8b8b8b8b614214565b50505050505050505050565b60405162d74f0b60e71b815260066004820152602481018390526001600160a01b038216604482015273f8e5de8baf8ad7c93dcb61d13d00eb3d57131c7290636ba78580906064015b5f6040518083038186803b158015611697575f80fd5b505af41580156116a9573d5f803e3d5ffd5b505050505050565b5f8281525f80516020615f1483398151915260205260409020600101546116d781613b12565b6114ae8383614372565b6001600160a01b038116331461170a5760405163334bd91960e11b815260040160405180910390fd5b61171482826143be565b505050565b7fe85fdec10fe0f93d0792364051df7c3d73e37c17b3a954bffe593960e3cd301261174381613b12565b5f5b828110156114ae575f84848381811061176057611760615cda565b90506020020135905061177281613b71565b6003546040516325d9153960e11b8152600481018390525f916001600160a01b031690634bb22a72906024016020604051808303815f875af11580156117ba573d5f803e3d5ffd5b505050506040513d601f19601f820116820180604052508101906117de9190615cc3565b9050801561184b5760035460405163449add1b60e01b8152600481018490526001600160a01b039091169063449add1b906024015f604051808303815f87803b158015611829575f80fd5b505af115801561183b573d5f803e3d5ffd5b5050505061184b8260015f613ba7565b60405182907ef4fe19c0404d2fbb58da6f646c0a3ee5a6994a034213bbd22b072ed1ca5c27905f90a25050600101611745565b7f59911a6aa08a72fe3824aec4500dc42335c6d0702b6d5c5c72ceb265a0de93026118a881613b12565b6118b184613b71565b6003546001600160a01b031663dcab7f83856118ed7f000000000000000000000000000000000000000000000000016345785d8a000086615d02565b6040516001600160e01b031960e085901b168152600481019290925260248201526044015f604051808303815f87803b158015611928575f80fd5b505af115801561193a573d5f803e3d5ffd5b505060408051868152602081018690528793507feec4d6dbe34149c6728a9638eca869d0e5a7fcd85c7a96178f7e9780b4b7fe4b92500160405180910390a26114ae8460015f613ba7565b5f600881608085901b84175b815260208101919091526040015f205460ff169392505050565b6119b48561440a565b600380545f878152600660205260409081902090920154915163cc810cb960e01b81526001600160a01b039182169263cc810cb992611a01928a928a921690899089908990600401615d45565b5f604051808303815f87803b158015611a18575f80fd5b505af1158015611a2a573d5f803e3d5ffd5b505050506114ac85600180613ba7565b611a4383613b71565b600354604051637bcb377f60e11b81526001600160a01b039091169063f7966efe90611a79903390879087908790600401615d85565b5f604051808303815f87803b158015611a90575f80fd5b505af1158015611aa2573d5f803e3d5ffd5b5050505061171483600180613ba7565b7f59911a6aa08a72fe3824aec4500dc42335c6d0702b6d5c5c72ceb265a0de9302611adc81613b12565b611ae583613b71565b60035460405163d963ae5560e01b815260048101859052602481018490526001600160a01b039091169063d963ae55906044015f604051808303815f87803b158015611b2f575f80fd5b505af1158015611b41573d5f803e3d5ffd5b50505050827f1e7ebd3c5f4de9502000b6f7e6e7cf5d4ecb27d6fe1778e43fb9d1d0ca87d0e783604051611b7791815260200190565b60405180910390a261171483600180613ba7565b600954606090600160c01b90046001600160401b03168084101580611bae575082155b15611bc8575050604080515f815260208101909152611321565b5f611bd38583615ded565b8410611be857611be38583615ded565b611bea565b835b9050806001600160401b03811115611c0457611c04615b1d565b604051908082528060200260200182016040528015611c2d578160200160208202803683370190505b5092505f5b8351811015611c6a57611c458187615d02565b848281518110611c5757611c57615cda565b6020908102919091010152600101611c32565b50505092915050565b606080611c81858585614498565b611c8a836144d5565b9092509050611c9d85858585855f61457b565b935093915050565b611cae8561440a565b600380545f87815260066020526040908190209092015491516370903eb960e01b81526001600160a01b03918216926370903eb992611a01928a928a921690899089908990600401615d45565b604051631f46d51760e01b8152600660048201526024810182905273f8e5de8baf8ad7c93dcb61d13d00eb3d57131c7290631f46d517906044015b5f6040518083038186803b158015611d4c575f80fd5b505af41580156114ac573d5f803e3d5ffd5b611d66614609565b73a74528edc289b1a597faf83fcff7eff871cc01d96352d8bfc26040518163ffffffff1660e01b81526004015f6040518083038186803b158015611da8575f80fd5b505af41580156114ae573d5f803e3d5ffd5b5f600781608085901b8417611991565b611dd381613b71565b600354604051630b96641560e21b8152336004820152602481018390526001600160a01b0390911690632e5990549034906044015b5f604051808303818588803b158015611e1f575f80fd5b505af1158015611e31573d5f803e3d5ffd5b505050505061135981600180613ba7565b5f611e6b7fe8b012900cb200ee5dfc3b895a32791b67d12891b09f117814f167a237783a025490565b905090565b6060611e7d848484614498565b611e88848484614632565b949350505050565b611e98614609565b604051633d7ad0b760e21b815230600482015273a74528edc289b1a597faf83fcff7eff871cc01d9906389ad9443907f0000000000000000000000003f1c547b21f65e10480de3ad8e19faac46c95034906001600160a01b0382169063f5eb42dc90602401602060405180830381865afa158015611f18573d5f803e3d5ffd5b505050506040513d601f19601f82011682018060405250810190611f3c9190615cc3565b6040516001600160e01b031960e085901b1681526001600160a01b03909216600483015260248201526044015f6040518083038186803b158015611da8575f80fd5b611f86614609565b604051635c654ad960e01b81526001600160a01b03831660048201526024810182905273a74528edc289b1a597faf83fcff7eff871cc01d990635c654ad990604401611681565b6001600160801b0381165f90815260026020526040812054611321565b611ff2613e63565b5f611fff86838686613e8b565b600354604051636e13f09960e01b8152600481018390529192505f916001600160a01b0390911690630f23e742908e908390636e13f099906024015f60405180830381865afa158015612054573d5f803e3d5ffd5b505050506040513d5f823e601f3d908101601f1916820160405261207b9190810190615b89565b6040518363ffffffff1660e01b8152600401612098929190615c5b565b602060405180830381865afa1580156120b3573d5f803e3d5ffd5b505050506040513d601f19601f820116820180604052508101906120d79190615cc3565b60035460405163263f69e960e11b81529192506001600160a01b031690634c7ed3d29061210e903390869086908c90600401615d85565b5f604051808303815f87803b158015612125575f80fd5b505af1158015612137573d5f803e3d5ffd5b50505050612149828d8d8d8d8d614214565b505050505050505050505050565b60405163612b8c3b60e11b8152600660048201526024810182905273f8e5de8baf8ad7c93dcb61d13d00eb3d57131c729063c257187690604401611d36565b60405163c990450f60e01b8152600660048201526024810182905273f8e5de8baf8ad7c93dcb61d13d00eb3d57131c729063c990450f90604401611d36565b6121de81613b71565b6003546040516315b5c47760e01b8152600481018390526001600160a01b03909116906315b5c477903490602401611e08565b6040516351fbfaa560e11b81526001600482015260066024820152604481018290525f90739031730603ea1a523b34d4b04b81ea7a08db0fc49063a3f7f54a90606401602060405180830381865af415801561226f573d5f803e3d5ffd5b505050506040513d601f19601f820116820180604052508101906113219190615cc3565b6040516317a9a2c160e11b815260066004820152602481018390526001600160a01b038216604482015273f8e5de8baf8ad7c93dcb61d13d00eb3d57131c7290632f53458290606401611681565b6122e9614609565b6040516340cea66360e11b81526001600160a01b03831660048201526024810182905273a74528edc289b1a597faf83fcff7eff871cc01d99063819d4cc690604401611681565b6123398561440a565b600380545f878152600660205260409081902090920154915163f939122360e01b81526001600160a01b039182169263f939122392611a01928a928a921690899089908990600401615d45565b61238e614609565b604051638980f11f60e01b81526001600160a01b03831660048201526024810182905273a74528edc289b1a597faf83fcff7eff871cc01d990638980f11f90604401611681565b6123de836146cd565b5f8381526006602052604090208054600160401b900463ffffffff1683101561241a57604051635caf530f60e11b815260040160405180910390fd5b80545f906124339086908690869063ffffffff16614740565b90505f835f546124439190615e00565b905080156124d657600354604051632207e80f60e21b815260048101889052602481018390526001600160a01b039091169063881fa03c906044015f604051808303815f87803b158015612495575f80fd5b505af11580156124a7573d5f803e3d5ffd5b50506040518892507f1cbb8dafbedbdf4f813a8ed1f50d871def63e1104f8729b677af57905eda90f691505f90a25b825463ffffffff191663ffffffff831617835560405182815286907fdd01838a366ae4dc9a86e1922512c0716abebc9a440baae0e22d2dec578223f09060200160405180910390a2825463ffffffff60601b1916600160601b63ffffffff84160217835560405182815286907f947f955eec7e1f626bee3afd2aa47b5de04ddcdd3fe78dc8838213015ef58dfd9060200160405180910390a261257b865f6001613ba7565b6116a9613e23565b604051632a5a705b60e01b815260066004820152602481018390526001600160a01b038216604482015273f8e5de8baf8ad7c93dcb61d13d00eb3d57131c7290632a5a705b90606401611681565b5f80516020615ef48339815191526125e881613b12565b7f0000000000000000000000003f1c547b21f65e10480de3ad8e19faac46c950346001600160a01b0316638fcb4e5b60035f9054906101000a90046001600160a01b03166001600160a01b0316630d43e8ad6040518163ffffffff1660e01b8152600401602060405180830381865afa158015612667573d5f803e3d5ffd5b505050506040513d601f19601f8201168201806040525081019061268b9190615e17565b6040516001600160e01b031960e084901b1681526001600160a01b039091166004820152602481018590526044016020604051808303815f875af11580156126d5573d5f803e3d5ffd5b505050506040513d601f19601f820116820180604052508101906117149190615cc3565b5f8281527fc1f6fe24621ce81ec5827caf0253cadb74709b061630e6b55e82371705932000602081905260408220611e8890846148ca565b5f80516020615ef483398151915261274881613b12565b6113595f6148d5565b5f9182525f80516020615f14833981519152602090815260408084206001600160a01b0393909316845291905290205460ff1690565b61278f613e63565b612798876146cd565b6003546040516358a46db560e11b815260048101899052602481018890525f916001600160a01b03169063b148db6a90604401602060405180830381865afa1580156127e6573d5f803e3d5ffd5b505050506040513d601f19601f8201168201806040525081019061280a9190615cc3565b60035460405163263f69e960e11b81529192506001600160a01b031690634c7ed3d2906128419033908c9086908890600401615d85565b5f604051808303815f87803b158015612858575f80fd5b505af115801561286a573d5f803e3d5ffd5b5050505061287c888888888888614214565b5050505050505050565b5f80516020615ef483398151915261289d81613b12565b5f6128aa86868686614910565b90505f5b818110156128df576008810287013560c01c6010820286013560801c6128d582825f614983565b50506001016128ae565b506116a9613e23565b5f80516020615ef48339815191526128ff81613b12565b5f61290c86868686614910565b90505f5b818110156128df576008810287013560c01c6010820286013560801c6129368282614aa4565b5050600101612910565b612948613e63565b612951876146cd565b600354604051632884698160e01b815260048101899052602481018890525f916001600160a01b031690632884698190604401602060405180830381865afa15801561299f573d5f803e3d5ffd5b505050506040513d601f19601f820116820180604052508101906129c39190615cc3565b600354604051637bcb377f60e11b81529192506001600160a01b03169063f7966efe906128419033908c9086908890600401615d85565b5f80516020615ef4833981519152612a1181613b12565b604051630280e1e560e61b815260040160405180910390fd5b612a32613e63565b5f612a3f86838686613e8b565b600354604051636e13f09960e01b8152600481018390529192505f916001600160a01b0390911690639a4df8f0908e908390636e13f099906024015f60405180830381865afa158015612a94573d5f803e3d5ffd5b505050506040513d5f823e601f3d908101601f19168201604052612abb9190810190615b89565b6040518363ffffffff1660e01b8152600401612ad8929190615c5b565b602060405180830381865afa158015612af3573d5f803e3d5ffd5b505050506040513d601f19601f82011682018060405250810190612b179190615cc3565b600354604051637bcb377f60e11b81529192506001600160a01b03169063f7966efe9061210e903390869086908c90600401615d85565b612b57816146cd565b604051633f58c75d60e21b8152600160048201526006602482015260448101829052739031730603ea1a523b34d4b04b81ea7a08db0fc49063fd631d7490606401611d36565b5f612bc67fe8b012900cb200ee5dfc3b895a32791b67d12891b09f117814f167a237783a025490565b4210905090565b5f818152600660205260408082206003549151634e28b08160e11b815260048101859052839283928392839283928392839283916001600160a01b0390911690639c51610290602401602060405180830381865afa158015612c31573d5f803e3d5ffd5b505050506040513d601f19601f82011682018060405250810190612c559190615cc3565b90505f81118015612c7157508154600160e01b900460ff166002145b15612cac57815460029a50612ca59063ffffffff600160c01b8204811691600160201b810482169082160316839003614c17565b9850612cf6565b8015612cd857815460029a5063ffffffff600160201b8204811691811691909103168190039850612cf6565b8154600160e01b810460ff169a50600160c01b900463ffffffff1698505b508054600190910154989a97995063ffffffff600160801b82048116995f998a99509082169750600160401b830482169650600160a01b909204169350915050565b5f80516020615ef4833981519152612d4f81613b12565b5f612d5c86868686614910565b90505f5b818110156128df576008810287013560c01c6010820286013560801c612d8582613b71565b5f8281526006602052604090208054600160601b900463ffffffff168210612dc0576040516388e1a28160e01b815260040160405180910390fd5b8054600160401b900463ffffffff16821015612def576040516388e1a28160e01b815260040160405180910390fd5b805463ffffffff60601b1916600160601b63ffffffff84160217815560405182815283907f947f955eec7e1f626bee3afd2aa47b5de04ddcdd3fe78dc8838213015ef58dfd9060200160405180910390a260405183907fe5725d045d5c47bd1483feba445e395dc8647486963e6d54aad9ed03ff7d6ce6905f90a2612e75835f80613ba7565b505050806001019050612d60565b7f79dfcec784e591aafcf60db7db7b029a5c8b12aac4afd4e8c4eb740430405fa6612ead81613b12565b612eb6826148d5565b5050565b7ff0c57e16840df040f15088dc2f81fe391c3923bec73e23a9662efc9c229c6a008054600160401b810460ff1615906001600160401b03165f81158015612efe5750825b90505f826001600160401b03166001148015612f195750303b155b905081158015612f27575080155b15612f455760405163f92ee8a960e01b815260040160405180910390fd5b845467ffffffffffffffff191660011785558315612f6f57845460ff60401b1916600160401b1785555b6001600160a01b038916612f96576040516368ea2bc160e01b815260040160405180910390fd5b6001600160a01b038616612fbd57604051633ef39b8160e01b815260040160405180910390fd5b612fc5614c2c565b600380546001600160a01b03808c166001600160a01b03199283161790925560048054928b1692909116919091179055612fff5f87614372565b506130965f80516020615ef48339815191527f00000000000000000000000028fab2059c713a7f9d8c86db49f9bb0e96af1ef86001600160a01b031663ef6c064c6040518163ffffffff1660e01b8152600401602060405180830381865afa15801561306d573d5f803e3d5ffd5b505050506040513d601f19601f820116820180604052508101906130919190615e17565b614372565b506130a0876148d5565b6130aa5f19614c34565b83156130f057845460ff60401b19168555604051600181527fc7f505b2f371ae2175ee4913f4499e1f2633a7b5936321eed1cdaeb6115181d29060200160405180910390a15b505050505050505050565b6060805f80516020615ef483398151915261311581613b12565b61311e866144d5565b9093509150851561340a576001546001600160801b03165f908152600260205260408120548791905b8015613385575f6131588260c01c90565b6001600160401b039081165f8181526006602052604081208054929450608086901c90931692916131a09061319a90600160a01b900463ffffffff1685614c17565b88614c17565b9050808711806131af57508281145b156131f0576001808301805463ffffffff600160201b80830482168890039091160267ffffffff00000000199091161790556131ea90614c83565b5061324e565b60018201805463ffffffff600160201b808304821685900382160267ffffffff00000000199092169190911790915561322f90869083860390614ce216565b6001546001600160801b03165f90815260026020526040902081905594505b805f0361325e5750505050613365565b815461327c908590600160401b900463ffffffff16838d8d8b61457b565b815463ffffffff600160401b80830482168401821681026bffffffff000000000000000019909316929092178085556040519290041681529581019584907f24eb1c9e765ba41accf9437300ea91ece5ed3f897ec3cdee0e9debd7fe309b789060200160405180910390a2815463ffffffff600160a01b808304821684900391821690810263ffffffff60a01b199093169290921784556040519182529085907ff9109091b368cedad2edff45414eef892edd6b4fe80084bd590aa8f8def8ed339060200160405180910390a28188039750875f0361335f575050505050613385565b50505050505b506001546001600160801b03165f90815260026020526040902054613147565b508781146133a657604051630bc9ea5560e21b815260040160405180910390fd5b600980546001600160401b03600160801b80830482168c9003821602808216828416178c0190911667ffffffffffffffff1990911677ffffffffffffffff0000000000000000ffffffffffffffff1990921691909117179055613407613e23565b50505b50935093915050565b5f8181527fc1f6fe24621ce81ec5827caf0253cadb74709b061630e6b55e8237170593200060208190526040822061344a90614d07565b9392505050565b7f79dfcec784e591aafcf60db7db7b029a5c8b12aac4afd4e8c4eb740430405fa661347b81613b12565b600454600160a01b900460ff16156134a65760405163ef65161f60e01b815260040160405180910390fd5b6004805460ff60a01b1916600160a01b1790556040517fe5eb57aa4d841adeece4ac87bd294965df4a894f0aa24db4a4a55a39ab101d6e905f90a150565b5f8281525f80516020615f14833981519152602052604090206001015461350a81613b12565b6114ae83836143be565b61351d83613b71565b60035460405163263f69e960e11b81526001600160a01b0390911690634c7ed3d290611a79903390879087908790600401615d85565b5f80516020615ef483398151915261135981613b12565b5f80516020615ef483398151915261358181613b12565b61358d84846001614983565b6135978483614aa4565b6114ae613e23565b7f139c2898040ef16910dc9f44dc697df79363da767d8bc92f2e310312b816e46d6135c981613b12565b612eb682614c34565b7f0ce23c3e399818cfee81a7ab0880f714e53d7672b08df0fa62f2843416e1ea096135fc81613b12565b61360585613b71565b5f8581526006602052604090208054600160401b900463ffffffff16851061364057604051635caf530f60e11b815260040160405180910390fd5b608086901b85175f8181526007602052604090205460ff161561367657604051639fbfc58960e01b815260040160405180910390fd5b5f8181526007602052604090819020805460ff19166001908117909155835463ffffffff600160201b80830482169093011690910267ffffffff00000000199091161783555187907fcb2f99f65711a7d6df7f552255b910bf59f09fcd5935f44c170b4cb0d1b50995906136f69089908990918252602082015260400190565b60405180910390a283156137b7575f8181526008602052604090205460ff1615613744577f0000000000000000000000000000000000000000000000000de0b6b3a76400008501945061375d565b5f818152600860205260409020805460ff191660011790555b60035460405163449add1b60e01b8152600481018990526001600160a01b039091169063449add1b906024015f604051808303815f87803b1580156137a0575f80fd5b505af11580156137b2573d5f803e3d5ffd5b505050505b846801bc16d674ec80000011156138345760035460405163e5220e3f60e01b8152600481018990526801bc16d674ec80000087900360248201526001600160a01b039091169063e5220e3f906044015f604051808303815f87803b15801561381d575f80fd5b505af115801561382f573d5f803e3d5ffd5b505050505b61384087600180613ba7565b50505050505050565b7f0ce23c3e399818cfee81a7ab0880f714e53d7672b08df0fa62f2843416e1ea0961387381613b12565b61387c83613b71565b5f8381526006602052604090208054600160401b900463ffffffff1683106138b757604051635caf530f60e11b815260040160405180910390fd5b608084901b83175f8181526008602052604090205460ff16156138ed57604051639fbfc58960e01b815260040160405180910390fd5b5f8181526008602052604090819020805460ff191660011790555185907fd34db8e8c0ddbc9c7b6dd8c397623dfbe01929e41e527540bff8794685d9b407906139399087815260200190565b60405180910390a260035460405163e5220e3f60e01b8152600481018790527f0000000000000000000000000000000000000000000000000de0b6b3a764000060248201526001600160a01b039091169063e5220e3f906044015f604051808303815f87803b1580156139aa575f80fd5b505af11580156139bc573d5f803e3d5ffd5b505050506114ac8560015f613ba7565b6139d4613e63565b6139dd866146cd565b6003546040516358a46db560e11b815260048101889052602481018790526001600160a01b039091169063b148db6a90604401602060405180830381865afa158015613a2b573d5f803e3d5ffd5b505050506040513d601f19601f82011682018060405250810190613a4f9190615cc3565b3414613a6e5760405163162908e360e11b815260040160405180910390fd5b600354604051630b96641560e21b8152336004820152602481018890526001600160a01b0390911690632e5990549034906044015f604051808303818588803b158015613ab9575f80fd5b505af1158015613acb573d5f803e3d5ffd5b50505050506116a9868686868686614214565b5f6001600160e01b03198216637965db0b60e01b148061132157506301ffc9a760e01b6001600160e01b0319831614611321565b6113598133614d10565b613b24614d4d565b427fe8b012900cb200ee5dfc3b895a32791b67d12891b09f117814f167a237783a02556040517f62451d457bc659158be6e6247f56ec1df424a5c7597f71c20c2bc44e0965c8f9905f90a1565b600954600160c01b90046001600160401b0316811015613b8e5750565b604051633ed893db60e21b815260040160405180910390fd5b5f8381526006602052604081208054909190613bd99063ffffffff600160401b8204811691600160601b900416615e32565b6003546040516301a5e9e360e01b81526004810188905263ffffffff9290921692505f916001600160a01b03909116906301a5e9e390602401602060405180830381865afa158015613c2d573d5f803e3d5ffd5b505050506040513d601f19601f82011682018060405250810190613c519190615cc3565b905081811115613c63575f9150613c69565b80820391505b8254600160801b900463ffffffff1615801590613c8557505f82115b15613c8e575f91505b8254600160e01b900460ff1615801590613ca757505f82115b15613cff57825463ffffffff600160201b82048116600160401b8304821603811691613cfb91600160c01b909104168210613ce2575f613cf5565b8454600160c01b900463ffffffff168290035b84614c17565b9250505b8254600160a01b900463ffffffff1682146116a95782546009805467ffffffffffffffff60801b198116600160a01b9384900463ffffffff908116600160801b938490046001600160401b039081169190910388011690920217909155845463ffffffff60a01b191690841690910217835560405182815286907ff9109091b368cedad2edff45414eef892edd6b4fe80084bd590aa8f8def8ed339060200160405180910390a28415613db457613db4613e23565b83156116a957604051633f58c75d60e21b8152600160048201526006602482015260448101879052739031730603ea1a523b34d4b04b81ea7a08db0fc49063fd631d74906064015f6040518083038186803b158015613e11575f80fd5b505af415801561162c573d5f803e3d5ffd5b60058054600101908190556040519081527f7220970e1f1f12864ecccd8942690a837c7a8dd45d158cb891eb45a8a69134aa9060200160405180910390a1565b613e6b612b9d565b15613e8957604051630286f07360e31b815260040160405180910390fd5b565b6004545f90600160a01b900460ff16613ed257811580613eb457506004546001600160a01b0316155b15613ed25760405163084a55b960e41b815260040160405180910390fd5b50600954600160c01b90046001600160401b03165f81815260066020908152604082209190613f0390880188615e4f565b6001600160a01b031614613f2357613f1e6020870187615e4f565b613f25565b335b6001820180546001600160a01b0392909216600160401b027fffffffff0000000000000000000000000000000000000000ffffffffffffffff9092169190911790555f613f786040880160208901615e4f565b6001600160a01b031614613f9b57613f966040870160208801615e4f565b613f9d565b335b6003820180546001600160a01b0319166001600160a01b0392909216919091179055613fcf6060870160408801615e6a565b1561400357613fe46060870160408801615e6a565b600482018054911515600160a01b0260ff60a01b199092169190911790555b6009805460016001600160401b03600160c01b80840482168301909116026001600160c01b03909216919091179091556003820154908201546040516001600160a01b0392831692600160401b9092049091169084907ff35982c84fdc94f58d48e901c54c615804cf7d7939b9b8f76ce4d459354e6363905f90a46001600160a01b038516156140c3576040516001600160a01b0386169083907f67334334c388385e5f244703f8a8b28b7f4ffe52909130aca69bc62a8e27f09a905f90a35b82158015906140dc57506004546001600160a01b031615155b1561420b576004805460405163076123b360e21b81526001600160a01b0390911691631d848ecc916141149133918991899101615e83565b5f604051808303815f87803b15801561412b575f80fd5b505af115801561413d573d5f803e3d5ffd5b5050600354600480546040805163464b6c0d60e11b815290516001600160a01b03948516965063b2d03e4d9550889490921692638c96d81a9282820192602092908290030181865afa158015614195573d5f803e3d5ffd5b505050506040513d601f19601f820116820180604052508101906141b99190615cc3565b6040516001600160e01b031960e085901b168152600481019290925260248201526044015f604051808303815f87803b1580156141f4575f80fd5b505af1158015614206573d5f803e3d5ffd5b505050505b50949350505050565b5f868152600660205260409020805460045463ffffffff90911690600160a01b900460ff1615801561426757507f000000000000000000000000000000000000000000000000000000000000000a878201115b15614285576040516347f1bdb360e11b815260040160405180910390fd5b61429488828989898989614d72565b50815463ffffffff600160601b8204811691160361430f57815463ffffffff600160601b80830482168a018216810263ffffffff60601b199093169290921780855560405192900416815288907f947f955eec7e1f626bee3afd2aa47b5de04ddcdd3fe78dc8838213015ef58dfd9060200160405180910390a25b815463ffffffff80821689011663ffffffff199091168117835560405190815288907fdd01838a366ae4dc9a86e1922512c0716abebc9a440baae0e22d2dec578223f09060200160405180910390a261436a885f6001613ba7565b61287c613e23565b5f7fc1f6fe24621ce81ec5827caf0253cadb74709b061630e6b55e823717059320008161439f8585614f06565b90508015611e88575f85815260208390526040902061420b9085614fae565b5f7fc1f6fe24621ce81ec5827caf0253cadb74709b061630e6b55e82371705932000816143eb8585614fc2565b90508015611e88575f85815260208390526040902061420b908561503b565b5f8181526006602052604090206001810154600160401b90046001600160a01b031661444957604051633ed893db60e21b815260040160405180910390fd5b6001810154600160401b90046001600160a01b0316331480159061447a575060038101546001600160a01b03163314155b15612eb65760405163743a3f7960e11b815260040160405180910390fd5b5f8381526006602052604090205463ffffffff166144b68284615d02565b111561171457604051635caf530f60e11b815260040160405180910390fd5b6060806144e3603084615e00565b6001600160401b038111156144fa576144fa615b1d565b6040519080825280601f01601f191660200182016040528015614524576020820181803683370190505b50614530606085615e00565b6001600160401b0381111561454757614547615b1d565b6040519080825280601f01601f191660200182016040528015614571576020820181803683370190505b5091509150915091565b5f805b8581101561287c576145bc88614594838a615d02565b7f059e9c54cf92ba46cc39c6b4acd51d5116e9d49fabee6193530ea918b54be94a919061504f565b60018082015460801c85840160308181028a01908101929092528354602092830152600284015460609182028901928301526003840154604083015260048401549101529092500161457e565b613e897fb3e25b5404b87e5a838579cb5d7481d61ad96ee284d38ec1e97c07ba64e7f6fc613b12565b60605f614640603084615e00565b6001600160401b0381111561465757614657615b1d565b6040519080825280601f01601f191660200182016040528015614681576020820181803683370190505b5091505f5b838110156146c45761469c866145948388615d02565b9150603081026020840101600183015460801c60108201528254815250600181019050614686565b50509392505050565b5f8181526006602052604090206001810154600160401b90046001600160a01b031661470c57604051633ed893db60e21b815260040160405180910390fd5b6001810154600160401b90046001600160a01b03163314612eb65760405163743a3f7960e11b815260040160405180910390fd5b5f8215806147565750816147548486615d02565b115b80614764575063ffffffff82115b156147825760405163575697ff60e01b815260040160405180910390fd5b604080516030808252606082019092525f91829182918291906020820181803683370190505090508787015b888111156148bc576147e47f059e9c54cf92ba46cc39c6b4acd51d5116e9d49fabee6193530ea918b54be94a8b5f19840161504f565b9450600185015460801c60308301528454602083015286811015614856576148307f059e9c54cf92ba46cc39c6b4acd51d5116e9d49fabee6193530ea918b54be94a8b5f198a0161504f565b93505f92505b6005831015614852578284015483860155600183019250614836565b8394505b5f92505b6005831015614873575f8386015560018301925061485a565b600187039650600181039050897fea4b75aaf57196f73d338cadf79ecd0a437902e2dd0d2c4c2cf3ea71b8ab27b9836040516148af9190615661565b60405180910390a26147ae565b509498975050505050505050565b5f61344a8383615086565b5f8190556040518181527f699ec9c671aad1f3dcc15e571375584a1d6fb7176afd545d14467fd31477e98e906020015b60405180910390a150565b5f61491c600885615eb9565b614927601084615eb9565b14158061493d575061493a600885615ecc565b15155b80614951575061494e601083615ecc565b15155b1561496f5760405163319c9a2160e21b815260040160405180910390fd5b61497a600885615eb9565b95945050505050565b61498c83613b71565b5f838152600660205260409020600181015463ffffffff1683036149b05750505050565b8054600160401b900463ffffffff168311156149df5760405163cc11217f60e01b815260040160405180910390fd5b811580156149f65750600181015463ffffffff1683105b15614a14576040516371a4bd1560e01b815260040160405180910390fd5b6001810180546009805463ffffffff9283166001600160401b03600160401b808404821692909203890116026fffffffffffffffff000000000000000019909116179055815490851663ffffffff1990911617905560405183815284907f0f67960648751434ae86bf350db61194f387fda387e7f568b0ccd0ae0c2201669060200160405180910390a250505050565b614aad82613b71565b5f8281526006602052604090208054600160801b900463ffffffff168203614ad457505050565b6001810154815463ffffffff918216600160401b90910482160316821115614b0f57604051636af5e8d960e11b815260040160405180910390fd5b805463ffffffff60801b1916600160801b63ffffffff84160217815560405182815283907fb4f5879eca27b32881cec7907d1310378e9b4c79927062fb7d4a321434b5b04a9060200160405180910390a25f82118015614b7c57508054600160a01b900463ffffffff1615155b15614c0c5780546009805467ffffffffffffffff60801b198116600160a01b90930463ffffffff16600160801b918290046001600160401b03908116919091031602919091179055805463ffffffff60a01b191681556040515f815283907ff9109091b368cedad2edff45414eef892edd6b4fe80084bd590aa8f8def8ed339060200160405180910390a2505050565b611714835f80613ba7565b5f818310614c25578161344a565b5090919050565b613e896150ac565b614c3c613e63565b805f03614c5c5760405163ad58bfc760e01b815260040160405180910390fd5b5f5f198203614c6d57505f19614c7a565b614c778242615d02565b90505b612eb6816150f5565b80546001600160801b03165f90815260018201602052604090205480614cbc576040516363c3654960e01b815260040160405180910390fd5b81546fffffffffffffffffffffffffffffffff19166001600160801b0382161790915590565b60801b67ffffffffffffffff60801b1667ffffffffffffffff60801b19919091161790565b5f611321825490565b614d1a8282612751565b612eb65760405163e2517d3f60e01b81526001600160a01b03821660048201526024810183905260440160405180910390fd5b614d55612b9d565b613e895760405163b047186b60e01b815260040160405180910390fd5b5f851580614d8c575063ffffffff614d8a8789615d02565b115b15614daa5760405163575697ff60e01b815260040160405180910390fd5b6030860284141580614dbf5750606086028214155b15614ddd5760405163251f56a160e21b815260040160405180910390fd5b604080516030808252606082019092525f91829182916020820181803683370190505090505f5b89811015614ef657614e377f059e9c54cf92ba46cc39c6b4acd51d5116e9d49fabee6193530ea918b54be94a8d8d61504f565b60308281028b0160108101359185018290523560208501819052919550171592508215614e7757604051630f35a7eb60e21b815260040160405180910390fd5b60208201518455603082015160801b60018501556060810287018035600286015560208101356003860155604081013560048601555060018101905060018b019a508b7fc77a17d6b857abe6d6e6c37301621bc72c4dd52fa8830fb54dfa715c04911a8983604051614ee99190615661565b60405180910390a2614e04565b50989a9950505050505050505050565b5f5f80516020615f14833981519152614f1f8484612751565b614f9e575f848152602082815260408083206001600160a01b03871684529091529020805460ff19166001179055614f543390565b6001600160a01b0316836001600160a01b0316857f2f8788117e7eff1d82e926ec794901d17c78024a50270940304540a733656f0d60405160405180910390a46001915050611321565b5f915050611321565b5092915050565b5f61344a836001600160a01b038416615190565b5f5f80516020615f14833981519152614fdb8484612751565b15614f9e575f848152602082815260408083206001600160a01b0387168085529252808320805460ff1916905551339287917ff6391f5c32d9c69d2a47ea670b442974b53935d1edc7fd64eb21e047a839171b9190a46001915050611321565b5f61344a836001600160a01b0384166151dc565b6040805160208082019590955280820193909352606080840192909252805180840390920182526080909201909152805191012090565b5f825f01828154811061509b5761509b615cda565b905f5260205f200154905092915050565b7ff0c57e16840df040f15088dc2f81fe391c3923bec73e23a9662efc9c229c6a0054600160401b900460ff16613e8957604051631afcd79f60e31b815260040160405180910390fd5b61511e7fe8b012900cb200ee5dfc3b895a32791b67d12891b09f117814f167a237783a02829055565b5f198103615157576040515f1981527f32fb7c9891bc4f963c7de9f1186d2a7755c7d6e9f4604dabe1d8bb3027c2f49e90602001614905565b7f32fb7c9891bc4f963c7de9f1186d2a7755c7d6e9f4604dabe1d8bb3027c2f49e6151824283615ded565b604051908152602001614905565b5f8181526001830160205260408120546151d557508154600181810184555f848152602080822090930184905584548482528286019093526040902091909155611321565b505f611321565b5f8181526001830160205260408120548015614f9e575f6151fe600183615ded565b85549091505f9061521190600190615ded565b9050808214615270575f865f01828154811061522f5761522f615cda565b905f5260205f200154905080875f01848154811061524f5761524f615cda565b5f918252602080832090910192909255918252600188019052604090208390555b855486908061528157615281615edf565b600190038181905f5260205f20015f90559055856001015f8681526020019081526020015f205f905560019350505050611321565b5f602082840312156152c6575f80fd5b81356001600160e01b03198116811461344a575f80fd5b5f805f606084860312156152ef575f80fd5b505081359360208301359350604090920135919050565b5f8083601f840112615316575f80fd5b5081356001600160401b0381111561532c575f80fd5b602083019150836020828501011115615343575f80fd5b9250929050565b5f6060828403121561535a575f80fd5b50919050565b5f8083601f840112615370575f80fd5b5081356001600160401b03811115615386575f80fd5b6020830191508360208260051b8501011115615343575f80fd5b6001600160a01b0381168114611359575f80fd5b5f805f805f805f805f6101008a8c0312156153cd575f80fd5b8935985060208a01356001600160401b03808211156153ea575f80fd5b6153f68d838e01615306565b909a50985060408c013591508082111561540e575f80fd5b61541a8d838e01615306565b909850965086915061542f8d60608e0161534a565b955060c08c0135915080821115615444575f80fd5b506154518c828d01615360565b90945092505060e08a0135615465816153a0565b809150509295985092959850929598565b5f8060408385031215615487575f80fd5b823591506020830135615499816153a0565b809150509250929050565b5f602082840312156154b4575f80fd5b5035919050565b5f80602083850312156154cc575f80fd5b82356001600160401b038111156154e1575f80fd5b6154ed85828601615360565b90969095509350505050565b5f806040838503121561550a575f80fd5b50508035926020909101359150565b5f805f805f6080868803121561552d575f80fd5b85359450602086013593506040860135925060608601356001600160401b03811115615557575f80fd5b61556388828901615360565b969995985093965092949392505050565b5f60a0828403121561535a575f80fd5b5f805f60e08486031215615596575f80fd5b83359250602084013591506155ae8560408601615574565b90509250925092565b602080825282518282018190525f9190848201906040850190845b818110156155ee578351835292840192918401916001016155d2565b50909695505050505050565b5f81518084525f5b8181101561561e57602081850181015186830182015201615602565b505f602082860101526020601f19601f83011685010191505092915050565b604081525f61564f60408301856155fa565b828103602084015261497a81856155fa565b602081525f61344a60208301846155fa565b5f8060408385031215615684575f80fd5b823561568f816153a0565b946020939093013593505050565b5f602082840312156156ad575f80fd5b81356001600160801b038116811461344a575f80fd5b815163ffffffff1681526101e0810160208301516156e9602084018263ffffffff169052565b506040830151615701604084018263ffffffff169052565b506060830151615719606084018263ffffffff169052565b506080830151615731608084018263ffffffff169052565b5060a083015161574960a084018263ffffffff169052565b5060c083015161576160c084018263ffffffff169052565b5060e083015161577660e084018260ff169052565b506101008381015163ffffffff908116918401919091526101208085015190911690830152610140808401516001600160a01b039081169184019190915261016080850151821690840152610180808501518216908401526101a080850151909116908301526101c0928301511515929091019190915290565b5f805f805f805f805f806101a08b8d03121561580a575f80fd5b8a35995060208b01356001600160401b0380821115615827575f80fd5b6158338e838f01615306565b909b50995060408d013591508082111561584b575f80fd5b6158578e838f01615306565b909950975087915061586c8e60608f0161534a565b965061587b8e60c08f01615574565b95506101608d0135915080821115615891575f80fd5b5061589e8d828e01615360565b9094509250506101808b01356158b3816153a0565b809150509295989b9194979a5092959850565b5f805f805f805f610120888a0312156158dd575f80fd5b873596506020880135955060408801356001600160401b0380821115615901575f80fd5b61590d8b838c01615306565b909750955060608a0135915080821115615925575f80fd5b506159328a828b01615306565b909450925061594690508960808a01615574565b905092959891949750929550565b5f805f8060408587031215615967575f80fd5b84356001600160401b038082111561597d575f80fd5b61598988838901615306565b909650945060208701359150808211156159a1575f80fd5b506159ae87828801615306565b95989497509550505050565b5f805f80608085870312156159cd575f80fd5b84356159d8816153a0565b935060208501356159e8816153a0565b92506040850135915060608501356159ff816153a0565b939692955090935050565b5f805f60408486031215615a1c575f80fd5b8335925060208401356001600160401b03811115615a38575f80fd5b615a4486828701615306565b9497909650939450505050565b80358015158114615a60575f80fd5b919050565b5f805f8060808587031215615a78575f80fd5b843593506020850135925060408501359150615a9660608601615a51565b905092959194509250565b5f805f805f8060808789031215615ab6575f80fd5b863595506020870135945060408701356001600160401b0380821115615ada575f80fd5b615ae68a838b01615306565b90965094506060890135915080821115615afe575f80fd5b50615b0b89828a01615306565b979a9699509497509295939492505050565b634e487b7160e01b5f52604160045260245ffd5b604080519081016001600160401b0381118282101715615b5357615b53615b1d565b60405290565b604051601f8201601f191681016001600160401b0381118282101715615b8157615b81615b1d565b604052919050565b5f6020808385031215615b9a575f80fd5b82516001600160401b0380821115615bb0575f80fd5b9084019060408287031215615bc3575f80fd5b615bcb615b31565b825182811115615bd9575f80fd5b8301601f81018813615be9575f80fd5b805183811115615bfb57615bfb615b1d565b8060051b9350615c0c868501615b59565b818152938201860193868101908a861115615c25575f80fd5b928701925b85841015615c4357835182529287019290870190615c2a565b84525050509183015192820192909252949350505050565b8281525f60206040602084015260808301845160408086015281815180845260a0870191506020830193505f92505b80831015615caa5783518252928401926001929092019190840190615c8a565b5060208701516060870152809450505050509392505050565b5f60208284031215615cd3575f80fd5b5051919050565b634e487b7160e01b5f52603260045260245ffd5b634e487b7160e01b5f52601160045260245ffd5b8082018082111561132157611321615cee565b8183525f6001600160fb1b03831115615d2c575f80fd5b8260051b80836020870137939093016020019392505050565b8681528560208201526001600160a01b038516604082015283606082015260a060808201525f615d7960a083018486615d15565b98975050505050505050565b5f610100820190506001600160a01b03861682528460208301528360408301528235606083015260208301356080830152604083013560ff8116808214615dca575f80fd5b60a084015250606083013560c083015260809092013560e0909101529392505050565b8181038181111561132157611321615cee565b808202811582820484141761132157611321615cee565b5f60208284031215615e27575f80fd5b815161344a816153a0565b63ffffffff828116828216039080821115614fa757614fa7615cee565b5f60208284031215615e5f575f80fd5b813561344a816153a0565b5f60208284031215615e7a575f80fd5b61344a82615a51565b6001600160a01b0384168152604060208201525f61497a604083018486615d15565b634e487b7160e01b5f52601260045260245ffd5b5f82615ec757615ec7615ea5565b500490565b5f82615eda57615eda615ea5565b500690565b634e487b7160e01b5f52603160045260245ffdfebb75b874360e0bfd87f964eadd8276d8efb7c942134fc329b513032d0803e0c602dd7bc7dec4dceedda775e58dd541e08a116c6c53815c0bd028192f7b626800a164736f6c6343000818000a",
+}
+
+// CsmoduleABI is the input ABI used to generate the binding from.
+// Deprecated: Use CsmoduleMetaData.ABI instead.
+var CsmoduleABI = CsmoduleMetaData.ABI
+
+// CsmoduleBin is the compiled bytecode used for deploying new contracts.
+// Deprecated: Use CsmoduleMetaData.Bin instead.
+var CsmoduleBin = CsmoduleMetaData.Bin
+
+// DeployCsmodule deploys a new Ethereum contract, binding an instance of Csmodule to it.
+func DeployCsmodule(auth *bind.TransactOpts, backend bind.ContractBackend, moduleType [32]byte, minSlashingPenaltyQuotient *big.Int, elRewardsStealingFine *big.Int, maxKeysPerOperatorEA *big.Int, lidoLocator common.Address) (common.Address, *types.Transaction, *Csmodule, error) {
+	parsed, err := CsmoduleMetaData.GetAbi()
+	if err != nil {
+		return common.Address{}, nil, nil, err
+	}
+	if parsed == nil {
+		return common.Address{}, nil, nil, errors.New("GetABI returned nil")
+	}
+
+	address, tx, contract, err := bind.DeployContract(auth, *parsed, common.FromHex(CsmoduleBin), backend, moduleType, minSlashingPenaltyQuotient, elRewardsStealingFine, maxKeysPerOperatorEA, lidoLocator)
+	if err != nil {
+		return common.Address{}, nil, nil, err
+	}
+	return address, tx, &Csmodule{CsmoduleCaller: CsmoduleCaller{contract: contract}, CsmoduleTransactor: CsmoduleTransactor{contract: contract}, CsmoduleFilterer: CsmoduleFilterer{contract: contract}}, nil
+}
+
+// Csmodule is an auto generated Go binding around an Ethereum contract.
+type Csmodule struct {
+	CsmoduleCaller     // Read-only binding to the contract
+	CsmoduleTransactor // Write-only binding to the contract
+	CsmoduleFilterer   // Log filterer for contract events
+}
+
+// CsmoduleCaller is an auto generated read-only Go binding around an Ethereum contract.
+type CsmoduleCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// CsmoduleTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type CsmoduleTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// CsmoduleFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type CsmoduleFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// CsmoduleSession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type CsmoduleSession struct {
+	Contract     *Csmodule         // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// CsmoduleCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type CsmoduleCallerSession struct {
+	Contract *CsmoduleCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts   // Call options to use throughout this session
+}
+
+// CsmoduleTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type CsmoduleTransactorSession struct {
+	Contract     *CsmoduleTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts   // Transaction auth options to use throughout this session
+}
+
+// CsmoduleRaw is an auto generated low-level Go binding around an Ethereum contract.
+type CsmoduleRaw struct {
+	Contract *Csmodule // Generic contract binding to access the raw methods on
+}
+
+// CsmoduleCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type CsmoduleCallerRaw struct {
+	Contract *CsmoduleCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// CsmoduleTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type CsmoduleTransactorRaw struct {
+	Contract *CsmoduleTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewCsmodule creates a new instance of Csmodule, bound to a specific deployed contract.
+func NewCsmodule(address common.Address, backend bind.ContractBackend) (*Csmodule, error) {
+	contract, err := bindCsmodule(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &Csmodule{CsmoduleCaller: CsmoduleCaller{contract: contract}, CsmoduleTransactor: CsmoduleTransactor{contract: contract}, CsmoduleFilterer: CsmoduleFilterer{contract: contract}}, nil
+}
+
+// NewCsmoduleCaller creates a new read-only instance of Csmodule, bound to a specific deployed contract.
+func NewCsmoduleCaller(address common.Address, caller bind.ContractCaller) (*CsmoduleCaller, error) {
+	contract, err := bindCsmodule(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &CsmoduleCaller{contract: contract}, nil
+}
+
+// NewCsmoduleTransactor creates a new write-only instance of Csmodule, bound to a specific deployed contract.
+func NewCsmoduleTransactor(address common.Address, transactor bind.ContractTransactor) (*CsmoduleTransactor, error) {
+	contract, err := bindCsmodule(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &CsmoduleTransactor{contract: contract}, nil
+}
+
+// NewCsmoduleFilterer creates a new log filterer instance of Csmodule, bound to a specific deployed contract.
+func NewCsmoduleFilterer(address common.Address, filterer bind.ContractFilterer) (*CsmoduleFilterer, error) {
+	contract, err := bindCsmodule(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &CsmoduleFilterer{contract: contract}, nil
+}
+
+// bindCsmodule binds a generic wrapper to an already deployed contract.
+func bindCsmodule(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := CsmoduleMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_Csmodule *CsmoduleRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _Csmodule.Contract.CsmoduleCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_Csmodule *CsmoduleRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Csmodule.Contract.CsmoduleTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_Csmodule *CsmoduleRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _Csmodule.Contract.CsmoduleTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_Csmodule *CsmoduleCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _Csmodule.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_Csmodule *CsmoduleTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Csmodule.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_Csmodule *CsmoduleTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _Csmodule.Contract.contract.Transact(opts, method, params...)
+}
+
+// DEFAULTADMINROLE is a free data retrieval call binding the contract method 0xa217fddf.
+//
+// Solidity: function DEFAULT_ADMIN_ROLE() view returns(bytes32)
+func (_Csmodule *CsmoduleCaller) DEFAULTADMINROLE(opts *bind.CallOpts) ([32]byte, error) {
+	var out []interface{}
+	err := _Csmodule.contract.Call(opts, &out, "DEFAULT_ADMIN_ROLE")
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// DEFAULTADMINROLE is a free data retrieval call binding the contract method 0xa217fddf.
+//
+// Solidity: function DEFAULT_ADMIN_ROLE() view returns(bytes32)
+func (_Csmodule *CsmoduleSession) DEFAULTADMINROLE() ([32]byte, error) {
+	return _Csmodule.Contract.DEFAULTADMINROLE(&_Csmodule.CallOpts)
+}
+
+// DEFAULTADMINROLE is a free data retrieval call binding the contract method 0xa217fddf.
+//
+// Solidity: function DEFAULT_ADMIN_ROLE() view returns(bytes32)
+func (_Csmodule *CsmoduleCallerSession) DEFAULTADMINROLE() ([32]byte, error) {
+	return _Csmodule.Contract.DEFAULTADMINROLE(&_Csmodule.CallOpts)
+}
+
+// ELREWARDSSTEALINGFINE is a free data retrieval call binding the contract method 0xbdac46a2.
+//
+// Solidity: function EL_REWARDS_STEALING_FINE() view returns(uint256)
+func (_Csmodule *CsmoduleCaller) ELREWARDSSTEALINGFINE(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _Csmodule.contract.Call(opts, &out, "EL_REWARDS_STEALING_FINE")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// ELREWARDSSTEALINGFINE is a free data retrieval call binding the contract method 0xbdac46a2.
+//
+// Solidity: function EL_REWARDS_STEALING_FINE() view returns(uint256)
+func (_Csmodule *CsmoduleSession) ELREWARDSSTEALINGFINE() (*big.Int, error) {
+	return _Csmodule.Contract.ELREWARDSSTEALINGFINE(&_Csmodule.CallOpts)
+}
+
+// ELREWARDSSTEALINGFINE is a free data retrieval call binding the contract method 0xbdac46a2.
+//
+// Solidity: function EL_REWARDS_STEALING_FINE() view returns(uint256)
+func (_Csmodule *CsmoduleCallerSession) ELREWARDSSTEALINGFINE() (*big.Int, error) {
+	return _Csmodule.Contract.ELREWARDSSTEALINGFINE(&_Csmodule.CallOpts)
+}
+
+// INITIALSLASHINGPENALTY is a free data retrieval call binding the contract method 0xd6477919.
+//
+// Solidity: function INITIAL_SLASHING_PENALTY() view returns(uint256)
+func (_Csmodule *CsmoduleCaller) INITIALSLASHINGPENALTY(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _Csmodule.contract.Call(opts, &out, "INITIAL_SLASHING_PENALTY")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// INITIALSLASHINGPENALTY is a free data retrieval call binding the contract method 0xd6477919.
+//
+// Solidity: function INITIAL_SLASHING_PENALTY() view returns(uint256)
+func (_Csmodule *CsmoduleSession) INITIALSLASHINGPENALTY() (*big.Int, error) {
+	return _Csmodule.Contract.INITIALSLASHINGPENALTY(&_Csmodule.CallOpts)
+}
+
+// INITIALSLASHINGPENALTY is a free data retrieval call binding the contract method 0xd6477919.
+//
+// Solidity: function INITIAL_SLASHING_PENALTY() view returns(uint256)
+func (_Csmodule *CsmoduleCallerSession) INITIALSLASHINGPENALTY() (*big.Int, error) {
+	return _Csmodule.Contract.INITIALSLASHINGPENALTY(&_Csmodule.CallOpts)
+}
+
+// LIDOLOCATOR is a free data retrieval call binding the contract method 0xdbba4b48.
+//
+// Solidity: function LIDO_LOCATOR() view returns(address)
+func (_Csmodule *CsmoduleCaller) LIDOLOCATOR(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _Csmodule.contract.Call(opts, &out, "LIDO_LOCATOR")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// LIDOLOCATOR is a free data retrieval call binding the contract method 0xdbba4b48.
+//
+// Solidity: function LIDO_LOCATOR() view returns(address)
+func (_Csmodule *CsmoduleSession) LIDOLOCATOR() (common.Address, error) {
+	return _Csmodule.Contract.LIDOLOCATOR(&_Csmodule.CallOpts)
+}
+
+// LIDOLOCATOR is a free data retrieval call binding the contract method 0xdbba4b48.
+//
+// Solidity: function LIDO_LOCATOR() view returns(address)
+func (_Csmodule *CsmoduleCallerSession) LIDOLOCATOR() (common.Address, error) {
+	return _Csmodule.Contract.LIDOLOCATOR(&_Csmodule.CallOpts)
+}
+
+// MAXSIGNINGKEYSPEROPERATORBEFOREPUBLICRELEASE is a free data retrieval call binding the contract method 0x47faf311.
+//
+// Solidity: function MAX_SIGNING_KEYS_PER_OPERATOR_BEFORE_PUBLIC_RELEASE() view returns(uint256)
+func (_Csmodule *CsmoduleCaller) MAXSIGNINGKEYSPEROPERATORBEFOREPUBLICRELEASE(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _Csmodule.contract.Call(opts, &out, "MAX_SIGNING_KEYS_PER_OPERATOR_BEFORE_PUBLIC_RELEASE")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// MAXSIGNINGKEYSPEROPERATORBEFOREPUBLICRELEASE is a free data retrieval call binding the contract method 0x47faf311.
+//
+// Solidity: function MAX_SIGNING_KEYS_PER_OPERATOR_BEFORE_PUBLIC_RELEASE() view returns(uint256)
+func (_Csmodule *CsmoduleSession) MAXSIGNINGKEYSPEROPERATORBEFOREPUBLICRELEASE() (*big.Int, error) {
+	return _Csmodule.Contract.MAXSIGNINGKEYSPEROPERATORBEFOREPUBLICRELEASE(&_Csmodule.CallOpts)
+}
+
+// MAXSIGNINGKEYSPEROPERATORBEFOREPUBLICRELEASE is a free data retrieval call binding the contract method 0x47faf311.
+//
+// Solidity: function MAX_SIGNING_KEYS_PER_OPERATOR_BEFORE_PUBLIC_RELEASE() view returns(uint256)
+func (_Csmodule *CsmoduleCallerSession) MAXSIGNINGKEYSPEROPERATORBEFOREPUBLICRELEASE() (*big.Int, error) {
+	return _Csmodule.Contract.MAXSIGNINGKEYSPEROPERATORBEFOREPUBLICRELEASE(&_Csmodule.CallOpts)
+}
+
+// MODULEMANAGERROLE is a free data retrieval call binding the contract method 0xcb17ed3e.
+//
+// Solidity: function MODULE_MANAGER_ROLE() view returns(bytes32)
+func (_Csmodule *CsmoduleCaller) MODULEMANAGERROLE(opts *bind.CallOpts) ([32]byte, error) {
+	var out []interface{}
+	err := _Csmodule.contract.Call(opts, &out, "MODULE_MANAGER_ROLE")
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// MODULEMANAGERROLE is a free data retrieval call binding the contract method 0xcb17ed3e.
+//
+// Solidity: function MODULE_MANAGER_ROLE() view returns(bytes32)
+func (_Csmodule *CsmoduleSession) MODULEMANAGERROLE() ([32]byte, error) {
+	return _Csmodule.Contract.MODULEMANAGERROLE(&_Csmodule.CallOpts)
+}
+
+// MODULEMANAGERROLE is a free data retrieval call binding the contract method 0xcb17ed3e.
+//
+// Solidity: function MODULE_MANAGER_ROLE() view returns(bytes32)
+func (_Csmodule *CsmoduleCallerSession) MODULEMANAGERROLE() ([32]byte, error) {
+	return _Csmodule.Contract.MODULEMANAGERROLE(&_Csmodule.CallOpts)
+}
+
+// PAUSEINFINITELY is a free data retrieval call binding the contract method 0xa302ee38.
+//
+// Solidity: function PAUSE_INFINITELY() view returns(uint256)
+func (_Csmodule *CsmoduleCaller) PAUSEINFINITELY(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _Csmodule.contract.Call(opts, &out, "PAUSE_INFINITELY")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// PAUSEINFINITELY is a free data retrieval call binding the contract method 0xa302ee38.
+//
+// Solidity: function PAUSE_INFINITELY() view returns(uint256)
+func (_Csmodule *CsmoduleSession) PAUSEINFINITELY() (*big.Int, error) {
+	return _Csmodule.Contract.PAUSEINFINITELY(&_Csmodule.CallOpts)
+}
+
+// PAUSEINFINITELY is a free data retrieval call binding the contract method 0xa302ee38.
+//
+// Solidity: function PAUSE_INFINITELY() view returns(uint256)
+func (_Csmodule *CsmoduleCallerSession) PAUSEINFINITELY() (*big.Int, error) {
+	return _Csmodule.Contract.PAUSEINFINITELY(&_Csmodule.CallOpts)
+}
+
+// PAUSEROLE is a free data retrieval call binding the contract method 0x389ed267.
+//
+// Solidity: function PAUSE_ROLE() view returns(bytes32)
+func (_Csmodule *CsmoduleCaller) PAUSEROLE(opts *bind.CallOpts) ([32]byte, error) {
+	var out []interface{}
+	err := _Csmodule.contract.Call(opts, &out, "PAUSE_ROLE")
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// PAUSEROLE is a free data retrieval call binding the contract method 0x389ed267.
+//
+// Solidity: function PAUSE_ROLE() view returns(bytes32)
+func (_Csmodule *CsmoduleSession) PAUSEROLE() ([32]byte, error) {
+	return _Csmodule.Contract.PAUSEROLE(&_Csmodule.CallOpts)
+}
+
+// PAUSEROLE is a free data retrieval call binding the contract method 0x389ed267.
+//
+// Solidity: function PAUSE_ROLE() view returns(bytes32)
+func (_Csmodule *CsmoduleCallerSession) PAUSEROLE() ([32]byte, error) {
+	return _Csmodule.Contract.PAUSEROLE(&_Csmodule.CallOpts)
+}
+
+// RECOVERERROLE is a free data retrieval call binding the contract method 0xacf1c948.
+//
+// Solidity: function RECOVERER_ROLE() view returns(bytes32)
+func (_Csmodule *CsmoduleCaller) RECOVERERROLE(opts *bind.CallOpts) ([32]byte, error) {
+	var out []interface{}
+	err := _Csmodule.contract.Call(opts, &out, "RECOVERER_ROLE")
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// RECOVERERROLE is a free data retrieval call binding the contract method 0xacf1c948.
+//
+// Solidity: function RECOVERER_ROLE() view returns(bytes32)
+func (_Csmodule *CsmoduleSession) RECOVERERROLE() ([32]byte, error) {
+	return _Csmodule.Contract.RECOVERERROLE(&_Csmodule.CallOpts)
+}
+
+// RECOVERERROLE is a free data retrieval call binding the contract method 0xacf1c948.
+//
+// Solidity: function RECOVERER_ROLE() view returns(bytes32)
+func (_Csmodule *CsmoduleCallerSession) RECOVERERROLE() ([32]byte, error) {
+	return _Csmodule.Contract.RECOVERERROLE(&_Csmodule.CallOpts)
+}
+
+// REPORTELREWARDSSTEALINGPENALTYROLE is a free data retrieval call binding the contract method 0x8573e351.
+//
+// Solidity: function REPORT_EL_REWARDS_STEALING_PENALTY_ROLE() view returns(bytes32)
+func (_Csmodule *CsmoduleCaller) REPORTELREWARDSSTEALINGPENALTYROLE(opts *bind.CallOpts) ([32]byte, error) {
+	var out []interface{}
+	err := _Csmodule.contract.Call(opts, &out, "REPORT_EL_REWARDS_STEALING_PENALTY_ROLE")
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// REPORTELREWARDSSTEALINGPENALTYROLE is a free data retrieval call binding the contract method 0x8573e351.
+//
+// Solidity: function REPORT_EL_REWARDS_STEALING_PENALTY_ROLE() view returns(bytes32)
+func (_Csmodule *CsmoduleSession) REPORTELREWARDSSTEALINGPENALTYROLE() ([32]byte, error) {
+	return _Csmodule.Contract.REPORTELREWARDSSTEALINGPENALTYROLE(&_Csmodule.CallOpts)
+}
+
+// REPORTELREWARDSSTEALINGPENALTYROLE is a free data retrieval call binding the contract method 0x8573e351.
+//
+// Solidity: function REPORT_EL_REWARDS_STEALING_PENALTY_ROLE() view returns(bytes32)
+func (_Csmodule *CsmoduleCallerSession) REPORTELREWARDSSTEALINGPENALTYROLE() ([32]byte, error) {
+	return _Csmodule.Contract.REPORTELREWARDSSTEALINGPENALTYROLE(&_Csmodule.CallOpts)
+}
+
+// RESUMEROLE is a free data retrieval call binding the contract method 0x2de03aa1.
+//
+// Solidity: function RESUME_ROLE() view returns(bytes32)
+func (_Csmodule *CsmoduleCaller) RESUMEROLE(opts *bind.CallOpts) ([32]byte, error) {
+	var out []interface{}
+	err := _Csmodule.contract.Call(opts, &out, "RESUME_ROLE")
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// RESUMEROLE is a free data retrieval call binding the contract method 0x2de03aa1.
+//
+// Solidity: function RESUME_ROLE() view returns(bytes32)
+func (_Csmodule *CsmoduleSession) RESUMEROLE() ([32]byte, error) {
+	return _Csmodule.Contract.RESUMEROLE(&_Csmodule.CallOpts)
+}
+
+// RESUMEROLE is a free data retrieval call binding the contract method 0x2de03aa1.
+//
+// Solidity: function RESUME_ROLE() view returns(bytes32)
+func (_Csmodule *CsmoduleCallerSession) RESUMEROLE() ([32]byte, error) {
+	return _Csmodule.Contract.RESUMEROLE(&_Csmodule.CallOpts)
+}
+
+// SETTLEELREWARDSSTEALINGPENALTYROLE is a free data retrieval call binding the contract method 0x3f04f0c8.
+//
+// Solidity: function SETTLE_EL_REWARDS_STEALING_PENALTY_ROLE() view returns(bytes32)
+func (_Csmodule *CsmoduleCaller) SETTLEELREWARDSSTEALINGPENALTYROLE(opts *bind.CallOpts) ([32]byte, error) {
+	var out []interface{}
+	err := _Csmodule.contract.Call(opts, &out, "SETTLE_EL_REWARDS_STEALING_PENALTY_ROLE")
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// SETTLEELREWARDSSTEALINGPENALTYROLE is a free data retrieval call binding the contract method 0x3f04f0c8.
+//
+// Solidity: function SETTLE_EL_REWARDS_STEALING_PENALTY_ROLE() view returns(bytes32)
+func (_Csmodule *CsmoduleSession) SETTLEELREWARDSSTEALINGPENALTYROLE() ([32]byte, error) {
+	return _Csmodule.Contract.SETTLEELREWARDSSTEALINGPENALTYROLE(&_Csmodule.CallOpts)
+}
+
+// SETTLEELREWARDSSTEALINGPENALTYROLE is a free data retrieval call binding the contract method 0x3f04f0c8.
+//
+// Solidity: function SETTLE_EL_REWARDS_STEALING_PENALTY_ROLE() view returns(bytes32)
+func (_Csmodule *CsmoduleCallerSession) SETTLEELREWARDSSTEALINGPENALTYROLE() ([32]byte, error) {
+	return _Csmodule.Contract.SETTLEELREWARDSSTEALINGPENALTYROLE(&_Csmodule.CallOpts)
+}
+
+// STAKINGROUTERROLE is a free data retrieval call binding the contract method 0x80231f15.
+//
+// Solidity: function STAKING_ROUTER_ROLE() view returns(bytes32)
+func (_Csmodule *CsmoduleCaller) STAKINGROUTERROLE(opts *bind.CallOpts) ([32]byte, error) {
+	var out []interface{}
+	err := _Csmodule.contract.Call(opts, &out, "STAKING_ROUTER_ROLE")
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// STAKINGROUTERROLE is a free data retrieval call binding the contract method 0x80231f15.
+//
+// Solidity: function STAKING_ROUTER_ROLE() view returns(bytes32)
+func (_Csmodule *CsmoduleSession) STAKINGROUTERROLE() ([32]byte, error) {
+	return _Csmodule.Contract.STAKINGROUTERROLE(&_Csmodule.CallOpts)
+}
+
+// STAKINGROUTERROLE is a free data retrieval call binding the contract method 0x80231f15.
+//
+// Solidity: function STAKING_ROUTER_ROLE() view returns(bytes32)
+func (_Csmodule *CsmoduleCallerSession) STAKINGROUTERROLE() ([32]byte, error) {
+	return _Csmodule.Contract.STAKINGROUTERROLE(&_Csmodule.CallOpts)
+}
+
+// STETH is a free data retrieval call binding the contract method 0xe00bfe50.
+//
+// Solidity: function STETH() view returns(address)
+func (_Csmodule *CsmoduleCaller) STETH(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _Csmodule.contract.Call(opts, &out, "STETH")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// STETH is a free data retrieval call binding the contract method 0xe00bfe50.
+//
+// Solidity: function STETH() view returns(address)
+func (_Csmodule *CsmoduleSession) STETH() (common.Address, error) {
+	return _Csmodule.Contract.STETH(&_Csmodule.CallOpts)
+}
+
+// STETH is a free data retrieval call binding the contract method 0xe00bfe50.
+//
+// Solidity: function STETH() view returns(address)
+func (_Csmodule *CsmoduleCallerSession) STETH() (common.Address, error) {
+	return _Csmodule.Contract.STETH(&_Csmodule.CallOpts)
+}
+
+// VERIFIERROLE is a free data retrieval call binding the contract method 0xe7705db6.
+//
+// Solidity: function VERIFIER_ROLE() view returns(bytes32)
+func (_Csmodule *CsmoduleCaller) VERIFIERROLE(opts *bind.CallOpts) ([32]byte, error) {
+	var out []interface{}
+	err := _Csmodule.contract.Call(opts, &out, "VERIFIER_ROLE")
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// VERIFIERROLE is a free data retrieval call binding the contract method 0xe7705db6.
+//
+// Solidity: function VERIFIER_ROLE() view returns(bytes32)
+func (_Csmodule *CsmoduleSession) VERIFIERROLE() ([32]byte, error) {
+	return _Csmodule.Contract.VERIFIERROLE(&_Csmodule.CallOpts)
+}
+
+// VERIFIERROLE is a free data retrieval call binding the contract method 0xe7705db6.
+//
+// Solidity: function VERIFIER_ROLE() view returns(bytes32)
+func (_Csmodule *CsmoduleCallerSession) VERIFIERROLE() ([32]byte, error) {
+	return _Csmodule.Contract.VERIFIERROLE(&_Csmodule.CallOpts)
+}
+
+// Accounting is a free data retrieval call binding the contract method 0x9624e83e.
+//
+// Solidity: function accounting() view returns(address)
+func (_Csmodule *CsmoduleCaller) Accounting(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _Csmodule.contract.Call(opts, &out, "accounting")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// Accounting is a free data retrieval call binding the contract method 0x9624e83e.
+//
+// Solidity: function accounting() view returns(address)
+func (_Csmodule *CsmoduleSession) Accounting() (common.Address, error) {
+	return _Csmodule.Contract.Accounting(&_Csmodule.CallOpts)
+}
+
+// Accounting is a free data retrieval call binding the contract method 0x9624e83e.
+//
+// Solidity: function accounting() view returns(address)
+func (_Csmodule *CsmoduleCallerSession) Accounting() (common.Address, error) {
+	return _Csmodule.Contract.Accounting(&_Csmodule.CallOpts)
+}
+
+// DepositQueue is a free data retrieval call binding the contract method 0xf617eecc.
+//
+// Solidity: function depositQueue() view returns(uint128 head, uint128 tail)
+func (_Csmodule *CsmoduleCaller) DepositQueue(opts *bind.CallOpts) (struct {
+	Head *big.Int
+	Tail *big.Int
+}, error) {
+	var out []interface{}
+	err := _Csmodule.contract.Call(opts, &out, "depositQueue")
+
+	outstruct := new(struct {
+		Head *big.Int
+		Tail *big.Int
+	})
+	if err != nil {
+		return *outstruct, err
+	}
+
+	outstruct.Head = *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+	outstruct.Tail = *abi.ConvertType(out[1], new(*big.Int)).(**big.Int)
+
+	return *outstruct, err
+
+}
+
+// DepositQueue is a free data retrieval call binding the contract method 0xf617eecc.
+//
+// Solidity: function depositQueue() view returns(uint128 head, uint128 tail)
+func (_Csmodule *CsmoduleSession) DepositQueue() (struct {
+	Head *big.Int
+	Tail *big.Int
+}, error) {
+	return _Csmodule.Contract.DepositQueue(&_Csmodule.CallOpts)
+}
+
+// DepositQueue is a free data retrieval call binding the contract method 0xf617eecc.
+//
+// Solidity: function depositQueue() view returns(uint128 head, uint128 tail)
+func (_Csmodule *CsmoduleCallerSession) DepositQueue() (struct {
+	Head *big.Int
+	Tail *big.Int
+}, error) {
+	return _Csmodule.Contract.DepositQueue(&_Csmodule.CallOpts)
+}
+
+// DepositQueueItem is a free data retrieval call binding the contract method 0x5e169fb8.
+//
+// Solidity: function depositQueueItem(uint128 index) view returns(uint256)
+func (_Csmodule *CsmoduleCaller) DepositQueueItem(opts *bind.CallOpts, index *big.Int) (*big.Int, error) {
+	var out []interface{}
+	err := _Csmodule.contract.Call(opts, &out, "depositQueueItem", index)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// DepositQueueItem is a free data retrieval call binding the contract method 0x5e169fb8.
+//
+// Solidity: function depositQueueItem(uint128 index) view returns(uint256)
+func (_Csmodule *CsmoduleSession) DepositQueueItem(index *big.Int) (*big.Int, error) {
+	return _Csmodule.Contract.DepositQueueItem(&_Csmodule.CallOpts, index)
+}
+
+// DepositQueueItem is a free data retrieval call binding the contract method 0x5e169fb8.
+//
+// Solidity: function depositQueueItem(uint128 index) view returns(uint256)
+func (_Csmodule *CsmoduleCallerSession) DepositQueueItem(index *big.Int) (*big.Int, error) {
+	return _Csmodule.Contract.DepositQueueItem(&_Csmodule.CallOpts, index)
+}
+
+// EarlyAdoption is a free data retrieval call binding the contract method 0x26a666e4.
+//
+// Solidity: function earlyAdoption() view returns(address)
+func (_Csmodule *CsmoduleCaller) EarlyAdoption(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _Csmodule.contract.Call(opts, &out, "earlyAdoption")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// EarlyAdoption is a free data retrieval call binding the contract method 0x26a666e4.
+//
+// Solidity: function earlyAdoption() view returns(address)
+func (_Csmodule *CsmoduleSession) EarlyAdoption() (common.Address, error) {
+	return _Csmodule.Contract.EarlyAdoption(&_Csmodule.CallOpts)
+}
+
+// EarlyAdoption is a free data retrieval call binding the contract method 0x26a666e4.
+//
+// Solidity: function earlyAdoption() view returns(address)
+func (_Csmodule *CsmoduleCallerSession) EarlyAdoption() (common.Address, error) {
+	return _Csmodule.Contract.EarlyAdoption(&_Csmodule.CallOpts)
+}
+
+// GetActiveNodeOperatorsCount is a free data retrieval call binding the contract method 0x8469cbd3.
+//
+// Solidity: function getActiveNodeOperatorsCount() view returns(uint256)
+func (_Csmodule *CsmoduleCaller) GetActiveNodeOperatorsCount(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _Csmodule.contract.Call(opts, &out, "getActiveNodeOperatorsCount")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// GetActiveNodeOperatorsCount is a free data retrieval call binding the contract method 0x8469cbd3.
+//
+// Solidity: function getActiveNodeOperatorsCount() view returns(uint256)
+func (_Csmodule *CsmoduleSession) GetActiveNodeOperatorsCount() (*big.Int, error) {
+	return _Csmodule.Contract.GetActiveNodeOperatorsCount(&_Csmodule.CallOpts)
+}
+
+// GetActiveNodeOperatorsCount is a free data retrieval call binding the contract method 0x8469cbd3.
+//
+// Solidity: function getActiveNodeOperatorsCount() view returns(uint256)
+func (_Csmodule *CsmoduleCallerSession) GetActiveNodeOperatorsCount() (*big.Int, error) {
+	return _Csmodule.Contract.GetActiveNodeOperatorsCount(&_Csmodule.CallOpts)
+}
+
+// GetNodeOperator is a free data retrieval call binding the contract method 0x65c14dc7.
+//
+// Solidity: function getNodeOperator(uint256 nodeOperatorId) view returns((uint32,uint32,uint32,uint32,uint32,uint32,uint32,uint8,uint32,uint32,address,address,address,address,bool))
+func (_Csmodule *CsmoduleCaller) GetNodeOperator(opts *bind.CallOpts, nodeOperatorId *big.Int) (NodeOperator, error) {
+	var out []interface{}
+	err := _Csmodule.contract.Call(opts, &out, "getNodeOperator", nodeOperatorId)
+
+	if err != nil {
+		return *new(NodeOperator), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(NodeOperator)).(*NodeOperator)
+
+	return out0, err
+
+}
+
+// GetNodeOperator is a free data retrieval call binding the contract method 0x65c14dc7.
+//
+// Solidity: function getNodeOperator(uint256 nodeOperatorId) view returns((uint32,uint32,uint32,uint32,uint32,uint32,uint32,uint8,uint32,uint32,address,address,address,address,bool))
+func (_Csmodule *CsmoduleSession) GetNodeOperator(nodeOperatorId *big.Int) (NodeOperator, error) {
+	return _Csmodule.Contract.GetNodeOperator(&_Csmodule.CallOpts, nodeOperatorId)
+}
+
+// GetNodeOperator is a free data retrieval call binding the contract method 0x65c14dc7.
+//
+// Solidity: function getNodeOperator(uint256 nodeOperatorId) view returns((uint32,uint32,uint32,uint32,uint32,uint32,uint32,uint8,uint32,uint32,address,address,address,address,bool))
+func (_Csmodule *CsmoduleCallerSession) GetNodeOperator(nodeOperatorId *big.Int) (NodeOperator, error) {
+	return _Csmodule.Contract.GetNodeOperator(&_Csmodule.CallOpts, nodeOperatorId)
+}
+
+// GetNodeOperatorIds is a free data retrieval call binding the contract method 0x4febc81b.
+//
+// Solidity: function getNodeOperatorIds(uint256 offset, uint256 limit) view returns(uint256[] nodeOperatorIds)
+func (_Csmodule *CsmoduleCaller) GetNodeOperatorIds(opts *bind.CallOpts, offset *big.Int, limit *big.Int) ([]*big.Int, error) {
+	var out []interface{}
+	err := _Csmodule.contract.Call(opts, &out, "getNodeOperatorIds", offset, limit)
+
+	if err != nil {
+		return *new([]*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([]*big.Int)).(*[]*big.Int)
+
+	return out0, err
+
+}
+
+// GetNodeOperatorIds is a free data retrieval call binding the contract method 0x4febc81b.
+//
+// Solidity: function getNodeOperatorIds(uint256 offset, uint256 limit) view returns(uint256[] nodeOperatorIds)
+func (_Csmodule *CsmoduleSession) GetNodeOperatorIds(offset *big.Int, limit *big.Int) ([]*big.Int, error) {
+	return _Csmodule.Contract.GetNodeOperatorIds(&_Csmodule.CallOpts, offset, limit)
+}
+
+// GetNodeOperatorIds is a free data retrieval call binding the contract method 0x4febc81b.
+//
+// Solidity: function getNodeOperatorIds(uint256 offset, uint256 limit) view returns(uint256[] nodeOperatorIds)
+func (_Csmodule *CsmoduleCallerSession) GetNodeOperatorIds(offset *big.Int, limit *big.Int) ([]*big.Int, error) {
+	return _Csmodule.Contract.GetNodeOperatorIds(&_Csmodule.CallOpts, offset, limit)
+}
+
+// GetNodeOperatorIsActive is a free data retrieval call binding the contract method 0x5e2fb908.
+//
+// Solidity: function getNodeOperatorIsActive(uint256 nodeOperatorId) view returns(bool)
+func (_Csmodule *CsmoduleCaller) GetNodeOperatorIsActive(opts *bind.CallOpts, nodeOperatorId *big.Int) (bool, error) {
+	var out []interface{}
+	err := _Csmodule.contract.Call(opts, &out, "getNodeOperatorIsActive", nodeOperatorId)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// GetNodeOperatorIsActive is a free data retrieval call binding the contract method 0x5e2fb908.
+//
+// Solidity: function getNodeOperatorIsActive(uint256 nodeOperatorId) view returns(bool)
+func (_Csmodule *CsmoduleSession) GetNodeOperatorIsActive(nodeOperatorId *big.Int) (bool, error) {
+	return _Csmodule.Contract.GetNodeOperatorIsActive(&_Csmodule.CallOpts, nodeOperatorId)
+}
+
+// GetNodeOperatorIsActive is a free data retrieval call binding the contract method 0x5e2fb908.
+//
+// Solidity: function getNodeOperatorIsActive(uint256 nodeOperatorId) view returns(bool)
+func (_Csmodule *CsmoduleCallerSession) GetNodeOperatorIsActive(nodeOperatorId *big.Int) (bool, error) {
+	return _Csmodule.Contract.GetNodeOperatorIsActive(&_Csmodule.CallOpts, nodeOperatorId)
+}
+
+// GetNodeOperatorNonWithdrawnKeys is a free data retrieval call binding the contract method 0x8ec69028.
+//
+// Solidity: function getNodeOperatorNonWithdrawnKeys(uint256 nodeOperatorId) view returns(uint256)
+func (_Csmodule *CsmoduleCaller) GetNodeOperatorNonWithdrawnKeys(opts *bind.CallOpts, nodeOperatorId *big.Int) (*big.Int, error) {
+	var out []interface{}
+	err := _Csmodule.contract.Call(opts, &out, "getNodeOperatorNonWithdrawnKeys", nodeOperatorId)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// GetNodeOperatorNonWithdrawnKeys is a free data retrieval call binding the contract method 0x8ec69028.
+//
+// Solidity: function getNodeOperatorNonWithdrawnKeys(uint256 nodeOperatorId) view returns(uint256)
+func (_Csmodule *CsmoduleSession) GetNodeOperatorNonWithdrawnKeys(nodeOperatorId *big.Int) (*big.Int, error) {
+	return _Csmodule.Contract.GetNodeOperatorNonWithdrawnKeys(&_Csmodule.CallOpts, nodeOperatorId)
+}
+
+// GetNodeOperatorNonWithdrawnKeys is a free data retrieval call binding the contract method 0x8ec69028.
+//
+// Solidity: function getNodeOperatorNonWithdrawnKeys(uint256 nodeOperatorId) view returns(uint256)
+func (_Csmodule *CsmoduleCallerSession) GetNodeOperatorNonWithdrawnKeys(nodeOperatorId *big.Int) (*big.Int, error) {
+	return _Csmodule.Contract.GetNodeOperatorNonWithdrawnKeys(&_Csmodule.CallOpts, nodeOperatorId)
+}
+
+// GetNodeOperatorSummary is a free data retrieval call binding the contract method 0xb3076c3c.
+//
+// Solidity: function getNodeOperatorSummary(uint256 nodeOperatorId) view returns(uint256 targetLimitMode, uint256 targetValidatorsCount, uint256 stuckValidatorsCount, uint256 refundedValidatorsCount, uint256 stuckPenaltyEndTimestamp, uint256 totalExitedValidators, uint256 totalDepositedValidators, uint256 depositableValidatorsCount)
+func (_Csmodule *CsmoduleCaller) GetNodeOperatorSummary(opts *bind.CallOpts, nodeOperatorId *big.Int) (struct {
+	TargetLimitMode            *big.Int
+	TargetValidatorsCount      *big.Int
+	StuckValidatorsCount       *big.Int
+	RefundedValidatorsCount    *big.Int
+	StuckPenaltyEndTimestamp   *big.Int
+	TotalExitedValidators      *big.Int
+	TotalDepositedValidators   *big.Int
+	DepositableValidatorsCount *big.Int
+}, error) {
+	var out []interface{}
+	err := _Csmodule.contract.Call(opts, &out, "getNodeOperatorSummary", nodeOperatorId)
+
+	outstruct := new(struct {
+		TargetLimitMode            *big.Int
+		TargetValidatorsCount      *big.Int
+		StuckValidatorsCount       *big.Int
+		RefundedValidatorsCount    *big.Int
+		StuckPenaltyEndTimestamp   *big.Int
+		TotalExitedValidators      *big.Int
+		TotalDepositedValidators   *big.Int
+		DepositableValidatorsCount *big.Int
+	})
+	if err != nil {
+		return *outstruct, err
+	}
+
+	outstruct.TargetLimitMode = *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+	outstruct.TargetValidatorsCount = *abi.ConvertType(out[1], new(*big.Int)).(**big.Int)
+	outstruct.StuckValidatorsCount = *abi.ConvertType(out[2], new(*big.Int)).(**big.Int)
+	outstruct.RefundedValidatorsCount = *abi.ConvertType(out[3], new(*big.Int)).(**big.Int)
+	outstruct.StuckPenaltyEndTimestamp = *abi.ConvertType(out[4], new(*big.Int)).(**big.Int)
+	outstruct.TotalExitedValidators = *abi.ConvertType(out[5], new(*big.Int)).(**big.Int)
+	outstruct.TotalDepositedValidators = *abi.ConvertType(out[6], new(*big.Int)).(**big.Int)
+	outstruct.DepositableValidatorsCount = *abi.ConvertType(out[7], new(*big.Int)).(**big.Int)
+
+	return *outstruct, err
+
+}
+
+// GetNodeOperatorSummary is a free data retrieval call binding the contract method 0xb3076c3c.
+//
+// Solidity: function getNodeOperatorSummary(uint256 nodeOperatorId) view returns(uint256 targetLimitMode, uint256 targetValidatorsCount, uint256 stuckValidatorsCount, uint256 refundedValidatorsCount, uint256 stuckPenaltyEndTimestamp, uint256 totalExitedValidators, uint256 totalDepositedValidators, uint256 depositableValidatorsCount)
+func (_Csmodule *CsmoduleSession) GetNodeOperatorSummary(nodeOperatorId *big.Int) (struct {
+	TargetLimitMode            *big.Int
+	TargetValidatorsCount      *big.Int
+	StuckValidatorsCount       *big.Int
+	RefundedValidatorsCount    *big.Int
+	StuckPenaltyEndTimestamp   *big.Int
+	TotalExitedValidators      *big.Int
+	TotalDepositedValidators   *big.Int
+	DepositableValidatorsCount *big.Int
+}, error) {
+	return _Csmodule.Contract.GetNodeOperatorSummary(&_Csmodule.CallOpts, nodeOperatorId)
+}
+
+// GetNodeOperatorSummary is a free data retrieval call binding the contract method 0xb3076c3c.
+//
+// Solidity: function getNodeOperatorSummary(uint256 nodeOperatorId) view returns(uint256 targetLimitMode, uint256 targetValidatorsCount, uint256 stuckValidatorsCount, uint256 refundedValidatorsCount, uint256 stuckPenaltyEndTimestamp, uint256 totalExitedValidators, uint256 totalDepositedValidators, uint256 depositableValidatorsCount)
+func (_Csmodule *CsmoduleCallerSession) GetNodeOperatorSummary(nodeOperatorId *big.Int) (struct {
+	TargetLimitMode            *big.Int
+	TargetValidatorsCount      *big.Int
+	StuckValidatorsCount       *big.Int
+	RefundedValidatorsCount    *big.Int
+	StuckPenaltyEndTimestamp   *big.Int
+	TotalExitedValidators      *big.Int
+	TotalDepositedValidators   *big.Int
+	DepositableValidatorsCount *big.Int
+}, error) {
+	return _Csmodule.Contract.GetNodeOperatorSummary(&_Csmodule.CallOpts, nodeOperatorId)
+}
+
+// GetNodeOperatorsCount is a free data retrieval call binding the contract method 0xa70c70e4.
+//
+// Solidity: function getNodeOperatorsCount() view returns(uint256)
+func (_Csmodule *CsmoduleCaller) GetNodeOperatorsCount(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _Csmodule.contract.Call(opts, &out, "getNodeOperatorsCount")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// GetNodeOperatorsCount is a free data retrieval call binding the contract method 0xa70c70e4.
+//
+// Solidity: function getNodeOperatorsCount() view returns(uint256)
+func (_Csmodule *CsmoduleSession) GetNodeOperatorsCount() (*big.Int, error) {
+	return _Csmodule.Contract.GetNodeOperatorsCount(&_Csmodule.CallOpts)
+}
+
+// GetNodeOperatorsCount is a free data retrieval call binding the contract method 0xa70c70e4.
+//
+// Solidity: function getNodeOperatorsCount() view returns(uint256)
+func (_Csmodule *CsmoduleCallerSession) GetNodeOperatorsCount() (*big.Int, error) {
+	return _Csmodule.Contract.GetNodeOperatorsCount(&_Csmodule.CallOpts)
+}
+
+// GetNonce is a free data retrieval call binding the contract method 0xd087d288.
+//
+// Solidity: function getNonce() view returns(uint256)
+func (_Csmodule *CsmoduleCaller) GetNonce(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _Csmodule.contract.Call(opts, &out, "getNonce")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// GetNonce is a free data retrieval call binding the contract method 0xd087d288.
+//
+// Solidity: function getNonce() view returns(uint256)
+func (_Csmodule *CsmoduleSession) GetNonce() (*big.Int, error) {
+	return _Csmodule.Contract.GetNonce(&_Csmodule.CallOpts)
+}
+
+// GetNonce is a free data retrieval call binding the contract method 0xd087d288.
+//
+// Solidity: function getNonce() view returns(uint256)
+func (_Csmodule *CsmoduleCallerSession) GetNonce() (*big.Int, error) {
+	return _Csmodule.Contract.GetNonce(&_Csmodule.CallOpts)
+}
+
+// GetResumeSinceTimestamp is a free data retrieval call binding the contract method 0x589ff76c.
+//
+// Solidity: function getResumeSinceTimestamp() view returns(uint256)
+func (_Csmodule *CsmoduleCaller) GetResumeSinceTimestamp(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _Csmodule.contract.Call(opts, &out, "getResumeSinceTimestamp")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// GetResumeSinceTimestamp is a free data retrieval call binding the contract method 0x589ff76c.
+//
+// Solidity: function getResumeSinceTimestamp() view returns(uint256)
+func (_Csmodule *CsmoduleSession) GetResumeSinceTimestamp() (*big.Int, error) {
+	return _Csmodule.Contract.GetResumeSinceTimestamp(&_Csmodule.CallOpts)
+}
+
+// GetResumeSinceTimestamp is a free data retrieval call binding the contract method 0x589ff76c.
+//
+// Solidity: function getResumeSinceTimestamp() view returns(uint256)
+func (_Csmodule *CsmoduleCallerSession) GetResumeSinceTimestamp() (*big.Int, error) {
+	return _Csmodule.Contract.GetResumeSinceTimestamp(&_Csmodule.CallOpts)
+}
+
+// GetRoleAdmin is a free data retrieval call binding the contract method 0x248a9ca3.
+//
+// Solidity: function getRoleAdmin(bytes32 role) view returns(bytes32)
+func (_Csmodule *CsmoduleCaller) GetRoleAdmin(opts *bind.CallOpts, role [32]byte) ([32]byte, error) {
+	var out []interface{}
+	err := _Csmodule.contract.Call(opts, &out, "getRoleAdmin", role)
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// GetRoleAdmin is a free data retrieval call binding the contract method 0x248a9ca3.
+//
+// Solidity: function getRoleAdmin(bytes32 role) view returns(bytes32)
+func (_Csmodule *CsmoduleSession) GetRoleAdmin(role [32]byte) ([32]byte, error) {
+	return _Csmodule.Contract.GetRoleAdmin(&_Csmodule.CallOpts, role)
+}
+
+// GetRoleAdmin is a free data retrieval call binding the contract method 0x248a9ca3.
+//
+// Solidity: function getRoleAdmin(bytes32 role) view returns(bytes32)
+func (_Csmodule *CsmoduleCallerSession) GetRoleAdmin(role [32]byte) ([32]byte, error) {
+	return _Csmodule.Contract.GetRoleAdmin(&_Csmodule.CallOpts, role)
+}
+
+// GetRoleMember is a free data retrieval call binding the contract method 0x9010d07c.
+//
+// Solidity: function getRoleMember(bytes32 role, uint256 index) view returns(address)
+func (_Csmodule *CsmoduleCaller) GetRoleMember(opts *bind.CallOpts, role [32]byte, index *big.Int) (common.Address, error) {
+	var out []interface{}
+	err := _Csmodule.contract.Call(opts, &out, "getRoleMember", role, index)
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// GetRoleMember is a free data retrieval call binding the contract method 0x9010d07c.
+//
+// Solidity: function getRoleMember(bytes32 role, uint256 index) view returns(address)
+func (_Csmodule *CsmoduleSession) GetRoleMember(role [32]byte, index *big.Int) (common.Address, error) {
+	return _Csmodule.Contract.GetRoleMember(&_Csmodule.CallOpts, role, index)
+}
+
+// GetRoleMember is a free data retrieval call binding the contract method 0x9010d07c.
+//
+// Solidity: function getRoleMember(bytes32 role, uint256 index) view returns(address)
+func (_Csmodule *CsmoduleCallerSession) GetRoleMember(role [32]byte, index *big.Int) (common.Address, error) {
+	return _Csmodule.Contract.GetRoleMember(&_Csmodule.CallOpts, role, index)
+}
+
+// GetRoleMemberCount is a free data retrieval call binding the contract method 0xca15c873.
+//
+// Solidity: function getRoleMemberCount(bytes32 role) view returns(uint256)
+func (_Csmodule *CsmoduleCaller) GetRoleMemberCount(opts *bind.CallOpts, role [32]byte) (*big.Int, error) {
+	var out []interface{}
+	err := _Csmodule.contract.Call(opts, &out, "getRoleMemberCount", role)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// GetRoleMemberCount is a free data retrieval call binding the contract method 0xca15c873.
+//
+// Solidity: function getRoleMemberCount(bytes32 role) view returns(uint256)
+func (_Csmodule *CsmoduleSession) GetRoleMemberCount(role [32]byte) (*big.Int, error) {
+	return _Csmodule.Contract.GetRoleMemberCount(&_Csmodule.CallOpts, role)
+}
+
+// GetRoleMemberCount is a free data retrieval call binding the contract method 0xca15c873.
+//
+// Solidity: function getRoleMemberCount(bytes32 role) view returns(uint256)
+func (_Csmodule *CsmoduleCallerSession) GetRoleMemberCount(role [32]byte) (*big.Int, error) {
+	return _Csmodule.Contract.GetRoleMemberCount(&_Csmodule.CallOpts, role)
+}
+
+// GetSigningKeys is a free data retrieval call binding the contract method 0x59e25c12.
+//
+// Solidity: function getSigningKeys(uint256 nodeOperatorId, uint256 startIndex, uint256 keysCount) view returns(bytes)
+func (_Csmodule *CsmoduleCaller) GetSigningKeys(opts *bind.CallOpts, nodeOperatorId *big.Int, startIndex *big.Int, keysCount *big.Int) ([]byte, error) {
+	var out []interface{}
+	err := _Csmodule.contract.Call(opts, &out, "getSigningKeys", nodeOperatorId, startIndex, keysCount)
+
+	if err != nil {
+		return *new([]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([]byte)).(*[]byte)
+
+	return out0, err
+
+}
+
+// GetSigningKeys is a free data retrieval call binding the contract method 0x59e25c12.
+//
+// Solidity: function getSigningKeys(uint256 nodeOperatorId, uint256 startIndex, uint256 keysCount) view returns(bytes)
+func (_Csmodule *CsmoduleSession) GetSigningKeys(nodeOperatorId *big.Int, startIndex *big.Int, keysCount *big.Int) ([]byte, error) {
+	return _Csmodule.Contract.GetSigningKeys(&_Csmodule.CallOpts, nodeOperatorId, startIndex, keysCount)
+}
+
+// GetSigningKeys is a free data retrieval call binding the contract method 0x59e25c12.
+//
+// Solidity: function getSigningKeys(uint256 nodeOperatorId, uint256 startIndex, uint256 keysCount) view returns(bytes)
+func (_Csmodule *CsmoduleCallerSession) GetSigningKeys(nodeOperatorId *big.Int, startIndex *big.Int, keysCount *big.Int) ([]byte, error) {
+	return _Csmodule.Contract.GetSigningKeys(&_Csmodule.CallOpts, nodeOperatorId, startIndex, keysCount)
+}
+
+// GetSigningKeysWithSignatures is a free data retrieval call binding the contract method 0x50388cb6.
+//
+// Solidity: function getSigningKeysWithSignatures(uint256 nodeOperatorId, uint256 startIndex, uint256 keysCount) view returns(bytes keys, bytes signatures)
+func (_Csmodule *CsmoduleCaller) GetSigningKeysWithSignatures(opts *bind.CallOpts, nodeOperatorId *big.Int, startIndex *big.Int, keysCount *big.Int) (struct {
+	Keys       []byte
+	Signatures []byte
+}, error) {
+	var out []interface{}
+	err := _Csmodule.contract.Call(opts, &out, "getSigningKeysWithSignatures", nodeOperatorId, startIndex, keysCount)
+
+	outstruct := new(struct {
+		Keys       []byte
+		Signatures []byte
+	})
+	if err != nil {
+		return *outstruct, err
+	}
+
+	outstruct.Keys = *abi.ConvertType(out[0], new([]byte)).(*[]byte)
+	outstruct.Signatures = *abi.ConvertType(out[1], new([]byte)).(*[]byte)
+
+	return *outstruct, err
+
+}
+
+// GetSigningKeysWithSignatures is a free data retrieval call binding the contract method 0x50388cb6.
+//
+// Solidity: function getSigningKeysWithSignatures(uint256 nodeOperatorId, uint256 startIndex, uint256 keysCount) view returns(bytes keys, bytes signatures)
+func (_Csmodule *CsmoduleSession) GetSigningKeysWithSignatures(nodeOperatorId *big.Int, startIndex *big.Int, keysCount *big.Int) (struct {
+	Keys       []byte
+	Signatures []byte
+}, error) {
+	return _Csmodule.Contract.GetSigningKeysWithSignatures(&_Csmodule.CallOpts, nodeOperatorId, startIndex, keysCount)
+}
+
+// GetSigningKeysWithSignatures is a free data retrieval call binding the contract method 0x50388cb6.
+//
+// Solidity: function getSigningKeysWithSignatures(uint256 nodeOperatorId, uint256 startIndex, uint256 keysCount) view returns(bytes keys, bytes signatures)
+func (_Csmodule *CsmoduleCallerSession) GetSigningKeysWithSignatures(nodeOperatorId *big.Int, startIndex *big.Int, keysCount *big.Int) (struct {
+	Keys       []byte
+	Signatures []byte
+}, error) {
+	return _Csmodule.Contract.GetSigningKeysWithSignatures(&_Csmodule.CallOpts, nodeOperatorId, startIndex, keysCount)
+}
+
+// GetStakingModuleSummary is a free data retrieval call binding the contract method 0x9abddf09.
+//
+// Solidity: function getStakingModuleSummary() view returns(uint256 totalExitedValidators, uint256 totalDepositedValidators, uint256 depositableValidatorsCount)
+func (_Csmodule *CsmoduleCaller) GetStakingModuleSummary(opts *bind.CallOpts) (struct {
+	TotalExitedValidators      *big.Int
+	TotalDepositedValidators   *big.Int
+	DepositableValidatorsCount *big.Int
+}, error) {
+	var out []interface{}
+	err := _Csmodule.contract.Call(opts, &out, "getStakingModuleSummary")
+
+	outstruct := new(struct {
+		TotalExitedValidators      *big.Int
+		TotalDepositedValidators   *big.Int
+		DepositableValidatorsCount *big.Int
+	})
+	if err != nil {
+		return *outstruct, err
+	}
+
+	outstruct.TotalExitedValidators = *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+	outstruct.TotalDepositedValidators = *abi.ConvertType(out[1], new(*big.Int)).(**big.Int)
+	outstruct.DepositableValidatorsCount = *abi.ConvertType(out[2], new(*big.Int)).(**big.Int)
+
+	return *outstruct, err
+
+}
+
+// GetStakingModuleSummary is a free data retrieval call binding the contract method 0x9abddf09.
+//
+// Solidity: function getStakingModuleSummary() view returns(uint256 totalExitedValidators, uint256 totalDepositedValidators, uint256 depositableValidatorsCount)
+func (_Csmodule *CsmoduleSession) GetStakingModuleSummary() (struct {
+	TotalExitedValidators      *big.Int
+	TotalDepositedValidators   *big.Int
+	DepositableValidatorsCount *big.Int
+}, error) {
+	return _Csmodule.Contract.GetStakingModuleSummary(&_Csmodule.CallOpts)
+}
+
+// GetStakingModuleSummary is a free data retrieval call binding the contract method 0x9abddf09.
+//
+// Solidity: function getStakingModuleSummary() view returns(uint256 totalExitedValidators, uint256 totalDepositedValidators, uint256 depositableValidatorsCount)
+func (_Csmodule *CsmoduleCallerSession) GetStakingModuleSummary() (struct {
+	TotalExitedValidators      *big.Int
+	TotalDepositedValidators   *big.Int
+	DepositableValidatorsCount *big.Int
+}, error) {
+	return _Csmodule.Contract.GetStakingModuleSummary(&_Csmodule.CallOpts)
+}
+
+// GetType is a free data retrieval call binding the contract method 0x15dae03e.
+//
+// Solidity: function getType() view returns(bytes32)
+func (_Csmodule *CsmoduleCaller) GetType(opts *bind.CallOpts) ([32]byte, error) {
+	var out []interface{}
+	err := _Csmodule.contract.Call(opts, &out, "getType")
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// GetType is a free data retrieval call binding the contract method 0x15dae03e.
+//
+// Solidity: function getType() view returns(bytes32)
+func (_Csmodule *CsmoduleSession) GetType() ([32]byte, error) {
+	return _Csmodule.Contract.GetType(&_Csmodule.CallOpts)
+}
+
+// GetType is a free data retrieval call binding the contract method 0x15dae03e.
+//
+// Solidity: function getType() view returns(bytes32)
+func (_Csmodule *CsmoduleCallerSession) GetType() ([32]byte, error) {
+	return _Csmodule.Contract.GetType(&_Csmodule.CallOpts)
+}
+
+// HasRole is a free data retrieval call binding the contract method 0x91d14854.
+//
+// Solidity: function hasRole(bytes32 role, address account) view returns(bool)
+func (_Csmodule *CsmoduleCaller) HasRole(opts *bind.CallOpts, role [32]byte, account common.Address) (bool, error) {
+	var out []interface{}
+	err := _Csmodule.contract.Call(opts, &out, "hasRole", role, account)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// HasRole is a free data retrieval call binding the contract method 0x91d14854.
+//
+// Solidity: function hasRole(bytes32 role, address account) view returns(bool)
+func (_Csmodule *CsmoduleSession) HasRole(role [32]byte, account common.Address) (bool, error) {
+	return _Csmodule.Contract.HasRole(&_Csmodule.CallOpts, role, account)
+}
+
+// HasRole is a free data retrieval call binding the contract method 0x91d14854.
+//
+// Solidity: function hasRole(bytes32 role, address account) view returns(bool)
+func (_Csmodule *CsmoduleCallerSession) HasRole(role [32]byte, account common.Address) (bool, error) {
+	return _Csmodule.Contract.HasRole(&_Csmodule.CallOpts, role, account)
+}
+
+// IsPaused is a free data retrieval call binding the contract method 0xb187bd26.
+//
+// Solidity: function isPaused() view returns(bool)
+func (_Csmodule *CsmoduleCaller) IsPaused(opts *bind.CallOpts) (bool, error) {
+	var out []interface{}
+	err := _Csmodule.contract.Call(opts, &out, "isPaused")
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// IsPaused is a free data retrieval call binding the contract method 0xb187bd26.
+//
+// Solidity: function isPaused() view returns(bool)
+func (_Csmodule *CsmoduleSession) IsPaused() (bool, error) {
+	return _Csmodule.Contract.IsPaused(&_Csmodule.CallOpts)
+}
+
+// IsPaused is a free data retrieval call binding the contract method 0xb187bd26.
+//
+// Solidity: function isPaused() view returns(bool)
+func (_Csmodule *CsmoduleCallerSession) IsPaused() (bool, error) {
+	return _Csmodule.Contract.IsPaused(&_Csmodule.CallOpts)
+}
+
+// IsValidatorSlashed is a free data retrieval call binding the contract method 0x3dbe8b5a.
+//
+// Solidity: function isValidatorSlashed(uint256 nodeOperatorId, uint256 keyIndex) view returns(bool)
+func (_Csmodule *CsmoduleCaller) IsValidatorSlashed(opts *bind.CallOpts, nodeOperatorId *big.Int, keyIndex *big.Int) (bool, error) {
+	var out []interface{}
+	err := _Csmodule.contract.Call(opts, &out, "isValidatorSlashed", nodeOperatorId, keyIndex)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// IsValidatorSlashed is a free data retrieval call binding the contract method 0x3dbe8b5a.
+//
+// Solidity: function isValidatorSlashed(uint256 nodeOperatorId, uint256 keyIndex) view returns(bool)
+func (_Csmodule *CsmoduleSession) IsValidatorSlashed(nodeOperatorId *big.Int, keyIndex *big.Int) (bool, error) {
+	return _Csmodule.Contract.IsValidatorSlashed(&_Csmodule.CallOpts, nodeOperatorId, keyIndex)
+}
+
+// IsValidatorSlashed is a free data retrieval call binding the contract method 0x3dbe8b5a.
+//
+// Solidity: function isValidatorSlashed(uint256 nodeOperatorId, uint256 keyIndex) view returns(bool)
+func (_Csmodule *CsmoduleCallerSession) IsValidatorSlashed(nodeOperatorId *big.Int, keyIndex *big.Int) (bool, error) {
+	return _Csmodule.Contract.IsValidatorSlashed(&_Csmodule.CallOpts, nodeOperatorId, keyIndex)
+}
+
+// IsValidatorWithdrawn is a free data retrieval call binding the contract method 0x53433643.
+//
+// Solidity: function isValidatorWithdrawn(uint256 nodeOperatorId, uint256 keyIndex) view returns(bool)
+func (_Csmodule *CsmoduleCaller) IsValidatorWithdrawn(opts *bind.CallOpts, nodeOperatorId *big.Int, keyIndex *big.Int) (bool, error) {
+	var out []interface{}
+	err := _Csmodule.contract.Call(opts, &out, "isValidatorWithdrawn", nodeOperatorId, keyIndex)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// IsValidatorWithdrawn is a free data retrieval call binding the contract method 0x53433643.
+//
+// Solidity: function isValidatorWithdrawn(uint256 nodeOperatorId, uint256 keyIndex) view returns(bool)
+func (_Csmodule *CsmoduleSession) IsValidatorWithdrawn(nodeOperatorId *big.Int, keyIndex *big.Int) (bool, error) {
+	return _Csmodule.Contract.IsValidatorWithdrawn(&_Csmodule.CallOpts, nodeOperatorId, keyIndex)
+}
+
+// IsValidatorWithdrawn is a free data retrieval call binding the contract method 0x53433643.
+//
+// Solidity: function isValidatorWithdrawn(uint256 nodeOperatorId, uint256 keyIndex) view returns(bool)
+func (_Csmodule *CsmoduleCallerSession) IsValidatorWithdrawn(nodeOperatorId *big.Int, keyIndex *big.Int) (bool, error) {
+	return _Csmodule.Contract.IsValidatorWithdrawn(&_Csmodule.CallOpts, nodeOperatorId, keyIndex)
+}
+
+// KeyRemovalCharge is a free data retrieval call binding the contract method 0xd9df8c92.
+//
+// Solidity: function keyRemovalCharge() view returns(uint256)
+func (_Csmodule *CsmoduleCaller) KeyRemovalCharge(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _Csmodule.contract.Call(opts, &out, "keyRemovalCharge")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// KeyRemovalCharge is a free data retrieval call binding the contract method 0xd9df8c92.
+//
+// Solidity: function keyRemovalCharge() view returns(uint256)
+func (_Csmodule *CsmoduleSession) KeyRemovalCharge() (*big.Int, error) {
+	return _Csmodule.Contract.KeyRemovalCharge(&_Csmodule.CallOpts)
+}
+
+// KeyRemovalCharge is a free data retrieval call binding the contract method 0xd9df8c92.
+//
+// Solidity: function keyRemovalCharge() view returns(uint256)
+func (_Csmodule *CsmoduleCallerSession) KeyRemovalCharge() (*big.Int, error) {
+	return _Csmodule.Contract.KeyRemovalCharge(&_Csmodule.CallOpts)
+}
+
+// PublicRelease is a free data retrieval call binding the contract method 0xe21a430b.
+//
+// Solidity: function publicRelease() view returns(bool)
+func (_Csmodule *CsmoduleCaller) PublicRelease(opts *bind.CallOpts) (bool, error) {
+	var out []interface{}
+	err := _Csmodule.contract.Call(opts, &out, "publicRelease")
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// PublicRelease is a free data retrieval call binding the contract method 0xe21a430b.
+//
+// Solidity: function publicRelease() view returns(bool)
+func (_Csmodule *CsmoduleSession) PublicRelease() (bool, error) {
+	return _Csmodule.Contract.PublicRelease(&_Csmodule.CallOpts)
+}
+
+// PublicRelease is a free data retrieval call binding the contract method 0xe21a430b.
+//
+// Solidity: function publicRelease() view returns(bool)
+func (_Csmodule *CsmoduleCallerSession) PublicRelease() (bool, error) {
+	return _Csmodule.Contract.PublicRelease(&_Csmodule.CallOpts)
+}
+
+// SupportsInterface is a free data retrieval call binding the contract method 0x01ffc9a7.
+//
+// Solidity: function supportsInterface(bytes4 interfaceId) view returns(bool)
+func (_Csmodule *CsmoduleCaller) SupportsInterface(opts *bind.CallOpts, interfaceId [4]byte) (bool, error) {
+	var out []interface{}
+	err := _Csmodule.contract.Call(opts, &out, "supportsInterface", interfaceId)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// SupportsInterface is a free data retrieval call binding the contract method 0x01ffc9a7.
+//
+// Solidity: function supportsInterface(bytes4 interfaceId) view returns(bool)
+func (_Csmodule *CsmoduleSession) SupportsInterface(interfaceId [4]byte) (bool, error) {
+	return _Csmodule.Contract.SupportsInterface(&_Csmodule.CallOpts, interfaceId)
+}
+
+// SupportsInterface is a free data retrieval call binding the contract method 0x01ffc9a7.
+//
+// Solidity: function supportsInterface(bytes4 interfaceId) view returns(bool)
+func (_Csmodule *CsmoduleCallerSession) SupportsInterface(interfaceId [4]byte) (bool, error) {
+	return _Csmodule.Contract.SupportsInterface(&_Csmodule.CallOpts, interfaceId)
+}
+
+// ActivatePublicRelease is a paid mutator transaction binding the contract method 0xd3931457.
+//
+// Solidity: function activatePublicRelease() returns()
+func (_Csmodule *CsmoduleTransactor) ActivatePublicRelease(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Csmodule.contract.Transact(opts, "activatePublicRelease")
+}
+
+// ActivatePublicRelease is a paid mutator transaction binding the contract method 0xd3931457.
+//
+// Solidity: function activatePublicRelease() returns()
+func (_Csmodule *CsmoduleSession) ActivatePublicRelease() (*types.Transaction, error) {
+	return _Csmodule.Contract.ActivatePublicRelease(&_Csmodule.TransactOpts)
+}
+
+// ActivatePublicRelease is a paid mutator transaction binding the contract method 0xd3931457.
+//
+// Solidity: function activatePublicRelease() returns()
+func (_Csmodule *CsmoduleTransactorSession) ActivatePublicRelease() (*types.Transaction, error) {
+	return _Csmodule.Contract.ActivatePublicRelease(&_Csmodule.TransactOpts)
+}
+
+// AddNodeOperatorETH is a paid mutator transaction binding the contract method 0x157a039b.
+//
+// Solidity: function addNodeOperatorETH(uint256 keysCount, bytes publicKeys, bytes signatures, (address,address,bool) managementProperties, bytes32[] eaProof, address referrer) payable returns()
+func (_Csmodule *CsmoduleTransactor) AddNodeOperatorETH(opts *bind.TransactOpts, keysCount *big.Int, publicKeys []byte, signatures []byte, managementProperties NodeOperatorManagementProperties, eaProof [][32]byte, referrer common.Address) (*types.Transaction, error) {
+	return _Csmodule.contract.Transact(opts, "addNodeOperatorETH", keysCount, publicKeys, signatures, managementProperties, eaProof, referrer)
+}
+
+// AddNodeOperatorETH is a paid mutator transaction binding the contract method 0x157a039b.
+//
+// Solidity: function addNodeOperatorETH(uint256 keysCount, bytes publicKeys, bytes signatures, (address,address,bool) managementProperties, bytes32[] eaProof, address referrer) payable returns()
+func (_Csmodule *CsmoduleSession) AddNodeOperatorETH(keysCount *big.Int, publicKeys []byte, signatures []byte, managementProperties NodeOperatorManagementProperties, eaProof [][32]byte, referrer common.Address) (*types.Transaction, error) {
+	return _Csmodule.Contract.AddNodeOperatorETH(&_Csmodule.TransactOpts, keysCount, publicKeys, signatures, managementProperties, eaProof, referrer)
+}
+
+// AddNodeOperatorETH is a paid mutator transaction binding the contract method 0x157a039b.
+//
+// Solidity: function addNodeOperatorETH(uint256 keysCount, bytes publicKeys, bytes signatures, (address,address,bool) managementProperties, bytes32[] eaProof, address referrer) payable returns()
+func (_Csmodule *CsmoduleTransactorSession) AddNodeOperatorETH(keysCount *big.Int, publicKeys []byte, signatures []byte, managementProperties NodeOperatorManagementProperties, eaProof [][32]byte, referrer common.Address) (*types.Transaction, error) {
+	return _Csmodule.Contract.AddNodeOperatorETH(&_Csmodule.TransactOpts, keysCount, publicKeys, signatures, managementProperties, eaProof, referrer)
+}
+
+// AddNodeOperatorStETH is a paid mutator transaction binding the contract method 0x6a5f2c4a.
+//
+// Solidity: function addNodeOperatorStETH(uint256 keysCount, bytes publicKeys, bytes signatures, (address,address,bool) managementProperties, (uint256,uint256,uint8,bytes32,bytes32) permit, bytes32[] eaProof, address referrer) returns()
+func (_Csmodule *CsmoduleTransactor) AddNodeOperatorStETH(opts *bind.TransactOpts, keysCount *big.Int, publicKeys []byte, signatures []byte, managementProperties NodeOperatorManagementProperties, permit ICSAccountingPermitInput, eaProof [][32]byte, referrer common.Address) (*types.Transaction, error) {
+	return _Csmodule.contract.Transact(opts, "addNodeOperatorStETH", keysCount, publicKeys, signatures, managementProperties, permit, eaProof, referrer)
+}
+
+// AddNodeOperatorStETH is a paid mutator transaction binding the contract method 0x6a5f2c4a.
+//
+// Solidity: function addNodeOperatorStETH(uint256 keysCount, bytes publicKeys, bytes signatures, (address,address,bool) managementProperties, (uint256,uint256,uint8,bytes32,bytes32) permit, bytes32[] eaProof, address referrer) returns()
+func (_Csmodule *CsmoduleSession) AddNodeOperatorStETH(keysCount *big.Int, publicKeys []byte, signatures []byte, managementProperties NodeOperatorManagementProperties, permit ICSAccountingPermitInput, eaProof [][32]byte, referrer common.Address) (*types.Transaction, error) {
+	return _Csmodule.Contract.AddNodeOperatorStETH(&_Csmodule.TransactOpts, keysCount, publicKeys, signatures, managementProperties, permit, eaProof, referrer)
+}
+
+// AddNodeOperatorStETH is a paid mutator transaction binding the contract method 0x6a5f2c4a.
+//
+// Solidity: function addNodeOperatorStETH(uint256 keysCount, bytes publicKeys, bytes signatures, (address,address,bool) managementProperties, (uint256,uint256,uint8,bytes32,bytes32) permit, bytes32[] eaProof, address referrer) returns()
+func (_Csmodule *CsmoduleTransactorSession) AddNodeOperatorStETH(keysCount *big.Int, publicKeys []byte, signatures []byte, managementProperties NodeOperatorManagementProperties, permit ICSAccountingPermitInput, eaProof [][32]byte, referrer common.Address) (*types.Transaction, error) {
+	return _Csmodule.Contract.AddNodeOperatorStETH(&_Csmodule.TransactOpts, keysCount, publicKeys, signatures, managementProperties, permit, eaProof, referrer)
+}
+
+// AddNodeOperatorWstETH is a paid mutator transaction binding the contract method 0xacc446eb.
+//
+// Solidity: function addNodeOperatorWstETH(uint256 keysCount, bytes publicKeys, bytes signatures, (address,address,bool) managementProperties, (uint256,uint256,uint8,bytes32,bytes32) permit, bytes32[] eaProof, address referrer) returns()
+func (_Csmodule *CsmoduleTransactor) AddNodeOperatorWstETH(opts *bind.TransactOpts, keysCount *big.Int, publicKeys []byte, signatures []byte, managementProperties NodeOperatorManagementProperties, permit ICSAccountingPermitInput, eaProof [][32]byte, referrer common.Address) (*types.Transaction, error) {
+	return _Csmodule.contract.Transact(opts, "addNodeOperatorWstETH", keysCount, publicKeys, signatures, managementProperties, permit, eaProof, referrer)
+}
+
+// AddNodeOperatorWstETH is a paid mutator transaction binding the contract method 0xacc446eb.
+//
+// Solidity: function addNodeOperatorWstETH(uint256 keysCount, bytes publicKeys, bytes signatures, (address,address,bool) managementProperties, (uint256,uint256,uint8,bytes32,bytes32) permit, bytes32[] eaProof, address referrer) returns()
+func (_Csmodule *CsmoduleSession) AddNodeOperatorWstETH(keysCount *big.Int, publicKeys []byte, signatures []byte, managementProperties NodeOperatorManagementProperties, permit ICSAccountingPermitInput, eaProof [][32]byte, referrer common.Address) (*types.Transaction, error) {
+	return _Csmodule.Contract.AddNodeOperatorWstETH(&_Csmodule.TransactOpts, keysCount, publicKeys, signatures, managementProperties, permit, eaProof, referrer)
+}
+
+// AddNodeOperatorWstETH is a paid mutator transaction binding the contract method 0xacc446eb.
+//
+// Solidity: function addNodeOperatorWstETH(uint256 keysCount, bytes publicKeys, bytes signatures, (address,address,bool) managementProperties, (uint256,uint256,uint8,bytes32,bytes32) permit, bytes32[] eaProof, address referrer) returns()
+func (_Csmodule *CsmoduleTransactorSession) AddNodeOperatorWstETH(keysCount *big.Int, publicKeys []byte, signatures []byte, managementProperties NodeOperatorManagementProperties, permit ICSAccountingPermitInput, eaProof [][32]byte, referrer common.Address) (*types.Transaction, error) {
+	return _Csmodule.Contract.AddNodeOperatorWstETH(&_Csmodule.TransactOpts, keysCount, publicKeys, signatures, managementProperties, permit, eaProof, referrer)
+}
+
+// AddValidatorKeysETH is a paid mutator transaction binding the contract method 0xfe7ed3cd.
+//
+// Solidity: function addValidatorKeysETH(uint256 nodeOperatorId, uint256 keysCount, bytes publicKeys, bytes signatures) payable returns()
+func (_Csmodule *CsmoduleTransactor) AddValidatorKeysETH(opts *bind.TransactOpts, nodeOperatorId *big.Int, keysCount *big.Int, publicKeys []byte, signatures []byte) (*types.Transaction, error) {
+	return _Csmodule.contract.Transact(opts, "addValidatorKeysETH", nodeOperatorId, keysCount, publicKeys, signatures)
+}
+
+// AddValidatorKeysETH is a paid mutator transaction binding the contract method 0xfe7ed3cd.
+//
+// Solidity: function addValidatorKeysETH(uint256 nodeOperatorId, uint256 keysCount, bytes publicKeys, bytes signatures) payable returns()
+func (_Csmodule *CsmoduleSession) AddValidatorKeysETH(nodeOperatorId *big.Int, keysCount *big.Int, publicKeys []byte, signatures []byte) (*types.Transaction, error) {
+	return _Csmodule.Contract.AddValidatorKeysETH(&_Csmodule.TransactOpts, nodeOperatorId, keysCount, publicKeys, signatures)
+}
+
+// AddValidatorKeysETH is a paid mutator transaction binding the contract method 0xfe7ed3cd.
+//
+// Solidity: function addValidatorKeysETH(uint256 nodeOperatorId, uint256 keysCount, bytes publicKeys, bytes signatures) payable returns()
+func (_Csmodule *CsmoduleTransactorSession) AddValidatorKeysETH(nodeOperatorId *big.Int, keysCount *big.Int, publicKeys []byte, signatures []byte) (*types.Transaction, error) {
+	return _Csmodule.Contract.AddValidatorKeysETH(&_Csmodule.TransactOpts, nodeOperatorId, keysCount, publicKeys, signatures)
+}
+
+// AddValidatorKeysStETH is a paid mutator transaction binding the contract method 0x946654ad.
+//
+// Solidity: function addValidatorKeysStETH(uint256 nodeOperatorId, uint256 keysCount, bytes publicKeys, bytes signatures, (uint256,uint256,uint8,bytes32,bytes32) permit) returns()
+func (_Csmodule *CsmoduleTransactor) AddValidatorKeysStETH(opts *bind.TransactOpts, nodeOperatorId *big.Int, keysCount *big.Int, publicKeys []byte, signatures []byte, permit ICSAccountingPermitInput) (*types.Transaction, error) {
+	return _Csmodule.contract.Transact(opts, "addValidatorKeysStETH", nodeOperatorId, keysCount, publicKeys, signatures, permit)
+}
+
+// AddValidatorKeysStETH is a paid mutator transaction binding the contract method 0x946654ad.
+//
+// Solidity: function addValidatorKeysStETH(uint256 nodeOperatorId, uint256 keysCount, bytes publicKeys, bytes signatures, (uint256,uint256,uint8,bytes32,bytes32) permit) returns()
+func (_Csmodule *CsmoduleSession) AddValidatorKeysStETH(nodeOperatorId *big.Int, keysCount *big.Int, publicKeys []byte, signatures []byte, permit ICSAccountingPermitInput) (*types.Transaction, error) {
+	return _Csmodule.Contract.AddValidatorKeysStETH(&_Csmodule.TransactOpts, nodeOperatorId, keysCount, publicKeys, signatures, permit)
+}
+
+// AddValidatorKeysStETH is a paid mutator transaction binding the contract method 0x946654ad.
+//
+// Solidity: function addValidatorKeysStETH(uint256 nodeOperatorId, uint256 keysCount, bytes publicKeys, bytes signatures, (uint256,uint256,uint8,bytes32,bytes32) permit) returns()
+func (_Csmodule *CsmoduleTransactorSession) AddValidatorKeysStETH(nodeOperatorId *big.Int, keysCount *big.Int, publicKeys []byte, signatures []byte, permit ICSAccountingPermitInput) (*types.Transaction, error) {
+	return _Csmodule.Contract.AddValidatorKeysStETH(&_Csmodule.TransactOpts, nodeOperatorId, keysCount, publicKeys, signatures, permit)
+}
+
+// AddValidatorKeysWstETH is a paid mutator transaction binding the contract method 0x9ec3c24c.
+//
+// Solidity: function addValidatorKeysWstETH(uint256 nodeOperatorId, uint256 keysCount, bytes publicKeys, bytes signatures, (uint256,uint256,uint8,bytes32,bytes32) permit) returns()
+func (_Csmodule *CsmoduleTransactor) AddValidatorKeysWstETH(opts *bind.TransactOpts, nodeOperatorId *big.Int, keysCount *big.Int, publicKeys []byte, signatures []byte, permit ICSAccountingPermitInput) (*types.Transaction, error) {
+	return _Csmodule.contract.Transact(opts, "addValidatorKeysWstETH", nodeOperatorId, keysCount, publicKeys, signatures, permit)
+}
+
+// AddValidatorKeysWstETH is a paid mutator transaction binding the contract method 0x9ec3c24c.
+//
+// Solidity: function addValidatorKeysWstETH(uint256 nodeOperatorId, uint256 keysCount, bytes publicKeys, bytes signatures, (uint256,uint256,uint8,bytes32,bytes32) permit) returns()
+func (_Csmodule *CsmoduleSession) AddValidatorKeysWstETH(nodeOperatorId *big.Int, keysCount *big.Int, publicKeys []byte, signatures []byte, permit ICSAccountingPermitInput) (*types.Transaction, error) {
+	return _Csmodule.Contract.AddValidatorKeysWstETH(&_Csmodule.TransactOpts, nodeOperatorId, keysCount, publicKeys, signatures, permit)
+}
+
+// AddValidatorKeysWstETH is a paid mutator transaction binding the contract method 0x9ec3c24c.
+//
+// Solidity: function addValidatorKeysWstETH(uint256 nodeOperatorId, uint256 keysCount, bytes publicKeys, bytes signatures, (uint256,uint256,uint8,bytes32,bytes32) permit) returns()
+func (_Csmodule *CsmoduleTransactorSession) AddValidatorKeysWstETH(nodeOperatorId *big.Int, keysCount *big.Int, publicKeys []byte, signatures []byte, permit ICSAccountingPermitInput) (*types.Transaction, error) {
+	return _Csmodule.Contract.AddValidatorKeysWstETH(&_Csmodule.TransactOpts, nodeOperatorId, keysCount, publicKeys, signatures, permit)
+}
+
+// CancelELRewardsStealingPenalty is a paid mutator transaction binding the contract method 0x40044801.
+//
+// Solidity: function cancelELRewardsStealingPenalty(uint256 nodeOperatorId, uint256 amount) returns()
+func (_Csmodule *CsmoduleTransactor) CancelELRewardsStealingPenalty(opts *bind.TransactOpts, nodeOperatorId *big.Int, amount *big.Int) (*types.Transaction, error) {
+	return _Csmodule.contract.Transact(opts, "cancelELRewardsStealingPenalty", nodeOperatorId, amount)
+}
+
+// CancelELRewardsStealingPenalty is a paid mutator transaction binding the contract method 0x40044801.
+//
+// Solidity: function cancelELRewardsStealingPenalty(uint256 nodeOperatorId, uint256 amount) returns()
+func (_Csmodule *CsmoduleSession) CancelELRewardsStealingPenalty(nodeOperatorId *big.Int, amount *big.Int) (*types.Transaction, error) {
+	return _Csmodule.Contract.CancelELRewardsStealingPenalty(&_Csmodule.TransactOpts, nodeOperatorId, amount)
+}
+
+// CancelELRewardsStealingPenalty is a paid mutator transaction binding the contract method 0x40044801.
+//
+// Solidity: function cancelELRewardsStealingPenalty(uint256 nodeOperatorId, uint256 amount) returns()
+func (_Csmodule *CsmoduleTransactorSession) CancelELRewardsStealingPenalty(nodeOperatorId *big.Int, amount *big.Int) (*types.Transaction, error) {
+	return _Csmodule.Contract.CancelELRewardsStealingPenalty(&_Csmodule.TransactOpts, nodeOperatorId, amount)
+}
+
+// ChangeNodeOperatorRewardAddress is a paid mutator transaction binding the contract method 0x75a401da.
+//
+// Solidity: function changeNodeOperatorRewardAddress(uint256 nodeOperatorId, address newAddress) returns()
+func (_Csmodule *CsmoduleTransactor) ChangeNodeOperatorRewardAddress(opts *bind.TransactOpts, nodeOperatorId *big.Int, newAddress common.Address) (*types.Transaction, error) {
+	return _Csmodule.contract.Transact(opts, "changeNodeOperatorRewardAddress", nodeOperatorId, newAddress)
+}
+
+// ChangeNodeOperatorRewardAddress is a paid mutator transaction binding the contract method 0x75a401da.
+//
+// Solidity: function changeNodeOperatorRewardAddress(uint256 nodeOperatorId, address newAddress) returns()
+func (_Csmodule *CsmoduleSession) ChangeNodeOperatorRewardAddress(nodeOperatorId *big.Int, newAddress common.Address) (*types.Transaction, error) {
+	return _Csmodule.Contract.ChangeNodeOperatorRewardAddress(&_Csmodule.TransactOpts, nodeOperatorId, newAddress)
+}
+
+// ChangeNodeOperatorRewardAddress is a paid mutator transaction binding the contract method 0x75a401da.
+//
+// Solidity: function changeNodeOperatorRewardAddress(uint256 nodeOperatorId, address newAddress) returns()
+func (_Csmodule *CsmoduleTransactorSession) ChangeNodeOperatorRewardAddress(nodeOperatorId *big.Int, newAddress common.Address) (*types.Transaction, error) {
+	return _Csmodule.Contract.ChangeNodeOperatorRewardAddress(&_Csmodule.TransactOpts, nodeOperatorId, newAddress)
+}
+
+// ClaimRewardsStETH is a paid mutator transaction binding the contract method 0x8409d4fe.
+//
+// Solidity: function claimRewardsStETH(uint256 nodeOperatorId, uint256 stETHAmount, uint256 cumulativeFeeShares, bytes32[] rewardsProof) returns()
+func (_Csmodule *CsmoduleTransactor) ClaimRewardsStETH(opts *bind.TransactOpts, nodeOperatorId *big.Int, stETHAmount *big.Int, cumulativeFeeShares *big.Int, rewardsProof [][32]byte) (*types.Transaction, error) {
+	return _Csmodule.contract.Transact(opts, "claimRewardsStETH", nodeOperatorId, stETHAmount, cumulativeFeeShares, rewardsProof)
+}
+
+// ClaimRewardsStETH is a paid mutator transaction binding the contract method 0x8409d4fe.
+//
+// Solidity: function claimRewardsStETH(uint256 nodeOperatorId, uint256 stETHAmount, uint256 cumulativeFeeShares, bytes32[] rewardsProof) returns()
+func (_Csmodule *CsmoduleSession) ClaimRewardsStETH(nodeOperatorId *big.Int, stETHAmount *big.Int, cumulativeFeeShares *big.Int, rewardsProof [][32]byte) (*types.Transaction, error) {
+	return _Csmodule.Contract.ClaimRewardsStETH(&_Csmodule.TransactOpts, nodeOperatorId, stETHAmount, cumulativeFeeShares, rewardsProof)
+}
+
+// ClaimRewardsStETH is a paid mutator transaction binding the contract method 0x8409d4fe.
+//
+// Solidity: function claimRewardsStETH(uint256 nodeOperatorId, uint256 stETHAmount, uint256 cumulativeFeeShares, bytes32[] rewardsProof) returns()
+func (_Csmodule *CsmoduleTransactorSession) ClaimRewardsStETH(nodeOperatorId *big.Int, stETHAmount *big.Int, cumulativeFeeShares *big.Int, rewardsProof [][32]byte) (*types.Transaction, error) {
+	return _Csmodule.Contract.ClaimRewardsStETH(&_Csmodule.TransactOpts, nodeOperatorId, stETHAmount, cumulativeFeeShares, rewardsProof)
+}
+
+// ClaimRewardsUnstETH is a paid mutator transaction binding the contract method 0x3df6c438.
+//
+// Solidity: function claimRewardsUnstETH(uint256 nodeOperatorId, uint256 stEthAmount, uint256 cumulativeFeeShares, bytes32[] rewardsProof) returns()
+func (_Csmodule *CsmoduleTransactor) ClaimRewardsUnstETH(opts *bind.TransactOpts, nodeOperatorId *big.Int, stEthAmount *big.Int, cumulativeFeeShares *big.Int, rewardsProof [][32]byte) (*types.Transaction, error) {
+	return _Csmodule.contract.Transact(opts, "claimRewardsUnstETH", nodeOperatorId, stEthAmount, cumulativeFeeShares, rewardsProof)
+}
+
+// ClaimRewardsUnstETH is a paid mutator transaction binding the contract method 0x3df6c438.
+//
+// Solidity: function claimRewardsUnstETH(uint256 nodeOperatorId, uint256 stEthAmount, uint256 cumulativeFeeShares, bytes32[] rewardsProof) returns()
+func (_Csmodule *CsmoduleSession) ClaimRewardsUnstETH(nodeOperatorId *big.Int, stEthAmount *big.Int, cumulativeFeeShares *big.Int, rewardsProof [][32]byte) (*types.Transaction, error) {
+	return _Csmodule.Contract.ClaimRewardsUnstETH(&_Csmodule.TransactOpts, nodeOperatorId, stEthAmount, cumulativeFeeShares, rewardsProof)
+}
+
+// ClaimRewardsUnstETH is a paid mutator transaction binding the contract method 0x3df6c438.
+//
+// Solidity: function claimRewardsUnstETH(uint256 nodeOperatorId, uint256 stEthAmount, uint256 cumulativeFeeShares, bytes32[] rewardsProof) returns()
+func (_Csmodule *CsmoduleTransactorSession) ClaimRewardsUnstETH(nodeOperatorId *big.Int, stEthAmount *big.Int, cumulativeFeeShares *big.Int, rewardsProof [][32]byte) (*types.Transaction, error) {
+	return _Csmodule.Contract.ClaimRewardsUnstETH(&_Csmodule.TransactOpts, nodeOperatorId, stEthAmount, cumulativeFeeShares, rewardsProof)
+}
+
+// ClaimRewardsWstETH is a paid mutator transaction binding the contract method 0x5097ef59.
+//
+// Solidity: function claimRewardsWstETH(uint256 nodeOperatorId, uint256 wstETHAmount, uint256 cumulativeFeeShares, bytes32[] rewardsProof) returns()
+func (_Csmodule *CsmoduleTransactor) ClaimRewardsWstETH(opts *bind.TransactOpts, nodeOperatorId *big.Int, wstETHAmount *big.Int, cumulativeFeeShares *big.Int, rewardsProof [][32]byte) (*types.Transaction, error) {
+	return _Csmodule.contract.Transact(opts, "claimRewardsWstETH", nodeOperatorId, wstETHAmount, cumulativeFeeShares, rewardsProof)
+}
+
+// ClaimRewardsWstETH is a paid mutator transaction binding the contract method 0x5097ef59.
+//
+// Solidity: function claimRewardsWstETH(uint256 nodeOperatorId, uint256 wstETHAmount, uint256 cumulativeFeeShares, bytes32[] rewardsProof) returns()
+func (_Csmodule *CsmoduleSession) ClaimRewardsWstETH(nodeOperatorId *big.Int, wstETHAmount *big.Int, cumulativeFeeShares *big.Int, rewardsProof [][32]byte) (*types.Transaction, error) {
+	return _Csmodule.Contract.ClaimRewardsWstETH(&_Csmodule.TransactOpts, nodeOperatorId, wstETHAmount, cumulativeFeeShares, rewardsProof)
+}
+
+// ClaimRewardsWstETH is a paid mutator transaction binding the contract method 0x5097ef59.
+//
+// Solidity: function claimRewardsWstETH(uint256 nodeOperatorId, uint256 wstETHAmount, uint256 cumulativeFeeShares, bytes32[] rewardsProof) returns()
+func (_Csmodule *CsmoduleTransactorSession) ClaimRewardsWstETH(nodeOperatorId *big.Int, wstETHAmount *big.Int, cumulativeFeeShares *big.Int, rewardsProof [][32]byte) (*types.Transaction, error) {
+	return _Csmodule.Contract.ClaimRewardsWstETH(&_Csmodule.TransactOpts, nodeOperatorId, wstETHAmount, cumulativeFeeShares, rewardsProof)
+}
+
+// CleanDepositQueue is a paid mutator transaction binding the contract method 0x735dfa28.
+//
+// Solidity: function cleanDepositQueue(uint256 maxItems) returns(uint256)
+func (_Csmodule *CsmoduleTransactor) CleanDepositQueue(opts *bind.TransactOpts, maxItems *big.Int) (*types.Transaction, error) {
+	return _Csmodule.contract.Transact(opts, "cleanDepositQueue", maxItems)
+}
+
+// CleanDepositQueue is a paid mutator transaction binding the contract method 0x735dfa28.
+//
+// Solidity: function cleanDepositQueue(uint256 maxItems) returns(uint256)
+func (_Csmodule *CsmoduleSession) CleanDepositQueue(maxItems *big.Int) (*types.Transaction, error) {
+	return _Csmodule.Contract.CleanDepositQueue(&_Csmodule.TransactOpts, maxItems)
+}
+
+// CleanDepositQueue is a paid mutator transaction binding the contract method 0x735dfa28.
+//
+// Solidity: function cleanDepositQueue(uint256 maxItems) returns(uint256)
+func (_Csmodule *CsmoduleTransactorSession) CleanDepositQueue(maxItems *big.Int) (*types.Transaction, error) {
+	return _Csmodule.Contract.CleanDepositQueue(&_Csmodule.TransactOpts, maxItems)
+}
+
+// CompensateELRewardsStealingPenalty is a paid mutator transaction binding the contract method 0x6efe37a2.
+//
+// Solidity: function compensateELRewardsStealingPenalty(uint256 nodeOperatorId) payable returns()
+func (_Csmodule *CsmoduleTransactor) CompensateELRewardsStealingPenalty(opts *bind.TransactOpts, nodeOperatorId *big.Int) (*types.Transaction, error) {
+	return _Csmodule.contract.Transact(opts, "compensateELRewardsStealingPenalty", nodeOperatorId)
+}
+
+// CompensateELRewardsStealingPenalty is a paid mutator transaction binding the contract method 0x6efe37a2.
+//
+// Solidity: function compensateELRewardsStealingPenalty(uint256 nodeOperatorId) payable returns()
+func (_Csmodule *CsmoduleSession) CompensateELRewardsStealingPenalty(nodeOperatorId *big.Int) (*types.Transaction, error) {
+	return _Csmodule.Contract.CompensateELRewardsStealingPenalty(&_Csmodule.TransactOpts, nodeOperatorId)
+}
+
+// CompensateELRewardsStealingPenalty is a paid mutator transaction binding the contract method 0x6efe37a2.
+//
+// Solidity: function compensateELRewardsStealingPenalty(uint256 nodeOperatorId) payable returns()
+func (_Csmodule *CsmoduleTransactorSession) CompensateELRewardsStealingPenalty(nodeOperatorId *big.Int) (*types.Transaction, error) {
+	return _Csmodule.Contract.CompensateELRewardsStealingPenalty(&_Csmodule.TransactOpts, nodeOperatorId)
+}
+
+// ConfirmNodeOperatorManagerAddressChange is a paid mutator transaction binding the contract method 0x6bb1bfdf.
+//
+// Solidity: function confirmNodeOperatorManagerAddressChange(uint256 nodeOperatorId) returns()
+func (_Csmodule *CsmoduleTransactor) ConfirmNodeOperatorManagerAddressChange(opts *bind.TransactOpts, nodeOperatorId *big.Int) (*types.Transaction, error) {
+	return _Csmodule.contract.Transact(opts, "confirmNodeOperatorManagerAddressChange", nodeOperatorId)
+}
+
+// ConfirmNodeOperatorManagerAddressChange is a paid mutator transaction binding the contract method 0x6bb1bfdf.
+//
+// Solidity: function confirmNodeOperatorManagerAddressChange(uint256 nodeOperatorId) returns()
+func (_Csmodule *CsmoduleSession) ConfirmNodeOperatorManagerAddressChange(nodeOperatorId *big.Int) (*types.Transaction, error) {
+	return _Csmodule.Contract.ConfirmNodeOperatorManagerAddressChange(&_Csmodule.TransactOpts, nodeOperatorId)
+}
+
+// ConfirmNodeOperatorManagerAddressChange is a paid mutator transaction binding the contract method 0x6bb1bfdf.
+//
+// Solidity: function confirmNodeOperatorManagerAddressChange(uint256 nodeOperatorId) returns()
+func (_Csmodule *CsmoduleTransactorSession) ConfirmNodeOperatorManagerAddressChange(nodeOperatorId *big.Int) (*types.Transaction, error) {
+	return _Csmodule.Contract.ConfirmNodeOperatorManagerAddressChange(&_Csmodule.TransactOpts, nodeOperatorId)
+}
+
+// ConfirmNodeOperatorRewardAddressChange is a paid mutator transaction binding the contract method 0x5204281c.
+//
+// Solidity: function confirmNodeOperatorRewardAddressChange(uint256 nodeOperatorId) returns()
+func (_Csmodule *CsmoduleTransactor) ConfirmNodeOperatorRewardAddressChange(opts *bind.TransactOpts, nodeOperatorId *big.Int) (*types.Transaction, error) {
+	return _Csmodule.contract.Transact(opts, "confirmNodeOperatorRewardAddressChange", nodeOperatorId)
+}
+
+// ConfirmNodeOperatorRewardAddressChange is a paid mutator transaction binding the contract method 0x5204281c.
+//
+// Solidity: function confirmNodeOperatorRewardAddressChange(uint256 nodeOperatorId) returns()
+func (_Csmodule *CsmoduleSession) ConfirmNodeOperatorRewardAddressChange(nodeOperatorId *big.Int) (*types.Transaction, error) {
+	return _Csmodule.Contract.ConfirmNodeOperatorRewardAddressChange(&_Csmodule.TransactOpts, nodeOperatorId)
+}
+
+// ConfirmNodeOperatorRewardAddressChange is a paid mutator transaction binding the contract method 0x5204281c.
+//
+// Solidity: function confirmNodeOperatorRewardAddressChange(uint256 nodeOperatorId) returns()
+func (_Csmodule *CsmoduleTransactorSession) ConfirmNodeOperatorRewardAddressChange(nodeOperatorId *big.Int) (*types.Transaction, error) {
+	return _Csmodule.Contract.ConfirmNodeOperatorRewardAddressChange(&_Csmodule.TransactOpts, nodeOperatorId)
+}
+
+// DecreaseVettedSigningKeysCount is a paid mutator transaction binding the contract method 0xb643189b.
+//
+// Solidity: function decreaseVettedSigningKeysCount(bytes nodeOperatorIds, bytes vettedSigningKeysCounts) returns()
+func (_Csmodule *CsmoduleTransactor) DecreaseVettedSigningKeysCount(opts *bind.TransactOpts, nodeOperatorIds []byte, vettedSigningKeysCounts []byte) (*types.Transaction, error) {
+	return _Csmodule.contract.Transact(opts, "decreaseVettedSigningKeysCount", nodeOperatorIds, vettedSigningKeysCounts)
+}
+
+// DecreaseVettedSigningKeysCount is a paid mutator transaction binding the contract method 0xb643189b.
+//
+// Solidity: function decreaseVettedSigningKeysCount(bytes nodeOperatorIds, bytes vettedSigningKeysCounts) returns()
+func (_Csmodule *CsmoduleSession) DecreaseVettedSigningKeysCount(nodeOperatorIds []byte, vettedSigningKeysCounts []byte) (*types.Transaction, error) {
+	return _Csmodule.Contract.DecreaseVettedSigningKeysCount(&_Csmodule.TransactOpts, nodeOperatorIds, vettedSigningKeysCounts)
+}
+
+// DecreaseVettedSigningKeysCount is a paid mutator transaction binding the contract method 0xb643189b.
+//
+// Solidity: function decreaseVettedSigningKeysCount(bytes nodeOperatorIds, bytes vettedSigningKeysCounts) returns()
+func (_Csmodule *CsmoduleTransactorSession) DecreaseVettedSigningKeysCount(nodeOperatorIds []byte, vettedSigningKeysCounts []byte) (*types.Transaction, error) {
+	return _Csmodule.Contract.DecreaseVettedSigningKeysCount(&_Csmodule.TransactOpts, nodeOperatorIds, vettedSigningKeysCounts)
+}
+
+// DepositETH is a paid mutator transaction binding the contract method 0x5358fbda.
+//
+// Solidity: function depositETH(uint256 nodeOperatorId) payable returns()
+func (_Csmodule *CsmoduleTransactor) DepositETH(opts *bind.TransactOpts, nodeOperatorId *big.Int) (*types.Transaction, error) {
+	return _Csmodule.contract.Transact(opts, "depositETH", nodeOperatorId)
+}
+
+// DepositETH is a paid mutator transaction binding the contract method 0x5358fbda.
+//
+// Solidity: function depositETH(uint256 nodeOperatorId) payable returns()
+func (_Csmodule *CsmoduleSession) DepositETH(nodeOperatorId *big.Int) (*types.Transaction, error) {
+	return _Csmodule.Contract.DepositETH(&_Csmodule.TransactOpts, nodeOperatorId)
+}
+
+// DepositETH is a paid mutator transaction binding the contract method 0x5358fbda.
+//
+// Solidity: function depositETH(uint256 nodeOperatorId) payable returns()
+func (_Csmodule *CsmoduleTransactorSession) DepositETH(nodeOperatorId *big.Int) (*types.Transaction, error) {
+	return _Csmodule.Contract.DepositETH(&_Csmodule.TransactOpts, nodeOperatorId)
+}
+
+// DepositStETH is a paid mutator transaction binding the contract method 0xe1aa105d.
+//
+// Solidity: function depositStETH(uint256 nodeOperatorId, uint256 stETHAmount, (uint256,uint256,uint8,bytes32,bytes32) permit) returns()
+func (_Csmodule *CsmoduleTransactor) DepositStETH(opts *bind.TransactOpts, nodeOperatorId *big.Int, stETHAmount *big.Int, permit ICSAccountingPermitInput) (*types.Transaction, error) {
+	return _Csmodule.contract.Transact(opts, "depositStETH", nodeOperatorId, stETHAmount, permit)
+}
+
+// DepositStETH is a paid mutator transaction binding the contract method 0xe1aa105d.
+//
+// Solidity: function depositStETH(uint256 nodeOperatorId, uint256 stETHAmount, (uint256,uint256,uint8,bytes32,bytes32) permit) returns()
+func (_Csmodule *CsmoduleSession) DepositStETH(nodeOperatorId *big.Int, stETHAmount *big.Int, permit ICSAccountingPermitInput) (*types.Transaction, error) {
+	return _Csmodule.Contract.DepositStETH(&_Csmodule.TransactOpts, nodeOperatorId, stETHAmount, permit)
+}
+
+// DepositStETH is a paid mutator transaction binding the contract method 0xe1aa105d.
+//
+// Solidity: function depositStETH(uint256 nodeOperatorId, uint256 stETHAmount, (uint256,uint256,uint8,bytes32,bytes32) permit) returns()
+func (_Csmodule *CsmoduleTransactorSession) DepositStETH(nodeOperatorId *big.Int, stETHAmount *big.Int, permit ICSAccountingPermitInput) (*types.Transaction, error) {
+	return _Csmodule.Contract.DepositStETH(&_Csmodule.TransactOpts, nodeOperatorId, stETHAmount, permit)
+}
+
+// DepositWstETH is a paid mutator transaction binding the contract method 0x3f214bb2.
+//
+// Solidity: function depositWstETH(uint256 nodeOperatorId, uint256 wstETHAmount, (uint256,uint256,uint8,bytes32,bytes32) permit) returns()
+func (_Csmodule *CsmoduleTransactor) DepositWstETH(opts *bind.TransactOpts, nodeOperatorId *big.Int, wstETHAmount *big.Int, permit ICSAccountingPermitInput) (*types.Transaction, error) {
+	return _Csmodule.contract.Transact(opts, "depositWstETH", nodeOperatorId, wstETHAmount, permit)
+}
+
+// DepositWstETH is a paid mutator transaction binding the contract method 0x3f214bb2.
+//
+// Solidity: function depositWstETH(uint256 nodeOperatorId, uint256 wstETHAmount, (uint256,uint256,uint8,bytes32,bytes32) permit) returns()
+func (_Csmodule *CsmoduleSession) DepositWstETH(nodeOperatorId *big.Int, wstETHAmount *big.Int, permit ICSAccountingPermitInput) (*types.Transaction, error) {
+	return _Csmodule.Contract.DepositWstETH(&_Csmodule.TransactOpts, nodeOperatorId, wstETHAmount, permit)
+}
+
+// DepositWstETH is a paid mutator transaction binding the contract method 0x3f214bb2.
+//
+// Solidity: function depositWstETH(uint256 nodeOperatorId, uint256 wstETHAmount, (uint256,uint256,uint8,bytes32,bytes32) permit) returns()
+func (_Csmodule *CsmoduleTransactorSession) DepositWstETH(nodeOperatorId *big.Int, wstETHAmount *big.Int, permit ICSAccountingPermitInput) (*types.Transaction, error) {
+	return _Csmodule.Contract.DepositWstETH(&_Csmodule.TransactOpts, nodeOperatorId, wstETHAmount, permit)
+}
+
+// GrantRole is a paid mutator transaction binding the contract method 0x2f2ff15d.
+//
+// Solidity: function grantRole(bytes32 role, address account) returns()
+func (_Csmodule *CsmoduleTransactor) GrantRole(opts *bind.TransactOpts, role [32]byte, account common.Address) (*types.Transaction, error) {
+	return _Csmodule.contract.Transact(opts, "grantRole", role, account)
+}
+
+// GrantRole is a paid mutator transaction binding the contract method 0x2f2ff15d.
+//
+// Solidity: function grantRole(bytes32 role, address account) returns()
+func (_Csmodule *CsmoduleSession) GrantRole(role [32]byte, account common.Address) (*types.Transaction, error) {
+	return _Csmodule.Contract.GrantRole(&_Csmodule.TransactOpts, role, account)
+}
+
+// GrantRole is a paid mutator transaction binding the contract method 0x2f2ff15d.
+//
+// Solidity: function grantRole(bytes32 role, address account) returns()
+func (_Csmodule *CsmoduleTransactorSession) GrantRole(role [32]byte, account common.Address) (*types.Transaction, error) {
+	return _Csmodule.Contract.GrantRole(&_Csmodule.TransactOpts, role, account)
+}
+
+// Initialize is a paid mutator transaction binding the contract method 0xbe203094.
+//
+// Solidity: function initialize(address _accounting, address _earlyAdoption, uint256 _keyRemovalCharge, address admin) returns()
+func (_Csmodule *CsmoduleTransactor) Initialize(opts *bind.TransactOpts, _accounting common.Address, _earlyAdoption common.Address, _keyRemovalCharge *big.Int, admin common.Address) (*types.Transaction, error) {
+	return _Csmodule.contract.Transact(opts, "initialize", _accounting, _earlyAdoption, _keyRemovalCharge, admin)
+}
+
+// Initialize is a paid mutator transaction binding the contract method 0xbe203094.
+//
+// Solidity: function initialize(address _accounting, address _earlyAdoption, uint256 _keyRemovalCharge, address admin) returns()
+func (_Csmodule *CsmoduleSession) Initialize(_accounting common.Address, _earlyAdoption common.Address, _keyRemovalCharge *big.Int, admin common.Address) (*types.Transaction, error) {
+	return _Csmodule.Contract.Initialize(&_Csmodule.TransactOpts, _accounting, _earlyAdoption, _keyRemovalCharge, admin)
+}
+
+// Initialize is a paid mutator transaction binding the contract method 0xbe203094.
+//
+// Solidity: function initialize(address _accounting, address _earlyAdoption, uint256 _keyRemovalCharge, address admin) returns()
+func (_Csmodule *CsmoduleTransactorSession) Initialize(_accounting common.Address, _earlyAdoption common.Address, _keyRemovalCharge *big.Int, admin common.Address) (*types.Transaction, error) {
+	return _Csmodule.Contract.Initialize(&_Csmodule.TransactOpts, _accounting, _earlyAdoption, _keyRemovalCharge, admin)
+}
+
+// NormalizeQueue is a paid mutator transaction binding the contract method 0xb1520dc5.
+//
+// Solidity: function normalizeQueue(uint256 nodeOperatorId) returns()
+func (_Csmodule *CsmoduleTransactor) NormalizeQueue(opts *bind.TransactOpts, nodeOperatorId *big.Int) (*types.Transaction, error) {
+	return _Csmodule.contract.Transact(opts, "normalizeQueue", nodeOperatorId)
+}
+
+// NormalizeQueue is a paid mutator transaction binding the contract method 0xb1520dc5.
+//
+// Solidity: function normalizeQueue(uint256 nodeOperatorId) returns()
+func (_Csmodule *CsmoduleSession) NormalizeQueue(nodeOperatorId *big.Int) (*types.Transaction, error) {
+	return _Csmodule.Contract.NormalizeQueue(&_Csmodule.TransactOpts, nodeOperatorId)
+}
+
+// NormalizeQueue is a paid mutator transaction binding the contract method 0xb1520dc5.
+//
+// Solidity: function normalizeQueue(uint256 nodeOperatorId) returns()
+func (_Csmodule *CsmoduleTransactorSession) NormalizeQueue(nodeOperatorId *big.Int) (*types.Transaction, error) {
+	return _Csmodule.Contract.NormalizeQueue(&_Csmodule.TransactOpts, nodeOperatorId)
+}
+
+// ObtainDepositData is a paid mutator transaction binding the contract method 0xbee41b58.
+//
+// Solidity: function obtainDepositData(uint256 depositsCount, bytes ) returns(bytes publicKeys, bytes signatures)
+func (_Csmodule *CsmoduleTransactor) ObtainDepositData(opts *bind.TransactOpts, depositsCount *big.Int, arg1 []byte) (*types.Transaction, error) {
+	return _Csmodule.contract.Transact(opts, "obtainDepositData", depositsCount, arg1)
+}
+
+// ObtainDepositData is a paid mutator transaction binding the contract method 0xbee41b58.
+//
+// Solidity: function obtainDepositData(uint256 depositsCount, bytes ) returns(bytes publicKeys, bytes signatures)
+func (_Csmodule *CsmoduleSession) ObtainDepositData(depositsCount *big.Int, arg1 []byte) (*types.Transaction, error) {
+	return _Csmodule.Contract.ObtainDepositData(&_Csmodule.TransactOpts, depositsCount, arg1)
+}
+
+// ObtainDepositData is a paid mutator transaction binding the contract method 0xbee41b58.
+//
+// Solidity: function obtainDepositData(uint256 depositsCount, bytes ) returns(bytes publicKeys, bytes signatures)
+func (_Csmodule *CsmoduleTransactorSession) ObtainDepositData(depositsCount *big.Int, arg1 []byte) (*types.Transaction, error) {
+	return _Csmodule.Contract.ObtainDepositData(&_Csmodule.TransactOpts, depositsCount, arg1)
+}
+
+// OnExitedAndStuckValidatorsCountsUpdated is a paid mutator transaction binding the contract method 0xe864299e.
+//
+// Solidity: function onExitedAndStuckValidatorsCountsUpdated() returns()
+func (_Csmodule *CsmoduleTransactor) OnExitedAndStuckValidatorsCountsUpdated(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Csmodule.contract.Transact(opts, "onExitedAndStuckValidatorsCountsUpdated")
+}
+
+// OnExitedAndStuckValidatorsCountsUpdated is a paid mutator transaction binding the contract method 0xe864299e.
+//
+// Solidity: function onExitedAndStuckValidatorsCountsUpdated() returns()
+func (_Csmodule *CsmoduleSession) OnExitedAndStuckValidatorsCountsUpdated() (*types.Transaction, error) {
+	return _Csmodule.Contract.OnExitedAndStuckValidatorsCountsUpdated(&_Csmodule.TransactOpts)
+}
+
+// OnExitedAndStuckValidatorsCountsUpdated is a paid mutator transaction binding the contract method 0xe864299e.
+//
+// Solidity: function onExitedAndStuckValidatorsCountsUpdated() returns()
+func (_Csmodule *CsmoduleTransactorSession) OnExitedAndStuckValidatorsCountsUpdated() (*types.Transaction, error) {
+	return _Csmodule.Contract.OnExitedAndStuckValidatorsCountsUpdated(&_Csmodule.TransactOpts)
+}
+
+// OnRewardsMinted is a paid mutator transaction binding the contract method 0x8d7e4017.
+//
+// Solidity: function onRewardsMinted(uint256 totalShares) returns()
+func (_Csmodule *CsmoduleTransactor) OnRewardsMinted(opts *bind.TransactOpts, totalShares *big.Int) (*types.Transaction, error) {
+	return _Csmodule.contract.Transact(opts, "onRewardsMinted", totalShares)
+}
+
+// OnRewardsMinted is a paid mutator transaction binding the contract method 0x8d7e4017.
+//
+// Solidity: function onRewardsMinted(uint256 totalShares) returns()
+func (_Csmodule *CsmoduleSession) OnRewardsMinted(totalShares *big.Int) (*types.Transaction, error) {
+	return _Csmodule.Contract.OnRewardsMinted(&_Csmodule.TransactOpts, totalShares)
+}
+
+// OnRewardsMinted is a paid mutator transaction binding the contract method 0x8d7e4017.
+//
+// Solidity: function onRewardsMinted(uint256 totalShares) returns()
+func (_Csmodule *CsmoduleTransactorSession) OnRewardsMinted(totalShares *big.Int) (*types.Transaction, error) {
+	return _Csmodule.Contract.OnRewardsMinted(&_Csmodule.TransactOpts, totalShares)
+}
+
+// OnWithdrawalCredentialsChanged is a paid mutator transaction binding the contract method 0x90c09bdb.
+//
+// Solidity: function onWithdrawalCredentialsChanged() returns()
+func (_Csmodule *CsmoduleTransactor) OnWithdrawalCredentialsChanged(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Csmodule.contract.Transact(opts, "onWithdrawalCredentialsChanged")
+}
+
+// OnWithdrawalCredentialsChanged is a paid mutator transaction binding the contract method 0x90c09bdb.
+//
+// Solidity: function onWithdrawalCredentialsChanged() returns()
+func (_Csmodule *CsmoduleSession) OnWithdrawalCredentialsChanged() (*types.Transaction, error) {
+	return _Csmodule.Contract.OnWithdrawalCredentialsChanged(&_Csmodule.TransactOpts)
+}
+
+// OnWithdrawalCredentialsChanged is a paid mutator transaction binding the contract method 0x90c09bdb.
+//
+// Solidity: function onWithdrawalCredentialsChanged() returns()
+func (_Csmodule *CsmoduleTransactorSession) OnWithdrawalCredentialsChanged() (*types.Transaction, error) {
+	return _Csmodule.Contract.OnWithdrawalCredentialsChanged(&_Csmodule.TransactOpts)
+}
+
+// PauseFor is a paid mutator transaction binding the contract method 0xf3f449c7.
+//
+// Solidity: function pauseFor(uint256 duration) returns()
+func (_Csmodule *CsmoduleTransactor) PauseFor(opts *bind.TransactOpts, duration *big.Int) (*types.Transaction, error) {
+	return _Csmodule.contract.Transact(opts, "pauseFor", duration)
+}
+
+// PauseFor is a paid mutator transaction binding the contract method 0xf3f449c7.
+//
+// Solidity: function pauseFor(uint256 duration) returns()
+func (_Csmodule *CsmoduleSession) PauseFor(duration *big.Int) (*types.Transaction, error) {
+	return _Csmodule.Contract.PauseFor(&_Csmodule.TransactOpts, duration)
+}
+
+// PauseFor is a paid mutator transaction binding the contract method 0xf3f449c7.
+//
+// Solidity: function pauseFor(uint256 duration) returns()
+func (_Csmodule *CsmoduleTransactorSession) PauseFor(duration *big.Int) (*types.Transaction, error) {
+	return _Csmodule.Contract.PauseFor(&_Csmodule.TransactOpts, duration)
+}
+
+// ProposeNodeOperatorManagerAddressChange is a paid mutator transaction binding the contract method 0x8cabe959.
+//
+// Solidity: function proposeNodeOperatorManagerAddressChange(uint256 nodeOperatorId, address proposedAddress) returns()
+func (_Csmodule *CsmoduleTransactor) ProposeNodeOperatorManagerAddressChange(opts *bind.TransactOpts, nodeOperatorId *big.Int, proposedAddress common.Address) (*types.Transaction, error) {
+	return _Csmodule.contract.Transact(opts, "proposeNodeOperatorManagerAddressChange", nodeOperatorId, proposedAddress)
+}
+
+// ProposeNodeOperatorManagerAddressChange is a paid mutator transaction binding the contract method 0x8cabe959.
+//
+// Solidity: function proposeNodeOperatorManagerAddressChange(uint256 nodeOperatorId, address proposedAddress) returns()
+func (_Csmodule *CsmoduleSession) ProposeNodeOperatorManagerAddressChange(nodeOperatorId *big.Int, proposedAddress common.Address) (*types.Transaction, error) {
+	return _Csmodule.Contract.ProposeNodeOperatorManagerAddressChange(&_Csmodule.TransactOpts, nodeOperatorId, proposedAddress)
+}
+
+// ProposeNodeOperatorManagerAddressChange is a paid mutator transaction binding the contract method 0x8cabe959.
+//
+// Solidity: function proposeNodeOperatorManagerAddressChange(uint256 nodeOperatorId, address proposedAddress) returns()
+func (_Csmodule *CsmoduleTransactorSession) ProposeNodeOperatorManagerAddressChange(nodeOperatorId *big.Int, proposedAddress common.Address) (*types.Transaction, error) {
+	return _Csmodule.Contract.ProposeNodeOperatorManagerAddressChange(&_Csmodule.TransactOpts, nodeOperatorId, proposedAddress)
+}
+
+// ProposeNodeOperatorRewardAddressChange is a paid mutator transaction binding the contract method 0x1b40b231.
+//
+// Solidity: function proposeNodeOperatorRewardAddressChange(uint256 nodeOperatorId, address proposedAddress) returns()
+func (_Csmodule *CsmoduleTransactor) ProposeNodeOperatorRewardAddressChange(opts *bind.TransactOpts, nodeOperatorId *big.Int, proposedAddress common.Address) (*types.Transaction, error) {
+	return _Csmodule.contract.Transact(opts, "proposeNodeOperatorRewardAddressChange", nodeOperatorId, proposedAddress)
+}
+
+// ProposeNodeOperatorRewardAddressChange is a paid mutator transaction binding the contract method 0x1b40b231.
+//
+// Solidity: function proposeNodeOperatorRewardAddressChange(uint256 nodeOperatorId, address proposedAddress) returns()
+func (_Csmodule *CsmoduleSession) ProposeNodeOperatorRewardAddressChange(nodeOperatorId *big.Int, proposedAddress common.Address) (*types.Transaction, error) {
+	return _Csmodule.Contract.ProposeNodeOperatorRewardAddressChange(&_Csmodule.TransactOpts, nodeOperatorId, proposedAddress)
+}
+
+// ProposeNodeOperatorRewardAddressChange is a paid mutator transaction binding the contract method 0x1b40b231.
+//
+// Solidity: function proposeNodeOperatorRewardAddressChange(uint256 nodeOperatorId, address proposedAddress) returns()
+func (_Csmodule *CsmoduleTransactorSession) ProposeNodeOperatorRewardAddressChange(nodeOperatorId *big.Int, proposedAddress common.Address) (*types.Transaction, error) {
+	return _Csmodule.Contract.ProposeNodeOperatorRewardAddressChange(&_Csmodule.TransactOpts, nodeOperatorId, proposedAddress)
+}
+
+// RecoverERC1155 is a paid mutator transaction binding the contract method 0x5c654ad9.
+//
+// Solidity: function recoverERC1155(address token, uint256 tokenId) returns()
+func (_Csmodule *CsmoduleTransactor) RecoverERC1155(opts *bind.TransactOpts, token common.Address, tokenId *big.Int) (*types.Transaction, error) {
+	return _Csmodule.contract.Transact(opts, "recoverERC1155", token, tokenId)
+}
+
+// RecoverERC1155 is a paid mutator transaction binding the contract method 0x5c654ad9.
+//
+// Solidity: function recoverERC1155(address token, uint256 tokenId) returns()
+func (_Csmodule *CsmoduleSession) RecoverERC1155(token common.Address, tokenId *big.Int) (*types.Transaction, error) {
+	return _Csmodule.Contract.RecoverERC1155(&_Csmodule.TransactOpts, token, tokenId)
+}
+
+// RecoverERC1155 is a paid mutator transaction binding the contract method 0x5c654ad9.
+//
+// Solidity: function recoverERC1155(address token, uint256 tokenId) returns()
+func (_Csmodule *CsmoduleTransactorSession) RecoverERC1155(token common.Address, tokenId *big.Int) (*types.Transaction, error) {
+	return _Csmodule.Contract.RecoverERC1155(&_Csmodule.TransactOpts, token, tokenId)
+}
+
+// RecoverERC20 is a paid mutator transaction binding the contract method 0x8980f11f.
+//
+// Solidity: function recoverERC20(address token, uint256 amount) returns()
+func (_Csmodule *CsmoduleTransactor) RecoverERC20(opts *bind.TransactOpts, token common.Address, amount *big.Int) (*types.Transaction, error) {
+	return _Csmodule.contract.Transact(opts, "recoverERC20", token, amount)
+}
+
+// RecoverERC20 is a paid mutator transaction binding the contract method 0x8980f11f.
+//
+// Solidity: function recoverERC20(address token, uint256 amount) returns()
+func (_Csmodule *CsmoduleSession) RecoverERC20(token common.Address, amount *big.Int) (*types.Transaction, error) {
+	return _Csmodule.Contract.RecoverERC20(&_Csmodule.TransactOpts, token, amount)
+}
+
+// RecoverERC20 is a paid mutator transaction binding the contract method 0x8980f11f.
+//
+// Solidity: function recoverERC20(address token, uint256 amount) returns()
+func (_Csmodule *CsmoduleTransactorSession) RecoverERC20(token common.Address, amount *big.Int) (*types.Transaction, error) {
+	return _Csmodule.Contract.RecoverERC20(&_Csmodule.TransactOpts, token, amount)
+}
+
+// RecoverERC721 is a paid mutator transaction binding the contract method 0x819d4cc6.
+//
+// Solidity: function recoverERC721(address token, uint256 tokenId) returns()
+func (_Csmodule *CsmoduleTransactor) RecoverERC721(opts *bind.TransactOpts, token common.Address, tokenId *big.Int) (*types.Transaction, error) {
+	return _Csmodule.contract.Transact(opts, "recoverERC721", token, tokenId)
+}
+
+// RecoverERC721 is a paid mutator transaction binding the contract method 0x819d4cc6.
+//
+// Solidity: function recoverERC721(address token, uint256 tokenId) returns()
+func (_Csmodule *CsmoduleSession) RecoverERC721(token common.Address, tokenId *big.Int) (*types.Transaction, error) {
+	return _Csmodule.Contract.RecoverERC721(&_Csmodule.TransactOpts, token, tokenId)
+}
+
+// RecoverERC721 is a paid mutator transaction binding the contract method 0x819d4cc6.
+//
+// Solidity: function recoverERC721(address token, uint256 tokenId) returns()
+func (_Csmodule *CsmoduleTransactorSession) RecoverERC721(token common.Address, tokenId *big.Int) (*types.Transaction, error) {
+	return _Csmodule.Contract.RecoverERC721(&_Csmodule.TransactOpts, token, tokenId)
+}
+
+// RecoverEther is a paid mutator transaction binding the contract method 0x52d8bfc2.
+//
+// Solidity: function recoverEther() returns()
+func (_Csmodule *CsmoduleTransactor) RecoverEther(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Csmodule.contract.Transact(opts, "recoverEther")
+}
+
+// RecoverEther is a paid mutator transaction binding the contract method 0x52d8bfc2.
+//
+// Solidity: function recoverEther() returns()
+func (_Csmodule *CsmoduleSession) RecoverEther() (*types.Transaction, error) {
+	return _Csmodule.Contract.RecoverEther(&_Csmodule.TransactOpts)
+}
+
+// RecoverEther is a paid mutator transaction binding the contract method 0x52d8bfc2.
+//
+// Solidity: function recoverEther() returns()
+func (_Csmodule *CsmoduleTransactorSession) RecoverEther() (*types.Transaction, error) {
+	return _Csmodule.Contract.RecoverEther(&_Csmodule.TransactOpts)
+}
+
+// RecoverStETHShares is a paid mutator transaction binding the contract method 0x5a73bdc8.
+//
+// Solidity: function recoverStETHShares() returns()
+func (_Csmodule *CsmoduleTransactor) RecoverStETHShares(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Csmodule.contract.Transact(opts, "recoverStETHShares")
+}
+
+// RecoverStETHShares is a paid mutator transaction binding the contract method 0x5a73bdc8.
+//
+// Solidity: function recoverStETHShares() returns()
+func (_Csmodule *CsmoduleSession) RecoverStETHShares() (*types.Transaction, error) {
+	return _Csmodule.Contract.RecoverStETHShares(&_Csmodule.TransactOpts)
+}
+
+// RecoverStETHShares is a paid mutator transaction binding the contract method 0x5a73bdc8.
+//
+// Solidity: function recoverStETHShares() returns()
+func (_Csmodule *CsmoduleTransactorSession) RecoverStETHShares() (*types.Transaction, error) {
+	return _Csmodule.Contract.RecoverStETHShares(&_Csmodule.TransactOpts)
+}
+
+// RemoveKeys is a paid mutator transaction binding the contract method 0x8b3ac71d.
+//
+// Solidity: function removeKeys(uint256 nodeOperatorId, uint256 startIndex, uint256 keysCount) returns()
+func (_Csmodule *CsmoduleTransactor) RemoveKeys(opts *bind.TransactOpts, nodeOperatorId *big.Int, startIndex *big.Int, keysCount *big.Int) (*types.Transaction, error) {
+	return _Csmodule.contract.Transact(opts, "removeKeys", nodeOperatorId, startIndex, keysCount)
+}
+
+// RemoveKeys is a paid mutator transaction binding the contract method 0x8b3ac71d.
+//
+// Solidity: function removeKeys(uint256 nodeOperatorId, uint256 startIndex, uint256 keysCount) returns()
+func (_Csmodule *CsmoduleSession) RemoveKeys(nodeOperatorId *big.Int, startIndex *big.Int, keysCount *big.Int) (*types.Transaction, error) {
+	return _Csmodule.Contract.RemoveKeys(&_Csmodule.TransactOpts, nodeOperatorId, startIndex, keysCount)
+}
+
+// RemoveKeys is a paid mutator transaction binding the contract method 0x8b3ac71d.
+//
+// Solidity: function removeKeys(uint256 nodeOperatorId, uint256 startIndex, uint256 keysCount) returns()
+func (_Csmodule *CsmoduleTransactorSession) RemoveKeys(nodeOperatorId *big.Int, startIndex *big.Int, keysCount *big.Int) (*types.Transaction, error) {
+	return _Csmodule.Contract.RemoveKeys(&_Csmodule.TransactOpts, nodeOperatorId, startIndex, keysCount)
+}
+
+// RenounceRole is a paid mutator transaction binding the contract method 0x36568abe.
+//
+// Solidity: function renounceRole(bytes32 role, address callerConfirmation) returns()
+func (_Csmodule *CsmoduleTransactor) RenounceRole(opts *bind.TransactOpts, role [32]byte, callerConfirmation common.Address) (*types.Transaction, error) {
+	return _Csmodule.contract.Transact(opts, "renounceRole", role, callerConfirmation)
+}
+
+// RenounceRole is a paid mutator transaction binding the contract method 0x36568abe.
+//
+// Solidity: function renounceRole(bytes32 role, address callerConfirmation) returns()
+func (_Csmodule *CsmoduleSession) RenounceRole(role [32]byte, callerConfirmation common.Address) (*types.Transaction, error) {
+	return _Csmodule.Contract.RenounceRole(&_Csmodule.TransactOpts, role, callerConfirmation)
+}
+
+// RenounceRole is a paid mutator transaction binding the contract method 0x36568abe.
+//
+// Solidity: function renounceRole(bytes32 role, address callerConfirmation) returns()
+func (_Csmodule *CsmoduleTransactorSession) RenounceRole(role [32]byte, callerConfirmation common.Address) (*types.Transaction, error) {
+	return _Csmodule.Contract.RenounceRole(&_Csmodule.TransactOpts, role, callerConfirmation)
+}
+
+// ReportELRewardsStealingPenalty is a paid mutator transaction binding the contract method 0x388dd1d1.
+//
+// Solidity: function reportELRewardsStealingPenalty(uint256 nodeOperatorId, bytes32 blockHash, uint256 amount) returns()
+func (_Csmodule *CsmoduleTransactor) ReportELRewardsStealingPenalty(opts *bind.TransactOpts, nodeOperatorId *big.Int, blockHash [32]byte, amount *big.Int) (*types.Transaction, error) {
+	return _Csmodule.contract.Transact(opts, "reportELRewardsStealingPenalty", nodeOperatorId, blockHash, amount)
+}
+
+// ReportELRewardsStealingPenalty is a paid mutator transaction binding the contract method 0x388dd1d1.
+//
+// Solidity: function reportELRewardsStealingPenalty(uint256 nodeOperatorId, bytes32 blockHash, uint256 amount) returns()
+func (_Csmodule *CsmoduleSession) ReportELRewardsStealingPenalty(nodeOperatorId *big.Int, blockHash [32]byte, amount *big.Int) (*types.Transaction, error) {
+	return _Csmodule.Contract.ReportELRewardsStealingPenalty(&_Csmodule.TransactOpts, nodeOperatorId, blockHash, amount)
+}
+
+// ReportELRewardsStealingPenalty is a paid mutator transaction binding the contract method 0x388dd1d1.
+//
+// Solidity: function reportELRewardsStealingPenalty(uint256 nodeOperatorId, bytes32 blockHash, uint256 amount) returns()
+func (_Csmodule *CsmoduleTransactorSession) ReportELRewardsStealingPenalty(nodeOperatorId *big.Int, blockHash [32]byte, amount *big.Int) (*types.Transaction, error) {
+	return _Csmodule.Contract.ReportELRewardsStealingPenalty(&_Csmodule.TransactOpts, nodeOperatorId, blockHash, amount)
+}
+
+// ResetNodeOperatorManagerAddress is a paid mutator transaction binding the contract method 0x6a6304cc.
+//
+// Solidity: function resetNodeOperatorManagerAddress(uint256 nodeOperatorId) returns()
+func (_Csmodule *CsmoduleTransactor) ResetNodeOperatorManagerAddress(opts *bind.TransactOpts, nodeOperatorId *big.Int) (*types.Transaction, error) {
+	return _Csmodule.contract.Transact(opts, "resetNodeOperatorManagerAddress", nodeOperatorId)
+}
+
+// ResetNodeOperatorManagerAddress is a paid mutator transaction binding the contract method 0x6a6304cc.
+//
+// Solidity: function resetNodeOperatorManagerAddress(uint256 nodeOperatorId) returns()
+func (_Csmodule *CsmoduleSession) ResetNodeOperatorManagerAddress(nodeOperatorId *big.Int) (*types.Transaction, error) {
+	return _Csmodule.Contract.ResetNodeOperatorManagerAddress(&_Csmodule.TransactOpts, nodeOperatorId)
+}
+
+// ResetNodeOperatorManagerAddress is a paid mutator transaction binding the contract method 0x6a6304cc.
+//
+// Solidity: function resetNodeOperatorManagerAddress(uint256 nodeOperatorId) returns()
+func (_Csmodule *CsmoduleTransactorSession) ResetNodeOperatorManagerAddress(nodeOperatorId *big.Int) (*types.Transaction, error) {
+	return _Csmodule.Contract.ResetNodeOperatorManagerAddress(&_Csmodule.TransactOpts, nodeOperatorId)
+}
+
+// Resume is a paid mutator transaction binding the contract method 0x046f7da2.
+//
+// Solidity: function resume() returns()
+func (_Csmodule *CsmoduleTransactor) Resume(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Csmodule.contract.Transact(opts, "resume")
+}
+
+// Resume is a paid mutator transaction binding the contract method 0x046f7da2.
+//
+// Solidity: function resume() returns()
+func (_Csmodule *CsmoduleSession) Resume() (*types.Transaction, error) {
+	return _Csmodule.Contract.Resume(&_Csmodule.TransactOpts)
+}
+
+// Resume is a paid mutator transaction binding the contract method 0x046f7da2.
+//
+// Solidity: function resume() returns()
+func (_Csmodule *CsmoduleTransactorSession) Resume() (*types.Transaction, error) {
+	return _Csmodule.Contract.Resume(&_Csmodule.TransactOpts)
+}
+
+// RevokeRole is a paid mutator transaction binding the contract method 0xd547741f.
+//
+// Solidity: function revokeRole(bytes32 role, address account) returns()
+func (_Csmodule *CsmoduleTransactor) RevokeRole(opts *bind.TransactOpts, role [32]byte, account common.Address) (*types.Transaction, error) {
+	return _Csmodule.contract.Transact(opts, "revokeRole", role, account)
+}
+
+// RevokeRole is a paid mutator transaction binding the contract method 0xd547741f.
+//
+// Solidity: function revokeRole(bytes32 role, address account) returns()
+func (_Csmodule *CsmoduleSession) RevokeRole(role [32]byte, account common.Address) (*types.Transaction, error) {
+	return _Csmodule.Contract.RevokeRole(&_Csmodule.TransactOpts, role, account)
+}
+
+// RevokeRole is a paid mutator transaction binding the contract method 0xd547741f.
+//
+// Solidity: function revokeRole(bytes32 role, address account) returns()
+func (_Csmodule *CsmoduleTransactorSession) RevokeRole(role [32]byte, account common.Address) (*types.Transaction, error) {
+	return _Csmodule.Contract.RevokeRole(&_Csmodule.TransactOpts, role, account)
+}
+
+// SetKeyRemovalCharge is a paid mutator transaction binding the contract method 0xba1557ae.
+//
+// Solidity: function setKeyRemovalCharge(uint256 amount) returns()
+func (_Csmodule *CsmoduleTransactor) SetKeyRemovalCharge(opts *bind.TransactOpts, amount *big.Int) (*types.Transaction, error) {
+	return _Csmodule.contract.Transact(opts, "setKeyRemovalCharge", amount)
+}
+
+// SetKeyRemovalCharge is a paid mutator transaction binding the contract method 0xba1557ae.
+//
+// Solidity: function setKeyRemovalCharge(uint256 amount) returns()
+func (_Csmodule *CsmoduleSession) SetKeyRemovalCharge(amount *big.Int) (*types.Transaction, error) {
+	return _Csmodule.Contract.SetKeyRemovalCharge(&_Csmodule.TransactOpts, amount)
+}
+
+// SetKeyRemovalCharge is a paid mutator transaction binding the contract method 0xba1557ae.
+//
+// Solidity: function setKeyRemovalCharge(uint256 amount) returns()
+func (_Csmodule *CsmoduleTransactorSession) SetKeyRemovalCharge(amount *big.Int) (*types.Transaction, error) {
+	return _Csmodule.Contract.SetKeyRemovalCharge(&_Csmodule.TransactOpts, amount)
+}
+
+// SettleELRewardsStealingPenalty is a paid mutator transaction binding the contract method 0x37b12b5f.
+//
+// Solidity: function settleELRewardsStealingPenalty(uint256[] nodeOperatorIds) returns()
+func (_Csmodule *CsmoduleTransactor) SettleELRewardsStealingPenalty(opts *bind.TransactOpts, nodeOperatorIds []*big.Int) (*types.Transaction, error) {
+	return _Csmodule.contract.Transact(opts, "settleELRewardsStealingPenalty", nodeOperatorIds)
+}
+
+// SettleELRewardsStealingPenalty is a paid mutator transaction binding the contract method 0x37b12b5f.
+//
+// Solidity: function settleELRewardsStealingPenalty(uint256[] nodeOperatorIds) returns()
+func (_Csmodule *CsmoduleSession) SettleELRewardsStealingPenalty(nodeOperatorIds []*big.Int) (*types.Transaction, error) {
+	return _Csmodule.Contract.SettleELRewardsStealingPenalty(&_Csmodule.TransactOpts, nodeOperatorIds)
+}
+
+// SettleELRewardsStealingPenalty is a paid mutator transaction binding the contract method 0x37b12b5f.
+//
+// Solidity: function settleELRewardsStealingPenalty(uint256[] nodeOperatorIds) returns()
+func (_Csmodule *CsmoduleTransactorSession) SettleELRewardsStealingPenalty(nodeOperatorIds []*big.Int) (*types.Transaction, error) {
+	return _Csmodule.Contract.SettleELRewardsStealingPenalty(&_Csmodule.TransactOpts, nodeOperatorIds)
+}
+
+// SubmitInitialSlashing is a paid mutator transaction binding the contract method 0xf96d3952.
+//
+// Solidity: function submitInitialSlashing(uint256 nodeOperatorId, uint256 keyIndex) returns()
+func (_Csmodule *CsmoduleTransactor) SubmitInitialSlashing(opts *bind.TransactOpts, nodeOperatorId *big.Int, keyIndex *big.Int) (*types.Transaction, error) {
+	return _Csmodule.contract.Transact(opts, "submitInitialSlashing", nodeOperatorId, keyIndex)
+}
+
+// SubmitInitialSlashing is a paid mutator transaction binding the contract method 0xf96d3952.
+//
+// Solidity: function submitInitialSlashing(uint256 nodeOperatorId, uint256 keyIndex) returns()
+func (_Csmodule *CsmoduleSession) SubmitInitialSlashing(nodeOperatorId *big.Int, keyIndex *big.Int) (*types.Transaction, error) {
+	return _Csmodule.Contract.SubmitInitialSlashing(&_Csmodule.TransactOpts, nodeOperatorId, keyIndex)
+}
+
+// SubmitInitialSlashing is a paid mutator transaction binding the contract method 0xf96d3952.
+//
+// Solidity: function submitInitialSlashing(uint256 nodeOperatorId, uint256 keyIndex) returns()
+func (_Csmodule *CsmoduleTransactorSession) SubmitInitialSlashing(nodeOperatorId *big.Int, keyIndex *big.Int) (*types.Transaction, error) {
+	return _Csmodule.Contract.SubmitInitialSlashing(&_Csmodule.TransactOpts, nodeOperatorId, keyIndex)
+}
+
+// SubmitWithdrawal is a paid mutator transaction binding the contract method 0xf408b551.
+//
+// Solidity: function submitWithdrawal(uint256 nodeOperatorId, uint256 keyIndex, uint256 amount, bool isSlashed) returns()
+func (_Csmodule *CsmoduleTransactor) SubmitWithdrawal(opts *bind.TransactOpts, nodeOperatorId *big.Int, keyIndex *big.Int, amount *big.Int, isSlashed bool) (*types.Transaction, error) {
+	return _Csmodule.contract.Transact(opts, "submitWithdrawal", nodeOperatorId, keyIndex, amount, isSlashed)
+}
+
+// SubmitWithdrawal is a paid mutator transaction binding the contract method 0xf408b551.
+//
+// Solidity: function submitWithdrawal(uint256 nodeOperatorId, uint256 keyIndex, uint256 amount, bool isSlashed) returns()
+func (_Csmodule *CsmoduleSession) SubmitWithdrawal(nodeOperatorId *big.Int, keyIndex *big.Int, amount *big.Int, isSlashed bool) (*types.Transaction, error) {
+	return _Csmodule.Contract.SubmitWithdrawal(&_Csmodule.TransactOpts, nodeOperatorId, keyIndex, amount, isSlashed)
+}
+
+// SubmitWithdrawal is a paid mutator transaction binding the contract method 0xf408b551.
+//
+// Solidity: function submitWithdrawal(uint256 nodeOperatorId, uint256 keyIndex, uint256 amount, bool isSlashed) returns()
+func (_Csmodule *CsmoduleTransactorSession) SubmitWithdrawal(nodeOperatorId *big.Int, keyIndex *big.Int, amount *big.Int, isSlashed bool) (*types.Transaction, error) {
+	return _Csmodule.Contract.SubmitWithdrawal(&_Csmodule.TransactOpts, nodeOperatorId, keyIndex, amount, isSlashed)
+}
+
+// UnsafeUpdateValidatorsCount is a paid mutator transaction binding the contract method 0xf2e2ca63.
+//
+// Solidity: function unsafeUpdateValidatorsCount(uint256 nodeOperatorId, uint256 exitedValidatorsKeysCount, uint256 stuckValidatorsKeysCount) returns()
+func (_Csmodule *CsmoduleTransactor) UnsafeUpdateValidatorsCount(opts *bind.TransactOpts, nodeOperatorId *big.Int, exitedValidatorsKeysCount *big.Int, stuckValidatorsKeysCount *big.Int) (*types.Transaction, error) {
+	return _Csmodule.contract.Transact(opts, "unsafeUpdateValidatorsCount", nodeOperatorId, exitedValidatorsKeysCount, stuckValidatorsKeysCount)
+}
+
+// UnsafeUpdateValidatorsCount is a paid mutator transaction binding the contract method 0xf2e2ca63.
+//
+// Solidity: function unsafeUpdateValidatorsCount(uint256 nodeOperatorId, uint256 exitedValidatorsKeysCount, uint256 stuckValidatorsKeysCount) returns()
+func (_Csmodule *CsmoduleSession) UnsafeUpdateValidatorsCount(nodeOperatorId *big.Int, exitedValidatorsKeysCount *big.Int, stuckValidatorsKeysCount *big.Int) (*types.Transaction, error) {
+	return _Csmodule.Contract.UnsafeUpdateValidatorsCount(&_Csmodule.TransactOpts, nodeOperatorId, exitedValidatorsKeysCount, stuckValidatorsKeysCount)
+}
+
+// UnsafeUpdateValidatorsCount is a paid mutator transaction binding the contract method 0xf2e2ca63.
+//
+// Solidity: function unsafeUpdateValidatorsCount(uint256 nodeOperatorId, uint256 exitedValidatorsKeysCount, uint256 stuckValidatorsKeysCount) returns()
+func (_Csmodule *CsmoduleTransactorSession) UnsafeUpdateValidatorsCount(nodeOperatorId *big.Int, exitedValidatorsKeysCount *big.Int, stuckValidatorsKeysCount *big.Int) (*types.Transaction, error) {
+	return _Csmodule.Contract.UnsafeUpdateValidatorsCount(&_Csmodule.TransactOpts, nodeOperatorId, exitedValidatorsKeysCount, stuckValidatorsKeysCount)
+}
+
+// UpdateExitedValidatorsCount is a paid mutator transaction binding the contract method 0x9b00c146.
+//
+// Solidity: function updateExitedValidatorsCount(bytes nodeOperatorIds, bytes exitedValidatorsCounts) returns()
+func (_Csmodule *CsmoduleTransactor) UpdateExitedValidatorsCount(opts *bind.TransactOpts, nodeOperatorIds []byte, exitedValidatorsCounts []byte) (*types.Transaction, error) {
+	return _Csmodule.contract.Transact(opts, "updateExitedValidatorsCount", nodeOperatorIds, exitedValidatorsCounts)
+}
+
+// UpdateExitedValidatorsCount is a paid mutator transaction binding the contract method 0x9b00c146.
+//
+// Solidity: function updateExitedValidatorsCount(bytes nodeOperatorIds, bytes exitedValidatorsCounts) returns()
+func (_Csmodule *CsmoduleSession) UpdateExitedValidatorsCount(nodeOperatorIds []byte, exitedValidatorsCounts []byte) (*types.Transaction, error) {
+	return _Csmodule.Contract.UpdateExitedValidatorsCount(&_Csmodule.TransactOpts, nodeOperatorIds, exitedValidatorsCounts)
+}
+
+// UpdateExitedValidatorsCount is a paid mutator transaction binding the contract method 0x9b00c146.
+//
+// Solidity: function updateExitedValidatorsCount(bytes nodeOperatorIds, bytes exitedValidatorsCounts) returns()
+func (_Csmodule *CsmoduleTransactorSession) UpdateExitedValidatorsCount(nodeOperatorIds []byte, exitedValidatorsCounts []byte) (*types.Transaction, error) {
+	return _Csmodule.Contract.UpdateExitedValidatorsCount(&_Csmodule.TransactOpts, nodeOperatorIds, exitedValidatorsCounts)
+}
+
+// UpdateRefundedValidatorsCount is a paid mutator transaction binding the contract method 0xa2e080f1.
+//
+// Solidity: function updateRefundedValidatorsCount(uint256 , uint256 ) returns()
+func (_Csmodule *CsmoduleTransactor) UpdateRefundedValidatorsCount(opts *bind.TransactOpts, arg0 *big.Int, arg1 *big.Int) (*types.Transaction, error) {
+	return _Csmodule.contract.Transact(opts, "updateRefundedValidatorsCount", arg0, arg1)
+}
+
+// UpdateRefundedValidatorsCount is a paid mutator transaction binding the contract method 0xa2e080f1.
+//
+// Solidity: function updateRefundedValidatorsCount(uint256 , uint256 ) returns()
+func (_Csmodule *CsmoduleSession) UpdateRefundedValidatorsCount(arg0 *big.Int, arg1 *big.Int) (*types.Transaction, error) {
+	return _Csmodule.Contract.UpdateRefundedValidatorsCount(&_Csmodule.TransactOpts, arg0, arg1)
+}
+
+// UpdateRefundedValidatorsCount is a paid mutator transaction binding the contract method 0xa2e080f1.
+//
+// Solidity: function updateRefundedValidatorsCount(uint256 , uint256 ) returns()
+func (_Csmodule *CsmoduleTransactorSession) UpdateRefundedValidatorsCount(arg0 *big.Int, arg1 *big.Int) (*types.Transaction, error) {
+	return _Csmodule.Contract.UpdateRefundedValidatorsCount(&_Csmodule.TransactOpts, arg0, arg1)
+}
+
+// UpdateStuckValidatorsCount is a paid mutator transaction binding the contract method 0x9b3d1900.
+//
+// Solidity: function updateStuckValidatorsCount(bytes nodeOperatorIds, bytes stuckValidatorsCounts) returns()
+func (_Csmodule *CsmoduleTransactor) UpdateStuckValidatorsCount(opts *bind.TransactOpts, nodeOperatorIds []byte, stuckValidatorsCounts []byte) (*types.Transaction, error) {
+	return _Csmodule.contract.Transact(opts, "updateStuckValidatorsCount", nodeOperatorIds, stuckValidatorsCounts)
+}
+
+// UpdateStuckValidatorsCount is a paid mutator transaction binding the contract method 0x9b3d1900.
+//
+// Solidity: function updateStuckValidatorsCount(bytes nodeOperatorIds, bytes stuckValidatorsCounts) returns()
+func (_Csmodule *CsmoduleSession) UpdateStuckValidatorsCount(nodeOperatorIds []byte, stuckValidatorsCounts []byte) (*types.Transaction, error) {
+	return _Csmodule.Contract.UpdateStuckValidatorsCount(&_Csmodule.TransactOpts, nodeOperatorIds, stuckValidatorsCounts)
+}
+
+// UpdateStuckValidatorsCount is a paid mutator transaction binding the contract method 0x9b3d1900.
+//
+// Solidity: function updateStuckValidatorsCount(bytes nodeOperatorIds, bytes stuckValidatorsCounts) returns()
+func (_Csmodule *CsmoduleTransactorSession) UpdateStuckValidatorsCount(nodeOperatorIds []byte, stuckValidatorsCounts []byte) (*types.Transaction, error) {
+	return _Csmodule.Contract.UpdateStuckValidatorsCount(&_Csmodule.TransactOpts, nodeOperatorIds, stuckValidatorsCounts)
+}
+
+// UpdateTargetValidatorsLimits is a paid mutator transaction binding the contract method 0x08a679ad.
+//
+// Solidity: function updateTargetValidatorsLimits(uint256 nodeOperatorId, uint256 targetLimitMode, uint256 targetLimit) returns()
+func (_Csmodule *CsmoduleTransactor) UpdateTargetValidatorsLimits(opts *bind.TransactOpts, nodeOperatorId *big.Int, targetLimitMode *big.Int, targetLimit *big.Int) (*types.Transaction, error) {
+	return _Csmodule.contract.Transact(opts, "updateTargetValidatorsLimits", nodeOperatorId, targetLimitMode, targetLimit)
+}
+
+// UpdateTargetValidatorsLimits is a paid mutator transaction binding the contract method 0x08a679ad.
+//
+// Solidity: function updateTargetValidatorsLimits(uint256 nodeOperatorId, uint256 targetLimitMode, uint256 targetLimit) returns()
+func (_Csmodule *CsmoduleSession) UpdateTargetValidatorsLimits(nodeOperatorId *big.Int, targetLimitMode *big.Int, targetLimit *big.Int) (*types.Transaction, error) {
+	return _Csmodule.Contract.UpdateTargetValidatorsLimits(&_Csmodule.TransactOpts, nodeOperatorId, targetLimitMode, targetLimit)
+}
+
+// UpdateTargetValidatorsLimits is a paid mutator transaction binding the contract method 0x08a679ad.
+//
+// Solidity: function updateTargetValidatorsLimits(uint256 nodeOperatorId, uint256 targetLimitMode, uint256 targetLimit) returns()
+func (_Csmodule *CsmoduleTransactorSession) UpdateTargetValidatorsLimits(nodeOperatorId *big.Int, targetLimitMode *big.Int, targetLimit *big.Int) (*types.Transaction, error) {
+	return _Csmodule.Contract.UpdateTargetValidatorsLimits(&_Csmodule.TransactOpts, nodeOperatorId, targetLimitMode, targetLimit)
+}
+
+// CsmoduleBatchEnqueuedIterator is returned from FilterBatchEnqueued and is used to iterate over the raw logs and unpacked data for BatchEnqueued events raised by the Csmodule contract.
+type CsmoduleBatchEnqueuedIterator struct {
+	Event *CsmoduleBatchEnqueued // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *CsmoduleBatchEnqueuedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(CsmoduleBatchEnqueued)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(CsmoduleBatchEnqueued)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *CsmoduleBatchEnqueuedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *CsmoduleBatchEnqueuedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// CsmoduleBatchEnqueued represents a BatchEnqueued event raised by the Csmodule contract.
+type CsmoduleBatchEnqueued struct {
+	NodeOperatorId *big.Int
+	Count          *big.Int
+	Raw            types.Log // Blockchain specific contextual infos
+}
+
+// FilterBatchEnqueued is a free log retrieval operation binding the contract event 0x162b3db9d9ca7d0abe51ad8229dc058550a74b769457fd055579b5bdc5492536.
+//
+// Solidity: event BatchEnqueued(uint256 indexed nodeOperatorId, uint256 count)
+func (_Csmodule *CsmoduleFilterer) FilterBatchEnqueued(opts *bind.FilterOpts, nodeOperatorId []*big.Int) (*CsmoduleBatchEnqueuedIterator, error) {
+
+	var nodeOperatorIdRule []interface{}
+	for _, nodeOperatorIdItem := range nodeOperatorId {
+		nodeOperatorIdRule = append(nodeOperatorIdRule, nodeOperatorIdItem)
+	}
+
+	logs, sub, err := _Csmodule.contract.FilterLogs(opts, "BatchEnqueued", nodeOperatorIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return &CsmoduleBatchEnqueuedIterator{contract: _Csmodule.contract, event: "BatchEnqueued", logs: logs, sub: sub}, nil
+}
+
+// WatchBatchEnqueued is a free log subscription operation binding the contract event 0x162b3db9d9ca7d0abe51ad8229dc058550a74b769457fd055579b5bdc5492536.
+//
+// Solidity: event BatchEnqueued(uint256 indexed nodeOperatorId, uint256 count)
+func (_Csmodule *CsmoduleFilterer) WatchBatchEnqueued(opts *bind.WatchOpts, sink chan<- *CsmoduleBatchEnqueued, nodeOperatorId []*big.Int) (event.Subscription, error) {
+
+	var nodeOperatorIdRule []interface{}
+	for _, nodeOperatorIdItem := range nodeOperatorId {
+		nodeOperatorIdRule = append(nodeOperatorIdRule, nodeOperatorIdItem)
+	}
+
+	logs, sub, err := _Csmodule.contract.WatchLogs(opts, "BatchEnqueued", nodeOperatorIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(CsmoduleBatchEnqueued)
+				if err := _Csmodule.contract.UnpackLog(event, "BatchEnqueued", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseBatchEnqueued is a log parse operation binding the contract event 0x162b3db9d9ca7d0abe51ad8229dc058550a74b769457fd055579b5bdc5492536.
+//
+// Solidity: event BatchEnqueued(uint256 indexed nodeOperatorId, uint256 count)
+func (_Csmodule *CsmoduleFilterer) ParseBatchEnqueued(log types.Log) (*CsmoduleBatchEnqueued, error) {
+	event := new(CsmoduleBatchEnqueued)
+	if err := _Csmodule.contract.UnpackLog(event, "BatchEnqueued", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// CsmoduleDepositableSigningKeysCountChangedIterator is returned from FilterDepositableSigningKeysCountChanged and is used to iterate over the raw logs and unpacked data for DepositableSigningKeysCountChanged events raised by the Csmodule contract.
+type CsmoduleDepositableSigningKeysCountChangedIterator struct {
+	Event *CsmoduleDepositableSigningKeysCountChanged // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *CsmoduleDepositableSigningKeysCountChangedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(CsmoduleDepositableSigningKeysCountChanged)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(CsmoduleDepositableSigningKeysCountChanged)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *CsmoduleDepositableSigningKeysCountChangedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *CsmoduleDepositableSigningKeysCountChangedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// CsmoduleDepositableSigningKeysCountChanged represents a DepositableSigningKeysCountChanged event raised by the Csmodule contract.
+type CsmoduleDepositableSigningKeysCountChanged struct {
+	NodeOperatorId       *big.Int
+	DepositableKeysCount *big.Int
+	Raw                  types.Log // Blockchain specific contextual infos
+}
+
+// FilterDepositableSigningKeysCountChanged is a free log retrieval operation binding the contract event 0xf9109091b368cedad2edff45414eef892edd6b4fe80084bd590aa8f8def8ed33.
+//
+// Solidity: event DepositableSigningKeysCountChanged(uint256 indexed nodeOperatorId, uint256 depositableKeysCount)
+func (_Csmodule *CsmoduleFilterer) FilterDepositableSigningKeysCountChanged(opts *bind.FilterOpts, nodeOperatorId []*big.Int) (*CsmoduleDepositableSigningKeysCountChangedIterator, error) {
+
+	var nodeOperatorIdRule []interface{}
+	for _, nodeOperatorIdItem := range nodeOperatorId {
+		nodeOperatorIdRule = append(nodeOperatorIdRule, nodeOperatorIdItem)
+	}
+
+	logs, sub, err := _Csmodule.contract.FilterLogs(opts, "DepositableSigningKeysCountChanged", nodeOperatorIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return &CsmoduleDepositableSigningKeysCountChangedIterator{contract: _Csmodule.contract, event: "DepositableSigningKeysCountChanged", logs: logs, sub: sub}, nil
+}
+
+// WatchDepositableSigningKeysCountChanged is a free log subscription operation binding the contract event 0xf9109091b368cedad2edff45414eef892edd6b4fe80084bd590aa8f8def8ed33.
+//
+// Solidity: event DepositableSigningKeysCountChanged(uint256 indexed nodeOperatorId, uint256 depositableKeysCount)
+func (_Csmodule *CsmoduleFilterer) WatchDepositableSigningKeysCountChanged(opts *bind.WatchOpts, sink chan<- *CsmoduleDepositableSigningKeysCountChanged, nodeOperatorId []*big.Int) (event.Subscription, error) {
+
+	var nodeOperatorIdRule []interface{}
+	for _, nodeOperatorIdItem := range nodeOperatorId {
+		nodeOperatorIdRule = append(nodeOperatorIdRule, nodeOperatorIdItem)
+	}
+
+	logs, sub, err := _Csmodule.contract.WatchLogs(opts, "DepositableSigningKeysCountChanged", nodeOperatorIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(CsmoduleDepositableSigningKeysCountChanged)
+				if err := _Csmodule.contract.UnpackLog(event, "DepositableSigningKeysCountChanged", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseDepositableSigningKeysCountChanged is a log parse operation binding the contract event 0xf9109091b368cedad2edff45414eef892edd6b4fe80084bd590aa8f8def8ed33.
+//
+// Solidity: event DepositableSigningKeysCountChanged(uint256 indexed nodeOperatorId, uint256 depositableKeysCount)
+func (_Csmodule *CsmoduleFilterer) ParseDepositableSigningKeysCountChanged(log types.Log) (*CsmoduleDepositableSigningKeysCountChanged, error) {
+	event := new(CsmoduleDepositableSigningKeysCountChanged)
+	if err := _Csmodule.contract.UnpackLog(event, "DepositableSigningKeysCountChanged", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// CsmoduleDepositedSigningKeysCountChangedIterator is returned from FilterDepositedSigningKeysCountChanged and is used to iterate over the raw logs and unpacked data for DepositedSigningKeysCountChanged events raised by the Csmodule contract.
+type CsmoduleDepositedSigningKeysCountChangedIterator struct {
+	Event *CsmoduleDepositedSigningKeysCountChanged // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *CsmoduleDepositedSigningKeysCountChangedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(CsmoduleDepositedSigningKeysCountChanged)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(CsmoduleDepositedSigningKeysCountChanged)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *CsmoduleDepositedSigningKeysCountChangedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *CsmoduleDepositedSigningKeysCountChangedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// CsmoduleDepositedSigningKeysCountChanged represents a DepositedSigningKeysCountChanged event raised by the Csmodule contract.
+type CsmoduleDepositedSigningKeysCountChanged struct {
+	NodeOperatorId     *big.Int
+	DepositedKeysCount *big.Int
+	Raw                types.Log // Blockchain specific contextual infos
+}
+
+// FilterDepositedSigningKeysCountChanged is a free log retrieval operation binding the contract event 0x24eb1c9e765ba41accf9437300ea91ece5ed3f897ec3cdee0e9debd7fe309b78.
+//
+// Solidity: event DepositedSigningKeysCountChanged(uint256 indexed nodeOperatorId, uint256 depositedKeysCount)
+func (_Csmodule *CsmoduleFilterer) FilterDepositedSigningKeysCountChanged(opts *bind.FilterOpts, nodeOperatorId []*big.Int) (*CsmoduleDepositedSigningKeysCountChangedIterator, error) {
+
+	var nodeOperatorIdRule []interface{}
+	for _, nodeOperatorIdItem := range nodeOperatorId {
+		nodeOperatorIdRule = append(nodeOperatorIdRule, nodeOperatorIdItem)
+	}
+
+	logs, sub, err := _Csmodule.contract.FilterLogs(opts, "DepositedSigningKeysCountChanged", nodeOperatorIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return &CsmoduleDepositedSigningKeysCountChangedIterator{contract: _Csmodule.contract, event: "DepositedSigningKeysCountChanged", logs: logs, sub: sub}, nil
+}
+
+// WatchDepositedSigningKeysCountChanged is a free log subscription operation binding the contract event 0x24eb1c9e765ba41accf9437300ea91ece5ed3f897ec3cdee0e9debd7fe309b78.
+//
+// Solidity: event DepositedSigningKeysCountChanged(uint256 indexed nodeOperatorId, uint256 depositedKeysCount)
+func (_Csmodule *CsmoduleFilterer) WatchDepositedSigningKeysCountChanged(opts *bind.WatchOpts, sink chan<- *CsmoduleDepositedSigningKeysCountChanged, nodeOperatorId []*big.Int) (event.Subscription, error) {
+
+	var nodeOperatorIdRule []interface{}
+	for _, nodeOperatorIdItem := range nodeOperatorId {
+		nodeOperatorIdRule = append(nodeOperatorIdRule, nodeOperatorIdItem)
+	}
+
+	logs, sub, err := _Csmodule.contract.WatchLogs(opts, "DepositedSigningKeysCountChanged", nodeOperatorIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(CsmoduleDepositedSigningKeysCountChanged)
+				if err := _Csmodule.contract.UnpackLog(event, "DepositedSigningKeysCountChanged", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseDepositedSigningKeysCountChanged is a log parse operation binding the contract event 0x24eb1c9e765ba41accf9437300ea91ece5ed3f897ec3cdee0e9debd7fe309b78.
+//
+// Solidity: event DepositedSigningKeysCountChanged(uint256 indexed nodeOperatorId, uint256 depositedKeysCount)
+func (_Csmodule *CsmoduleFilterer) ParseDepositedSigningKeysCountChanged(log types.Log) (*CsmoduleDepositedSigningKeysCountChanged, error) {
+	event := new(CsmoduleDepositedSigningKeysCountChanged)
+	if err := _Csmodule.contract.UnpackLog(event, "DepositedSigningKeysCountChanged", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// CsmoduleELRewardsStealingPenaltyCancelledIterator is returned from FilterELRewardsStealingPenaltyCancelled and is used to iterate over the raw logs and unpacked data for ELRewardsStealingPenaltyCancelled events raised by the Csmodule contract.
+type CsmoduleELRewardsStealingPenaltyCancelledIterator struct {
+	Event *CsmoduleELRewardsStealingPenaltyCancelled // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *CsmoduleELRewardsStealingPenaltyCancelledIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(CsmoduleELRewardsStealingPenaltyCancelled)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(CsmoduleELRewardsStealingPenaltyCancelled)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *CsmoduleELRewardsStealingPenaltyCancelledIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *CsmoduleELRewardsStealingPenaltyCancelledIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// CsmoduleELRewardsStealingPenaltyCancelled represents a ELRewardsStealingPenaltyCancelled event raised by the Csmodule contract.
+type CsmoduleELRewardsStealingPenaltyCancelled struct {
+	NodeOperatorId *big.Int
+	Amount         *big.Int
+	Raw            types.Log // Blockchain specific contextual infos
+}
+
+// FilterELRewardsStealingPenaltyCancelled is a free log retrieval operation binding the contract event 0x1e7ebd3c5f4de9502000b6f7e6e7cf5d4ecb27d6fe1778e43fb9d1d0ca87d0e7.
+//
+// Solidity: event ELRewardsStealingPenaltyCancelled(uint256 indexed nodeOperatorId, uint256 amount)
+func (_Csmodule *CsmoduleFilterer) FilterELRewardsStealingPenaltyCancelled(opts *bind.FilterOpts, nodeOperatorId []*big.Int) (*CsmoduleELRewardsStealingPenaltyCancelledIterator, error) {
+
+	var nodeOperatorIdRule []interface{}
+	for _, nodeOperatorIdItem := range nodeOperatorId {
+		nodeOperatorIdRule = append(nodeOperatorIdRule, nodeOperatorIdItem)
+	}
+
+	logs, sub, err := _Csmodule.contract.FilterLogs(opts, "ELRewardsStealingPenaltyCancelled", nodeOperatorIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return &CsmoduleELRewardsStealingPenaltyCancelledIterator{contract: _Csmodule.contract, event: "ELRewardsStealingPenaltyCancelled", logs: logs, sub: sub}, nil
+}
+
+// WatchELRewardsStealingPenaltyCancelled is a free log subscription operation binding the contract event 0x1e7ebd3c5f4de9502000b6f7e6e7cf5d4ecb27d6fe1778e43fb9d1d0ca87d0e7.
+//
+// Solidity: event ELRewardsStealingPenaltyCancelled(uint256 indexed nodeOperatorId, uint256 amount)
+func (_Csmodule *CsmoduleFilterer) WatchELRewardsStealingPenaltyCancelled(opts *bind.WatchOpts, sink chan<- *CsmoduleELRewardsStealingPenaltyCancelled, nodeOperatorId []*big.Int) (event.Subscription, error) {
+
+	var nodeOperatorIdRule []interface{}
+	for _, nodeOperatorIdItem := range nodeOperatorId {
+		nodeOperatorIdRule = append(nodeOperatorIdRule, nodeOperatorIdItem)
+	}
+
+	logs, sub, err := _Csmodule.contract.WatchLogs(opts, "ELRewardsStealingPenaltyCancelled", nodeOperatorIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(CsmoduleELRewardsStealingPenaltyCancelled)
+				if err := _Csmodule.contract.UnpackLog(event, "ELRewardsStealingPenaltyCancelled", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseELRewardsStealingPenaltyCancelled is a log parse operation binding the contract event 0x1e7ebd3c5f4de9502000b6f7e6e7cf5d4ecb27d6fe1778e43fb9d1d0ca87d0e7.
+//
+// Solidity: event ELRewardsStealingPenaltyCancelled(uint256 indexed nodeOperatorId, uint256 amount)
+func (_Csmodule *CsmoduleFilterer) ParseELRewardsStealingPenaltyCancelled(log types.Log) (*CsmoduleELRewardsStealingPenaltyCancelled, error) {
+	event := new(CsmoduleELRewardsStealingPenaltyCancelled)
+	if err := _Csmodule.contract.UnpackLog(event, "ELRewardsStealingPenaltyCancelled", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// CsmoduleELRewardsStealingPenaltyReportedIterator is returned from FilterELRewardsStealingPenaltyReported and is used to iterate over the raw logs and unpacked data for ELRewardsStealingPenaltyReported events raised by the Csmodule contract.
+type CsmoduleELRewardsStealingPenaltyReportedIterator struct {
+	Event *CsmoduleELRewardsStealingPenaltyReported // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *CsmoduleELRewardsStealingPenaltyReportedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(CsmoduleELRewardsStealingPenaltyReported)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(CsmoduleELRewardsStealingPenaltyReported)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *CsmoduleELRewardsStealingPenaltyReportedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *CsmoduleELRewardsStealingPenaltyReportedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// CsmoduleELRewardsStealingPenaltyReported represents a ELRewardsStealingPenaltyReported event raised by the Csmodule contract.
+type CsmoduleELRewardsStealingPenaltyReported struct {
+	NodeOperatorId    *big.Int
+	ProposedBlockHash [32]byte
+	StolenAmount      *big.Int
+	Raw               types.Log // Blockchain specific contextual infos
+}
+
+// FilterELRewardsStealingPenaltyReported is a free log retrieval operation binding the contract event 0xeec4d6dbe34149c6728a9638eca869d0e5a7fcd85c7a96178f7e9780b4b7fe4b.
+//
+// Solidity: event ELRewardsStealingPenaltyReported(uint256 indexed nodeOperatorId, bytes32 proposedBlockHash, uint256 stolenAmount)
+func (_Csmodule *CsmoduleFilterer) FilterELRewardsStealingPenaltyReported(opts *bind.FilterOpts, nodeOperatorId []*big.Int) (*CsmoduleELRewardsStealingPenaltyReportedIterator, error) {
+
+	var nodeOperatorIdRule []interface{}
+	for _, nodeOperatorIdItem := range nodeOperatorId {
+		nodeOperatorIdRule = append(nodeOperatorIdRule, nodeOperatorIdItem)
+	}
+
+	logs, sub, err := _Csmodule.contract.FilterLogs(opts, "ELRewardsStealingPenaltyReported", nodeOperatorIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return &CsmoduleELRewardsStealingPenaltyReportedIterator{contract: _Csmodule.contract, event: "ELRewardsStealingPenaltyReported", logs: logs, sub: sub}, nil
+}
+
+// WatchELRewardsStealingPenaltyReported is a free log subscription operation binding the contract event 0xeec4d6dbe34149c6728a9638eca869d0e5a7fcd85c7a96178f7e9780b4b7fe4b.
+//
+// Solidity: event ELRewardsStealingPenaltyReported(uint256 indexed nodeOperatorId, bytes32 proposedBlockHash, uint256 stolenAmount)
+func (_Csmodule *CsmoduleFilterer) WatchELRewardsStealingPenaltyReported(opts *bind.WatchOpts, sink chan<- *CsmoduleELRewardsStealingPenaltyReported, nodeOperatorId []*big.Int) (event.Subscription, error) {
+
+	var nodeOperatorIdRule []interface{}
+	for _, nodeOperatorIdItem := range nodeOperatorId {
+		nodeOperatorIdRule = append(nodeOperatorIdRule, nodeOperatorIdItem)
+	}
+
+	logs, sub, err := _Csmodule.contract.WatchLogs(opts, "ELRewardsStealingPenaltyReported", nodeOperatorIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(CsmoduleELRewardsStealingPenaltyReported)
+				if err := _Csmodule.contract.UnpackLog(event, "ELRewardsStealingPenaltyReported", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseELRewardsStealingPenaltyReported is a log parse operation binding the contract event 0xeec4d6dbe34149c6728a9638eca869d0e5a7fcd85c7a96178f7e9780b4b7fe4b.
+//
+// Solidity: event ELRewardsStealingPenaltyReported(uint256 indexed nodeOperatorId, bytes32 proposedBlockHash, uint256 stolenAmount)
+func (_Csmodule *CsmoduleFilterer) ParseELRewardsStealingPenaltyReported(log types.Log) (*CsmoduleELRewardsStealingPenaltyReported, error) {
+	event := new(CsmoduleELRewardsStealingPenaltyReported)
+	if err := _Csmodule.contract.UnpackLog(event, "ELRewardsStealingPenaltyReported", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// CsmoduleELRewardsStealingPenaltySettledIterator is returned from FilterELRewardsStealingPenaltySettled and is used to iterate over the raw logs and unpacked data for ELRewardsStealingPenaltySettled events raised by the Csmodule contract.
+type CsmoduleELRewardsStealingPenaltySettledIterator struct {
+	Event *CsmoduleELRewardsStealingPenaltySettled // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *CsmoduleELRewardsStealingPenaltySettledIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(CsmoduleELRewardsStealingPenaltySettled)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(CsmoduleELRewardsStealingPenaltySettled)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *CsmoduleELRewardsStealingPenaltySettledIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *CsmoduleELRewardsStealingPenaltySettledIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// CsmoduleELRewardsStealingPenaltySettled represents a ELRewardsStealingPenaltySettled event raised by the Csmodule contract.
+type CsmoduleELRewardsStealingPenaltySettled struct {
+	NodeOperatorId *big.Int
+	Raw            types.Log // Blockchain specific contextual infos
+}
+
+// FilterELRewardsStealingPenaltySettled is a free log retrieval operation binding the contract event 0x00f4fe19c0404d2fbb58da6f646c0a3ee5a6994a034213bbd22b072ed1ca5c27.
+//
+// Solidity: event ELRewardsStealingPenaltySettled(uint256 indexed nodeOperatorId)
+func (_Csmodule *CsmoduleFilterer) FilterELRewardsStealingPenaltySettled(opts *bind.FilterOpts, nodeOperatorId []*big.Int) (*CsmoduleELRewardsStealingPenaltySettledIterator, error) {
+
+	var nodeOperatorIdRule []interface{}
+	for _, nodeOperatorIdItem := range nodeOperatorId {
+		nodeOperatorIdRule = append(nodeOperatorIdRule, nodeOperatorIdItem)
+	}
+
+	logs, sub, err := _Csmodule.contract.FilterLogs(opts, "ELRewardsStealingPenaltySettled", nodeOperatorIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return &CsmoduleELRewardsStealingPenaltySettledIterator{contract: _Csmodule.contract, event: "ELRewardsStealingPenaltySettled", logs: logs, sub: sub}, nil
+}
+
+// WatchELRewardsStealingPenaltySettled is a free log subscription operation binding the contract event 0x00f4fe19c0404d2fbb58da6f646c0a3ee5a6994a034213bbd22b072ed1ca5c27.
+//
+// Solidity: event ELRewardsStealingPenaltySettled(uint256 indexed nodeOperatorId)
+func (_Csmodule *CsmoduleFilterer) WatchELRewardsStealingPenaltySettled(opts *bind.WatchOpts, sink chan<- *CsmoduleELRewardsStealingPenaltySettled, nodeOperatorId []*big.Int) (event.Subscription, error) {
+
+	var nodeOperatorIdRule []interface{}
+	for _, nodeOperatorIdItem := range nodeOperatorId {
+		nodeOperatorIdRule = append(nodeOperatorIdRule, nodeOperatorIdItem)
+	}
+
+	logs, sub, err := _Csmodule.contract.WatchLogs(opts, "ELRewardsStealingPenaltySettled", nodeOperatorIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(CsmoduleELRewardsStealingPenaltySettled)
+				if err := _Csmodule.contract.UnpackLog(event, "ELRewardsStealingPenaltySettled", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseELRewardsStealingPenaltySettled is a log parse operation binding the contract event 0x00f4fe19c0404d2fbb58da6f646c0a3ee5a6994a034213bbd22b072ed1ca5c27.
+//
+// Solidity: event ELRewardsStealingPenaltySettled(uint256 indexed nodeOperatorId)
+func (_Csmodule *CsmoduleFilterer) ParseELRewardsStealingPenaltySettled(log types.Log) (*CsmoduleELRewardsStealingPenaltySettled, error) {
+	event := new(CsmoduleELRewardsStealingPenaltySettled)
+	if err := _Csmodule.contract.UnpackLog(event, "ELRewardsStealingPenaltySettled", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// CsmoduleERC1155RecoveredIterator is returned from FilterERC1155Recovered and is used to iterate over the raw logs and unpacked data for ERC1155Recovered events raised by the Csmodule contract.
+type CsmoduleERC1155RecoveredIterator struct {
+	Event *CsmoduleERC1155Recovered // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *CsmoduleERC1155RecoveredIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(CsmoduleERC1155Recovered)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(CsmoduleERC1155Recovered)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *CsmoduleERC1155RecoveredIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *CsmoduleERC1155RecoveredIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// CsmoduleERC1155Recovered represents a ERC1155Recovered event raised by the Csmodule contract.
+type CsmoduleERC1155Recovered struct {
+	Token     common.Address
+	TokenId   *big.Int
+	Recipient common.Address
+	Amount    *big.Int
+	Raw       types.Log // Blockchain specific contextual infos
+}
+
+// FilterERC1155Recovered is a free log retrieval operation binding the contract event 0x5cf02e753b3eb0f4bee4460a72817d8e5e3c75cd4d65c1d0b06dca88b8032936.
+//
+// Solidity: event ERC1155Recovered(address indexed token, uint256 tokenId, address indexed recipient, uint256 amount)
+func (_Csmodule *CsmoduleFilterer) FilterERC1155Recovered(opts *bind.FilterOpts, token []common.Address, recipient []common.Address) (*CsmoduleERC1155RecoveredIterator, error) {
+
+	var tokenRule []interface{}
+	for _, tokenItem := range token {
+		tokenRule = append(tokenRule, tokenItem)
+	}
+
+	var recipientRule []interface{}
+	for _, recipientItem := range recipient {
+		recipientRule = append(recipientRule, recipientItem)
+	}
+
+	logs, sub, err := _Csmodule.contract.FilterLogs(opts, "ERC1155Recovered", tokenRule, recipientRule)
+	if err != nil {
+		return nil, err
+	}
+	return &CsmoduleERC1155RecoveredIterator{contract: _Csmodule.contract, event: "ERC1155Recovered", logs: logs, sub: sub}, nil
+}
+
+// WatchERC1155Recovered is a free log subscription operation binding the contract event 0x5cf02e753b3eb0f4bee4460a72817d8e5e3c75cd4d65c1d0b06dca88b8032936.
+//
+// Solidity: event ERC1155Recovered(address indexed token, uint256 tokenId, address indexed recipient, uint256 amount)
+func (_Csmodule *CsmoduleFilterer) WatchERC1155Recovered(opts *bind.WatchOpts, sink chan<- *CsmoduleERC1155Recovered, token []common.Address, recipient []common.Address) (event.Subscription, error) {
+
+	var tokenRule []interface{}
+	for _, tokenItem := range token {
+		tokenRule = append(tokenRule, tokenItem)
+	}
+
+	var recipientRule []interface{}
+	for _, recipientItem := range recipient {
+		recipientRule = append(recipientRule, recipientItem)
+	}
+
+	logs, sub, err := _Csmodule.contract.WatchLogs(opts, "ERC1155Recovered", tokenRule, recipientRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(CsmoduleERC1155Recovered)
+				if err := _Csmodule.contract.UnpackLog(event, "ERC1155Recovered", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseERC1155Recovered is a log parse operation binding the contract event 0x5cf02e753b3eb0f4bee4460a72817d8e5e3c75cd4d65c1d0b06dca88b8032936.
+//
+// Solidity: event ERC1155Recovered(address indexed token, uint256 tokenId, address indexed recipient, uint256 amount)
+func (_Csmodule *CsmoduleFilterer) ParseERC1155Recovered(log types.Log) (*CsmoduleERC1155Recovered, error) {
+	event := new(CsmoduleERC1155Recovered)
+	if err := _Csmodule.contract.UnpackLog(event, "ERC1155Recovered", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// CsmoduleERC20RecoveredIterator is returned from FilterERC20Recovered and is used to iterate over the raw logs and unpacked data for ERC20Recovered events raised by the Csmodule contract.
+type CsmoduleERC20RecoveredIterator struct {
+	Event *CsmoduleERC20Recovered // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *CsmoduleERC20RecoveredIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(CsmoduleERC20Recovered)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(CsmoduleERC20Recovered)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *CsmoduleERC20RecoveredIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *CsmoduleERC20RecoveredIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// CsmoduleERC20Recovered represents a ERC20Recovered event raised by the Csmodule contract.
+type CsmoduleERC20Recovered struct {
+	Token     common.Address
+	Recipient common.Address
+	Amount    *big.Int
+	Raw       types.Log // Blockchain specific contextual infos
+}
+
+// FilterERC20Recovered is a free log retrieval operation binding the contract event 0xaca8fb252cde442184e5f10e0f2e6e4029e8cd7717cae63559079610702436aa.
+//
+// Solidity: event ERC20Recovered(address indexed token, address indexed recipient, uint256 amount)
+func (_Csmodule *CsmoduleFilterer) FilterERC20Recovered(opts *bind.FilterOpts, token []common.Address, recipient []common.Address) (*CsmoduleERC20RecoveredIterator, error) {
+
+	var tokenRule []interface{}
+	for _, tokenItem := range token {
+		tokenRule = append(tokenRule, tokenItem)
+	}
+	var recipientRule []interface{}
+	for _, recipientItem := range recipient {
+		recipientRule = append(recipientRule, recipientItem)
+	}
+
+	logs, sub, err := _Csmodule.contract.FilterLogs(opts, "ERC20Recovered", tokenRule, recipientRule)
+	if err != nil {
+		return nil, err
+	}
+	return &CsmoduleERC20RecoveredIterator{contract: _Csmodule.contract, event: "ERC20Recovered", logs: logs, sub: sub}, nil
+}
+
+// WatchERC20Recovered is a free log subscription operation binding the contract event 0xaca8fb252cde442184e5f10e0f2e6e4029e8cd7717cae63559079610702436aa.
+//
+// Solidity: event ERC20Recovered(address indexed token, address indexed recipient, uint256 amount)
+func (_Csmodule *CsmoduleFilterer) WatchERC20Recovered(opts *bind.WatchOpts, sink chan<- *CsmoduleERC20Recovered, token []common.Address, recipient []common.Address) (event.Subscription, error) {
+
+	var tokenRule []interface{}
+	for _, tokenItem := range token {
+		tokenRule = append(tokenRule, tokenItem)
+	}
+	var recipientRule []interface{}
+	for _, recipientItem := range recipient {
+		recipientRule = append(recipientRule, recipientItem)
+	}
+
+	logs, sub, err := _Csmodule.contract.WatchLogs(opts, "ERC20Recovered", tokenRule, recipientRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(CsmoduleERC20Recovered)
+				if err := _Csmodule.contract.UnpackLog(event, "ERC20Recovered", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseERC20Recovered is a log parse operation binding the contract event 0xaca8fb252cde442184e5f10e0f2e6e4029e8cd7717cae63559079610702436aa.
+//
+// Solidity: event ERC20Recovered(address indexed token, address indexed recipient, uint256 amount)
+func (_Csmodule *CsmoduleFilterer) ParseERC20Recovered(log types.Log) (*CsmoduleERC20Recovered, error) {
+	event := new(CsmoduleERC20Recovered)
+	if err := _Csmodule.contract.UnpackLog(event, "ERC20Recovered", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// CsmoduleERC721RecoveredIterator is returned from FilterERC721Recovered and is used to iterate over the raw logs and unpacked data for ERC721Recovered events raised by the Csmodule contract.
+type CsmoduleERC721RecoveredIterator struct {
+	Event *CsmoduleERC721Recovered // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *CsmoduleERC721RecoveredIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(CsmoduleERC721Recovered)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(CsmoduleERC721Recovered)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *CsmoduleERC721RecoveredIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *CsmoduleERC721RecoveredIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// CsmoduleERC721Recovered represents a ERC721Recovered event raised by the Csmodule contract.
+type CsmoduleERC721Recovered struct {
+	Token     common.Address
+	TokenId   *big.Int
+	Recipient common.Address
+	Raw       types.Log // Blockchain specific contextual infos
+}
+
+// FilterERC721Recovered is a free log retrieval operation binding the contract event 0x8166bf75d2ff2fa3c8f3c44410540bf42e9a5359b48409e8d660291dc9f788c8.
+//
+// Solidity: event ERC721Recovered(address indexed token, uint256 tokenId, address indexed recipient)
+func (_Csmodule *CsmoduleFilterer) FilterERC721Recovered(opts *bind.FilterOpts, token []common.Address, recipient []common.Address) (*CsmoduleERC721RecoveredIterator, error) {
+
+	var tokenRule []interface{}
+	for _, tokenItem := range token {
+		tokenRule = append(tokenRule, tokenItem)
+	}
+
+	var recipientRule []interface{}
+	for _, recipientItem := range recipient {
+		recipientRule = append(recipientRule, recipientItem)
+	}
+
+	logs, sub, err := _Csmodule.contract.FilterLogs(opts, "ERC721Recovered", tokenRule, recipientRule)
+	if err != nil {
+		return nil, err
+	}
+	return &CsmoduleERC721RecoveredIterator{contract: _Csmodule.contract, event: "ERC721Recovered", logs: logs, sub: sub}, nil
+}
+
+// WatchERC721Recovered is a free log subscription operation binding the contract event 0x8166bf75d2ff2fa3c8f3c44410540bf42e9a5359b48409e8d660291dc9f788c8.
+//
+// Solidity: event ERC721Recovered(address indexed token, uint256 tokenId, address indexed recipient)
+func (_Csmodule *CsmoduleFilterer) WatchERC721Recovered(opts *bind.WatchOpts, sink chan<- *CsmoduleERC721Recovered, token []common.Address, recipient []common.Address) (event.Subscription, error) {
+
+	var tokenRule []interface{}
+	for _, tokenItem := range token {
+		tokenRule = append(tokenRule, tokenItem)
+	}
+
+	var recipientRule []interface{}
+	for _, recipientItem := range recipient {
+		recipientRule = append(recipientRule, recipientItem)
+	}
+
+	logs, sub, err := _Csmodule.contract.WatchLogs(opts, "ERC721Recovered", tokenRule, recipientRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(CsmoduleERC721Recovered)
+				if err := _Csmodule.contract.UnpackLog(event, "ERC721Recovered", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseERC721Recovered is a log parse operation binding the contract event 0x8166bf75d2ff2fa3c8f3c44410540bf42e9a5359b48409e8d660291dc9f788c8.
+//
+// Solidity: event ERC721Recovered(address indexed token, uint256 tokenId, address indexed recipient)
+func (_Csmodule *CsmoduleFilterer) ParseERC721Recovered(log types.Log) (*CsmoduleERC721Recovered, error) {
+	event := new(CsmoduleERC721Recovered)
+	if err := _Csmodule.contract.UnpackLog(event, "ERC721Recovered", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// CsmoduleEtherRecoveredIterator is returned from FilterEtherRecovered and is used to iterate over the raw logs and unpacked data for EtherRecovered events raised by the Csmodule contract.
+type CsmoduleEtherRecoveredIterator struct {
+	Event *CsmoduleEtherRecovered // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *CsmoduleEtherRecoveredIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(CsmoduleEtherRecovered)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(CsmoduleEtherRecovered)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *CsmoduleEtherRecoveredIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *CsmoduleEtherRecoveredIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// CsmoduleEtherRecovered represents a EtherRecovered event raised by the Csmodule contract.
+type CsmoduleEtherRecovered struct {
+	Recipient common.Address
+	Amount    *big.Int
+	Raw       types.Log // Blockchain specific contextual infos
+}
+
+// FilterEtherRecovered is a free log retrieval operation binding the contract event 0x8e274e42262a7f013b700b35c2b4629ccce1702f8fe83f8dfb7eacbb26a4382c.
+//
+// Solidity: event EtherRecovered(address indexed recipient, uint256 amount)
+func (_Csmodule *CsmoduleFilterer) FilterEtherRecovered(opts *bind.FilterOpts, recipient []common.Address) (*CsmoduleEtherRecoveredIterator, error) {
+
+	var recipientRule []interface{}
+	for _, recipientItem := range recipient {
+		recipientRule = append(recipientRule, recipientItem)
+	}
+
+	logs, sub, err := _Csmodule.contract.FilterLogs(opts, "EtherRecovered", recipientRule)
+	if err != nil {
+		return nil, err
+	}
+	return &CsmoduleEtherRecoveredIterator{contract: _Csmodule.contract, event: "EtherRecovered", logs: logs, sub: sub}, nil
+}
+
+// WatchEtherRecovered is a free log subscription operation binding the contract event 0x8e274e42262a7f013b700b35c2b4629ccce1702f8fe83f8dfb7eacbb26a4382c.
+//
+// Solidity: event EtherRecovered(address indexed recipient, uint256 amount)
+func (_Csmodule *CsmoduleFilterer) WatchEtherRecovered(opts *bind.WatchOpts, sink chan<- *CsmoduleEtherRecovered, recipient []common.Address) (event.Subscription, error) {
+
+	var recipientRule []interface{}
+	for _, recipientItem := range recipient {
+		recipientRule = append(recipientRule, recipientItem)
+	}
+
+	logs, sub, err := _Csmodule.contract.WatchLogs(opts, "EtherRecovered", recipientRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(CsmoduleEtherRecovered)
+				if err := _Csmodule.contract.UnpackLog(event, "EtherRecovered", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseEtherRecovered is a log parse operation binding the contract event 0x8e274e42262a7f013b700b35c2b4629ccce1702f8fe83f8dfb7eacbb26a4382c.
+//
+// Solidity: event EtherRecovered(address indexed recipient, uint256 amount)
+func (_Csmodule *CsmoduleFilterer) ParseEtherRecovered(log types.Log) (*CsmoduleEtherRecovered, error) {
+	event := new(CsmoduleEtherRecovered)
+	if err := _Csmodule.contract.UnpackLog(event, "EtherRecovered", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// CsmoduleExitedSigningKeysCountChangedIterator is returned from FilterExitedSigningKeysCountChanged and is used to iterate over the raw logs and unpacked data for ExitedSigningKeysCountChanged events raised by the Csmodule contract.
+type CsmoduleExitedSigningKeysCountChangedIterator struct {
+	Event *CsmoduleExitedSigningKeysCountChanged // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *CsmoduleExitedSigningKeysCountChangedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(CsmoduleExitedSigningKeysCountChanged)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(CsmoduleExitedSigningKeysCountChanged)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *CsmoduleExitedSigningKeysCountChangedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *CsmoduleExitedSigningKeysCountChangedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// CsmoduleExitedSigningKeysCountChanged represents a ExitedSigningKeysCountChanged event raised by the Csmodule contract.
+type CsmoduleExitedSigningKeysCountChanged struct {
+	NodeOperatorId  *big.Int
+	ExitedKeysCount *big.Int
+	Raw             types.Log // Blockchain specific contextual infos
+}
+
+// FilterExitedSigningKeysCountChanged is a free log retrieval operation binding the contract event 0x0f67960648751434ae86bf350db61194f387fda387e7f568b0ccd0ae0c220166.
+//
+// Solidity: event ExitedSigningKeysCountChanged(uint256 indexed nodeOperatorId, uint256 exitedKeysCount)
+func (_Csmodule *CsmoduleFilterer) FilterExitedSigningKeysCountChanged(opts *bind.FilterOpts, nodeOperatorId []*big.Int) (*CsmoduleExitedSigningKeysCountChangedIterator, error) {
+
+	var nodeOperatorIdRule []interface{}
+	for _, nodeOperatorIdItem := range nodeOperatorId {
+		nodeOperatorIdRule = append(nodeOperatorIdRule, nodeOperatorIdItem)
+	}
+
+	logs, sub, err := _Csmodule.contract.FilterLogs(opts, "ExitedSigningKeysCountChanged", nodeOperatorIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return &CsmoduleExitedSigningKeysCountChangedIterator{contract: _Csmodule.contract, event: "ExitedSigningKeysCountChanged", logs: logs, sub: sub}, nil
+}
+
+// WatchExitedSigningKeysCountChanged is a free log subscription operation binding the contract event 0x0f67960648751434ae86bf350db61194f387fda387e7f568b0ccd0ae0c220166.
+//
+// Solidity: event ExitedSigningKeysCountChanged(uint256 indexed nodeOperatorId, uint256 exitedKeysCount)
+func (_Csmodule *CsmoduleFilterer) WatchExitedSigningKeysCountChanged(opts *bind.WatchOpts, sink chan<- *CsmoduleExitedSigningKeysCountChanged, nodeOperatorId []*big.Int) (event.Subscription, error) {
+
+	var nodeOperatorIdRule []interface{}
+	for _, nodeOperatorIdItem := range nodeOperatorId {
+		nodeOperatorIdRule = append(nodeOperatorIdRule, nodeOperatorIdItem)
+	}
+
+	logs, sub, err := _Csmodule.contract.WatchLogs(opts, "ExitedSigningKeysCountChanged", nodeOperatorIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(CsmoduleExitedSigningKeysCountChanged)
+				if err := _Csmodule.contract.UnpackLog(event, "ExitedSigningKeysCountChanged", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseExitedSigningKeysCountChanged is a log parse operation binding the contract event 0x0f67960648751434ae86bf350db61194f387fda387e7f568b0ccd0ae0c220166.
+//
+// Solidity: event ExitedSigningKeysCountChanged(uint256 indexed nodeOperatorId, uint256 exitedKeysCount)
+func (_Csmodule *CsmoduleFilterer) ParseExitedSigningKeysCountChanged(log types.Log) (*CsmoduleExitedSigningKeysCountChanged, error) {
+	event := new(CsmoduleExitedSigningKeysCountChanged)
+	if err := _Csmodule.contract.UnpackLog(event, "ExitedSigningKeysCountChanged", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// CsmoduleInitialSlashingSubmittedIterator is returned from FilterInitialSlashingSubmitted and is used to iterate over the raw logs and unpacked data for InitialSlashingSubmitted events raised by the Csmodule contract.
+type CsmoduleInitialSlashingSubmittedIterator struct {
+	Event *CsmoduleInitialSlashingSubmitted // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *CsmoduleInitialSlashingSubmittedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(CsmoduleInitialSlashingSubmitted)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(CsmoduleInitialSlashingSubmitted)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *CsmoduleInitialSlashingSubmittedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *CsmoduleInitialSlashingSubmittedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// CsmoduleInitialSlashingSubmitted represents a InitialSlashingSubmitted event raised by the Csmodule contract.
+type CsmoduleInitialSlashingSubmitted struct {
+	NodeOperatorId *big.Int
+	KeyIndex       *big.Int
+	Raw            types.Log // Blockchain specific contextual infos
+}
+
+// FilterInitialSlashingSubmitted is a free log retrieval operation binding the contract event 0xd34db8e8c0ddbc9c7b6dd8c397623dfbe01929e41e527540bff8794685d9b407.
+//
+// Solidity: event InitialSlashingSubmitted(uint256 indexed nodeOperatorId, uint256 keyIndex)
+func (_Csmodule *CsmoduleFilterer) FilterInitialSlashingSubmitted(opts *bind.FilterOpts, nodeOperatorId []*big.Int) (*CsmoduleInitialSlashingSubmittedIterator, error) {
+
+	var nodeOperatorIdRule []interface{}
+	for _, nodeOperatorIdItem := range nodeOperatorId {
+		nodeOperatorIdRule = append(nodeOperatorIdRule, nodeOperatorIdItem)
+	}
+
+	logs, sub, err := _Csmodule.contract.FilterLogs(opts, "InitialSlashingSubmitted", nodeOperatorIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return &CsmoduleInitialSlashingSubmittedIterator{contract: _Csmodule.contract, event: "InitialSlashingSubmitted", logs: logs, sub: sub}, nil
+}
+
+// WatchInitialSlashingSubmitted is a free log subscription operation binding the contract event 0xd34db8e8c0ddbc9c7b6dd8c397623dfbe01929e41e527540bff8794685d9b407.
+//
+// Solidity: event InitialSlashingSubmitted(uint256 indexed nodeOperatorId, uint256 keyIndex)
+func (_Csmodule *CsmoduleFilterer) WatchInitialSlashingSubmitted(opts *bind.WatchOpts, sink chan<- *CsmoduleInitialSlashingSubmitted, nodeOperatorId []*big.Int) (event.Subscription, error) {
+
+	var nodeOperatorIdRule []interface{}
+	for _, nodeOperatorIdItem := range nodeOperatorId {
+		nodeOperatorIdRule = append(nodeOperatorIdRule, nodeOperatorIdItem)
+	}
+
+	logs, sub, err := _Csmodule.contract.WatchLogs(opts, "InitialSlashingSubmitted", nodeOperatorIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(CsmoduleInitialSlashingSubmitted)
+				if err := _Csmodule.contract.UnpackLog(event, "InitialSlashingSubmitted", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseInitialSlashingSubmitted is a log parse operation binding the contract event 0xd34db8e8c0ddbc9c7b6dd8c397623dfbe01929e41e527540bff8794685d9b407.
+//
+// Solidity: event InitialSlashingSubmitted(uint256 indexed nodeOperatorId, uint256 keyIndex)
+func (_Csmodule *CsmoduleFilterer) ParseInitialSlashingSubmitted(log types.Log) (*CsmoduleInitialSlashingSubmitted, error) {
+	event := new(CsmoduleInitialSlashingSubmitted)
+	if err := _Csmodule.contract.UnpackLog(event, "InitialSlashingSubmitted", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// CsmoduleInitializedIterator is returned from FilterInitialized and is used to iterate over the raw logs and unpacked data for Initialized events raised by the Csmodule contract.
+type CsmoduleInitializedIterator struct {
+	Event *CsmoduleInitialized // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *CsmoduleInitializedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(CsmoduleInitialized)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(CsmoduleInitialized)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *CsmoduleInitializedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *CsmoduleInitializedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// CsmoduleInitialized represents a Initialized event raised by the Csmodule contract.
+type CsmoduleInitialized struct {
+	Version uint64
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterInitialized is a free log retrieval operation binding the contract event 0xc7f505b2f371ae2175ee4913f4499e1f2633a7b5936321eed1cdaeb6115181d2.
+//
+// Solidity: event Initialized(uint64 version)
+func (_Csmodule *CsmoduleFilterer) FilterInitialized(opts *bind.FilterOpts) (*CsmoduleInitializedIterator, error) {
+
+	logs, sub, err := _Csmodule.contract.FilterLogs(opts, "Initialized")
+	if err != nil {
+		return nil, err
+	}
+	return &CsmoduleInitializedIterator{contract: _Csmodule.contract, event: "Initialized", logs: logs, sub: sub}, nil
+}
+
+// WatchInitialized is a free log subscription operation binding the contract event 0xc7f505b2f371ae2175ee4913f4499e1f2633a7b5936321eed1cdaeb6115181d2.
+//
+// Solidity: event Initialized(uint64 version)
+func (_Csmodule *CsmoduleFilterer) WatchInitialized(opts *bind.WatchOpts, sink chan<- *CsmoduleInitialized) (event.Subscription, error) {
+
+	logs, sub, err := _Csmodule.contract.WatchLogs(opts, "Initialized")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(CsmoduleInitialized)
+				if err := _Csmodule.contract.UnpackLog(event, "Initialized", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseInitialized is a log parse operation binding the contract event 0xc7f505b2f371ae2175ee4913f4499e1f2633a7b5936321eed1cdaeb6115181d2.
+//
+// Solidity: event Initialized(uint64 version)
+func (_Csmodule *CsmoduleFilterer) ParseInitialized(log types.Log) (*CsmoduleInitialized, error) {
+	event := new(CsmoduleInitialized)
+	if err := _Csmodule.contract.UnpackLog(event, "Initialized", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// CsmoduleKeyRemovalChargeAppliedIterator is returned from FilterKeyRemovalChargeApplied and is used to iterate over the raw logs and unpacked data for KeyRemovalChargeApplied events raised by the Csmodule contract.
+type CsmoduleKeyRemovalChargeAppliedIterator struct {
+	Event *CsmoduleKeyRemovalChargeApplied // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *CsmoduleKeyRemovalChargeAppliedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(CsmoduleKeyRemovalChargeApplied)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(CsmoduleKeyRemovalChargeApplied)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *CsmoduleKeyRemovalChargeAppliedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *CsmoduleKeyRemovalChargeAppliedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// CsmoduleKeyRemovalChargeApplied represents a KeyRemovalChargeApplied event raised by the Csmodule contract.
+type CsmoduleKeyRemovalChargeApplied struct {
+	NodeOperatorId *big.Int
+	Raw            types.Log // Blockchain specific contextual infos
+}
+
+// FilterKeyRemovalChargeApplied is a free log retrieval operation binding the contract event 0x1cbb8dafbedbdf4f813a8ed1f50d871def63e1104f8729b677af57905eda90f6.
+//
+// Solidity: event KeyRemovalChargeApplied(uint256 indexed nodeOperatorId)
+func (_Csmodule *CsmoduleFilterer) FilterKeyRemovalChargeApplied(opts *bind.FilterOpts, nodeOperatorId []*big.Int) (*CsmoduleKeyRemovalChargeAppliedIterator, error) {
+
+	var nodeOperatorIdRule []interface{}
+	for _, nodeOperatorIdItem := range nodeOperatorId {
+		nodeOperatorIdRule = append(nodeOperatorIdRule, nodeOperatorIdItem)
+	}
+
+	logs, sub, err := _Csmodule.contract.FilterLogs(opts, "KeyRemovalChargeApplied", nodeOperatorIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return &CsmoduleKeyRemovalChargeAppliedIterator{contract: _Csmodule.contract, event: "KeyRemovalChargeApplied", logs: logs, sub: sub}, nil
+}
+
+// WatchKeyRemovalChargeApplied is a free log subscription operation binding the contract event 0x1cbb8dafbedbdf4f813a8ed1f50d871def63e1104f8729b677af57905eda90f6.
+//
+// Solidity: event KeyRemovalChargeApplied(uint256 indexed nodeOperatorId)
+func (_Csmodule *CsmoduleFilterer) WatchKeyRemovalChargeApplied(opts *bind.WatchOpts, sink chan<- *CsmoduleKeyRemovalChargeApplied, nodeOperatorId []*big.Int) (event.Subscription, error) {
+
+	var nodeOperatorIdRule []interface{}
+	for _, nodeOperatorIdItem := range nodeOperatorId {
+		nodeOperatorIdRule = append(nodeOperatorIdRule, nodeOperatorIdItem)
+	}
+
+	logs, sub, err := _Csmodule.contract.WatchLogs(opts, "KeyRemovalChargeApplied", nodeOperatorIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(CsmoduleKeyRemovalChargeApplied)
+				if err := _Csmodule.contract.UnpackLog(event, "KeyRemovalChargeApplied", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseKeyRemovalChargeApplied is a log parse operation binding the contract event 0x1cbb8dafbedbdf4f813a8ed1f50d871def63e1104f8729b677af57905eda90f6.
+//
+// Solidity: event KeyRemovalChargeApplied(uint256 indexed nodeOperatorId)
+func (_Csmodule *CsmoduleFilterer) ParseKeyRemovalChargeApplied(log types.Log) (*CsmoduleKeyRemovalChargeApplied, error) {
+	event := new(CsmoduleKeyRemovalChargeApplied)
+	if err := _Csmodule.contract.UnpackLog(event, "KeyRemovalChargeApplied", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// CsmoduleKeyRemovalChargeSetIterator is returned from FilterKeyRemovalChargeSet and is used to iterate over the raw logs and unpacked data for KeyRemovalChargeSet events raised by the Csmodule contract.
+type CsmoduleKeyRemovalChargeSetIterator struct {
+	Event *CsmoduleKeyRemovalChargeSet // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *CsmoduleKeyRemovalChargeSetIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(CsmoduleKeyRemovalChargeSet)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(CsmoduleKeyRemovalChargeSet)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *CsmoduleKeyRemovalChargeSetIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *CsmoduleKeyRemovalChargeSetIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// CsmoduleKeyRemovalChargeSet represents a KeyRemovalChargeSet event raised by the Csmodule contract.
+type CsmoduleKeyRemovalChargeSet struct {
+	Amount *big.Int
+	Raw    types.Log // Blockchain specific contextual infos
+}
+
+// FilterKeyRemovalChargeSet is a free log retrieval operation binding the contract event 0x699ec9c671aad1f3dcc15e571375584a1d6fb7176afd545d14467fd31477e98e.
+//
+// Solidity: event KeyRemovalChargeSet(uint256 amount)
+func (_Csmodule *CsmoduleFilterer) FilterKeyRemovalChargeSet(opts *bind.FilterOpts) (*CsmoduleKeyRemovalChargeSetIterator, error) {
+
+	logs, sub, err := _Csmodule.contract.FilterLogs(opts, "KeyRemovalChargeSet")
+	if err != nil {
+		return nil, err
+	}
+	return &CsmoduleKeyRemovalChargeSetIterator{contract: _Csmodule.contract, event: "KeyRemovalChargeSet", logs: logs, sub: sub}, nil
+}
+
+// WatchKeyRemovalChargeSet is a free log subscription operation binding the contract event 0x699ec9c671aad1f3dcc15e571375584a1d6fb7176afd545d14467fd31477e98e.
+//
+// Solidity: event KeyRemovalChargeSet(uint256 amount)
+func (_Csmodule *CsmoduleFilterer) WatchKeyRemovalChargeSet(opts *bind.WatchOpts, sink chan<- *CsmoduleKeyRemovalChargeSet) (event.Subscription, error) {
+
+	logs, sub, err := _Csmodule.contract.WatchLogs(opts, "KeyRemovalChargeSet")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(CsmoduleKeyRemovalChargeSet)
+				if err := _Csmodule.contract.UnpackLog(event, "KeyRemovalChargeSet", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseKeyRemovalChargeSet is a log parse operation binding the contract event 0x699ec9c671aad1f3dcc15e571375584a1d6fb7176afd545d14467fd31477e98e.
+//
+// Solidity: event KeyRemovalChargeSet(uint256 amount)
+func (_Csmodule *CsmoduleFilterer) ParseKeyRemovalChargeSet(log types.Log) (*CsmoduleKeyRemovalChargeSet, error) {
+	event := new(CsmoduleKeyRemovalChargeSet)
+	if err := _Csmodule.contract.UnpackLog(event, "KeyRemovalChargeSet", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// CsmoduleNodeOperatorAddedIterator is returned from FilterNodeOperatorAdded and is used to iterate over the raw logs and unpacked data for NodeOperatorAdded events raised by the Csmodule contract.
+type CsmoduleNodeOperatorAddedIterator struct {
+	Event *CsmoduleNodeOperatorAdded // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *CsmoduleNodeOperatorAddedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(CsmoduleNodeOperatorAdded)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(CsmoduleNodeOperatorAdded)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *CsmoduleNodeOperatorAddedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *CsmoduleNodeOperatorAddedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// CsmoduleNodeOperatorAdded represents a NodeOperatorAdded event raised by the Csmodule contract.
+type CsmoduleNodeOperatorAdded struct {
+	NodeOperatorId *big.Int
+	ManagerAddress common.Address
+	RewardAddress  common.Address
+	Raw            types.Log // Blockchain specific contextual infos
+}
+
+// FilterNodeOperatorAdded is a free log retrieval operation binding the contract event 0xf35982c84fdc94f58d48e901c54c615804cf7d7939b9b8f76ce4d459354e6363.
+//
+// Solidity: event NodeOperatorAdded(uint256 indexed nodeOperatorId, address indexed managerAddress, address indexed rewardAddress)
+func (_Csmodule *CsmoduleFilterer) FilterNodeOperatorAdded(opts *bind.FilterOpts, nodeOperatorId []*big.Int, managerAddress []common.Address, rewardAddress []common.Address) (*CsmoduleNodeOperatorAddedIterator, error) {
+
+	var nodeOperatorIdRule []interface{}
+	for _, nodeOperatorIdItem := range nodeOperatorId {
+		nodeOperatorIdRule = append(nodeOperatorIdRule, nodeOperatorIdItem)
+	}
+	var managerAddressRule []interface{}
+	for _, managerAddressItem := range managerAddress {
+		managerAddressRule = append(managerAddressRule, managerAddressItem)
+	}
+	var rewardAddressRule []interface{}
+	for _, rewardAddressItem := range rewardAddress {
+		rewardAddressRule = append(rewardAddressRule, rewardAddressItem)
+	}
+
+	logs, sub, err := _Csmodule.contract.FilterLogs(opts, "NodeOperatorAdded", nodeOperatorIdRule, managerAddressRule, rewardAddressRule)
+	if err != nil {
+		return nil, err
+	}
+	return &CsmoduleNodeOperatorAddedIterator{contract: _Csmodule.contract, event: "NodeOperatorAdded", logs: logs, sub: sub}, nil
+}
+
+// WatchNodeOperatorAdded is a free log subscription operation binding the contract event 0xf35982c84fdc94f58d48e901c54c615804cf7d7939b9b8f76ce4d459354e6363.
+//
+// Solidity: event NodeOperatorAdded(uint256 indexed nodeOperatorId, address indexed managerAddress, address indexed rewardAddress)
+func (_Csmodule *CsmoduleFilterer) WatchNodeOperatorAdded(opts *bind.WatchOpts, sink chan<- *CsmoduleNodeOperatorAdded, nodeOperatorId []*big.Int, managerAddress []common.Address, rewardAddress []common.Address) (event.Subscription, error) {
+
+	var nodeOperatorIdRule []interface{}
+	for _, nodeOperatorIdItem := range nodeOperatorId {
+		nodeOperatorIdRule = append(nodeOperatorIdRule, nodeOperatorIdItem)
+	}
+	var managerAddressRule []interface{}
+	for _, managerAddressItem := range managerAddress {
+		managerAddressRule = append(managerAddressRule, managerAddressItem)
+	}
+	var rewardAddressRule []interface{}
+	for _, rewardAddressItem := range rewardAddress {
+		rewardAddressRule = append(rewardAddressRule, rewardAddressItem)
+	}
+
+	logs, sub, err := _Csmodule.contract.WatchLogs(opts, "NodeOperatorAdded", nodeOperatorIdRule, managerAddressRule, rewardAddressRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(CsmoduleNodeOperatorAdded)
+				if err := _Csmodule.contract.UnpackLog(event, "NodeOperatorAdded", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseNodeOperatorAdded is a log parse operation binding the contract event 0xf35982c84fdc94f58d48e901c54c615804cf7d7939b9b8f76ce4d459354e6363.
+//
+// Solidity: event NodeOperatorAdded(uint256 indexed nodeOperatorId, address indexed managerAddress, address indexed rewardAddress)
+func (_Csmodule *CsmoduleFilterer) ParseNodeOperatorAdded(log types.Log) (*CsmoduleNodeOperatorAdded, error) {
+	event := new(CsmoduleNodeOperatorAdded)
+	if err := _Csmodule.contract.UnpackLog(event, "NodeOperatorAdded", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// CsmoduleNodeOperatorManagerAddressChangeProposedIterator is returned from FilterNodeOperatorManagerAddressChangeProposed and is used to iterate over the raw logs and unpacked data for NodeOperatorManagerAddressChangeProposed events raised by the Csmodule contract.
+type CsmoduleNodeOperatorManagerAddressChangeProposedIterator struct {
+	Event *CsmoduleNodeOperatorManagerAddressChangeProposed // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *CsmoduleNodeOperatorManagerAddressChangeProposedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(CsmoduleNodeOperatorManagerAddressChangeProposed)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(CsmoduleNodeOperatorManagerAddressChangeProposed)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *CsmoduleNodeOperatorManagerAddressChangeProposedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *CsmoduleNodeOperatorManagerAddressChangeProposedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// CsmoduleNodeOperatorManagerAddressChangeProposed represents a NodeOperatorManagerAddressChangeProposed event raised by the Csmodule contract.
+type CsmoduleNodeOperatorManagerAddressChangeProposed struct {
+	NodeOperatorId     *big.Int
+	OldProposedAddress common.Address
+	NewProposedAddress common.Address
+	Raw                types.Log // Blockchain specific contextual infos
+}
+
+// FilterNodeOperatorManagerAddressChangeProposed is a free log retrieval operation binding the contract event 0x4048f15a706950765ca59f99d0fa6fe8edaaa3f3e3d0337417082e2131df82fb.
+//
+// Solidity: event NodeOperatorManagerAddressChangeProposed(uint256 indexed nodeOperatorId, address indexed oldProposedAddress, address indexed newProposedAddress)
+func (_Csmodule *CsmoduleFilterer) FilterNodeOperatorManagerAddressChangeProposed(opts *bind.FilterOpts, nodeOperatorId []*big.Int, oldProposedAddress []common.Address, newProposedAddress []common.Address) (*CsmoduleNodeOperatorManagerAddressChangeProposedIterator, error) {
+
+	var nodeOperatorIdRule []interface{}
+	for _, nodeOperatorIdItem := range nodeOperatorId {
+		nodeOperatorIdRule = append(nodeOperatorIdRule, nodeOperatorIdItem)
+	}
+	var oldProposedAddressRule []interface{}
+	for _, oldProposedAddressItem := range oldProposedAddress {
+		oldProposedAddressRule = append(oldProposedAddressRule, oldProposedAddressItem)
+	}
+	var newProposedAddressRule []interface{}
+	for _, newProposedAddressItem := range newProposedAddress {
+		newProposedAddressRule = append(newProposedAddressRule, newProposedAddressItem)
+	}
+
+	logs, sub, err := _Csmodule.contract.FilterLogs(opts, "NodeOperatorManagerAddressChangeProposed", nodeOperatorIdRule, oldProposedAddressRule, newProposedAddressRule)
+	if err != nil {
+		return nil, err
+	}
+	return &CsmoduleNodeOperatorManagerAddressChangeProposedIterator{contract: _Csmodule.contract, event: "NodeOperatorManagerAddressChangeProposed", logs: logs, sub: sub}, nil
+}
+
+// WatchNodeOperatorManagerAddressChangeProposed is a free log subscription operation binding the contract event 0x4048f15a706950765ca59f99d0fa6fe8edaaa3f3e3d0337417082e2131df82fb.
+//
+// Solidity: event NodeOperatorManagerAddressChangeProposed(uint256 indexed nodeOperatorId, address indexed oldProposedAddress, address indexed newProposedAddress)
+func (_Csmodule *CsmoduleFilterer) WatchNodeOperatorManagerAddressChangeProposed(opts *bind.WatchOpts, sink chan<- *CsmoduleNodeOperatorManagerAddressChangeProposed, nodeOperatorId []*big.Int, oldProposedAddress []common.Address, newProposedAddress []common.Address) (event.Subscription, error) {
+
+	var nodeOperatorIdRule []interface{}
+	for _, nodeOperatorIdItem := range nodeOperatorId {
+		nodeOperatorIdRule = append(nodeOperatorIdRule, nodeOperatorIdItem)
+	}
+	var oldProposedAddressRule []interface{}
+	for _, oldProposedAddressItem := range oldProposedAddress {
+		oldProposedAddressRule = append(oldProposedAddressRule, oldProposedAddressItem)
+	}
+	var newProposedAddressRule []interface{}
+	for _, newProposedAddressItem := range newProposedAddress {
+		newProposedAddressRule = append(newProposedAddressRule, newProposedAddressItem)
+	}
+
+	logs, sub, err := _Csmodule.contract.WatchLogs(opts, "NodeOperatorManagerAddressChangeProposed", nodeOperatorIdRule, oldProposedAddressRule, newProposedAddressRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(CsmoduleNodeOperatorManagerAddressChangeProposed)
+				if err := _Csmodule.contract.UnpackLog(event, "NodeOperatorManagerAddressChangeProposed", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseNodeOperatorManagerAddressChangeProposed is a log parse operation binding the contract event 0x4048f15a706950765ca59f99d0fa6fe8edaaa3f3e3d0337417082e2131df82fb.
+//
+// Solidity: event NodeOperatorManagerAddressChangeProposed(uint256 indexed nodeOperatorId, address indexed oldProposedAddress, address indexed newProposedAddress)
+func (_Csmodule *CsmoduleFilterer) ParseNodeOperatorManagerAddressChangeProposed(log types.Log) (*CsmoduleNodeOperatorManagerAddressChangeProposed, error) {
+	event := new(CsmoduleNodeOperatorManagerAddressChangeProposed)
+	if err := _Csmodule.contract.UnpackLog(event, "NodeOperatorManagerAddressChangeProposed", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// CsmoduleNodeOperatorManagerAddressChangedIterator is returned from FilterNodeOperatorManagerAddressChanged and is used to iterate over the raw logs and unpacked data for NodeOperatorManagerAddressChanged events raised by the Csmodule contract.
+type CsmoduleNodeOperatorManagerAddressChangedIterator struct {
+	Event *CsmoduleNodeOperatorManagerAddressChanged // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *CsmoduleNodeOperatorManagerAddressChangedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(CsmoduleNodeOperatorManagerAddressChanged)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(CsmoduleNodeOperatorManagerAddressChanged)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *CsmoduleNodeOperatorManagerAddressChangedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *CsmoduleNodeOperatorManagerAddressChangedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// CsmoduleNodeOperatorManagerAddressChanged represents a NodeOperatorManagerAddressChanged event raised by the Csmodule contract.
+type CsmoduleNodeOperatorManagerAddressChanged struct {
+	NodeOperatorId *big.Int
+	OldAddress     common.Address
+	NewAddress     common.Address
+	Raw            types.Log // Blockchain specific contextual infos
+}
+
+// FilterNodeOperatorManagerAddressChanged is a free log retrieval operation binding the contract event 0x862021f23449d6e8516867bd839be15a3d8698a7561c5c2c35069074b7e91e61.
+//
+// Solidity: event NodeOperatorManagerAddressChanged(uint256 indexed nodeOperatorId, address indexed oldAddress, address indexed newAddress)
+func (_Csmodule *CsmoduleFilterer) FilterNodeOperatorManagerAddressChanged(opts *bind.FilterOpts, nodeOperatorId []*big.Int, oldAddress []common.Address, newAddress []common.Address) (*CsmoduleNodeOperatorManagerAddressChangedIterator, error) {
+
+	var nodeOperatorIdRule []interface{}
+	for _, nodeOperatorIdItem := range nodeOperatorId {
+		nodeOperatorIdRule = append(nodeOperatorIdRule, nodeOperatorIdItem)
+	}
+	var oldAddressRule []interface{}
+	for _, oldAddressItem := range oldAddress {
+		oldAddressRule = append(oldAddressRule, oldAddressItem)
+	}
+	var newAddressRule []interface{}
+	for _, newAddressItem := range newAddress {
+		newAddressRule = append(newAddressRule, newAddressItem)
+	}
+
+	logs, sub, err := _Csmodule.contract.FilterLogs(opts, "NodeOperatorManagerAddressChanged", nodeOperatorIdRule, oldAddressRule, newAddressRule)
+	if err != nil {
+		return nil, err
+	}
+	return &CsmoduleNodeOperatorManagerAddressChangedIterator{contract: _Csmodule.contract, event: "NodeOperatorManagerAddressChanged", logs: logs, sub: sub}, nil
+}
+
+// WatchNodeOperatorManagerAddressChanged is a free log subscription operation binding the contract event 0x862021f23449d6e8516867bd839be15a3d8698a7561c5c2c35069074b7e91e61.
+//
+// Solidity: event NodeOperatorManagerAddressChanged(uint256 indexed nodeOperatorId, address indexed oldAddress, address indexed newAddress)
+func (_Csmodule *CsmoduleFilterer) WatchNodeOperatorManagerAddressChanged(opts *bind.WatchOpts, sink chan<- *CsmoduleNodeOperatorManagerAddressChanged, nodeOperatorId []*big.Int, oldAddress []common.Address, newAddress []common.Address) (event.Subscription, error) {
+
+	var nodeOperatorIdRule []interface{}
+	for _, nodeOperatorIdItem := range nodeOperatorId {
+		nodeOperatorIdRule = append(nodeOperatorIdRule, nodeOperatorIdItem)
+	}
+	var oldAddressRule []interface{}
+	for _, oldAddressItem := range oldAddress {
+		oldAddressRule = append(oldAddressRule, oldAddressItem)
+	}
+	var newAddressRule []interface{}
+	for _, newAddressItem := range newAddress {
+		newAddressRule = append(newAddressRule, newAddressItem)
+	}
+
+	logs, sub, err := _Csmodule.contract.WatchLogs(opts, "NodeOperatorManagerAddressChanged", nodeOperatorIdRule, oldAddressRule, newAddressRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(CsmoduleNodeOperatorManagerAddressChanged)
+				if err := _Csmodule.contract.UnpackLog(event, "NodeOperatorManagerAddressChanged", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseNodeOperatorManagerAddressChanged is a log parse operation binding the contract event 0x862021f23449d6e8516867bd839be15a3d8698a7561c5c2c35069074b7e91e61.
+//
+// Solidity: event NodeOperatorManagerAddressChanged(uint256 indexed nodeOperatorId, address indexed oldAddress, address indexed newAddress)
+func (_Csmodule *CsmoduleFilterer) ParseNodeOperatorManagerAddressChanged(log types.Log) (*CsmoduleNodeOperatorManagerAddressChanged, error) {
+	event := new(CsmoduleNodeOperatorManagerAddressChanged)
+	if err := _Csmodule.contract.UnpackLog(event, "NodeOperatorManagerAddressChanged", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// CsmoduleNodeOperatorRewardAddressChangeProposedIterator is returned from FilterNodeOperatorRewardAddressChangeProposed and is used to iterate over the raw logs and unpacked data for NodeOperatorRewardAddressChangeProposed events raised by the Csmodule contract.
+type CsmoduleNodeOperatorRewardAddressChangeProposedIterator struct {
+	Event *CsmoduleNodeOperatorRewardAddressChangeProposed // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *CsmoduleNodeOperatorRewardAddressChangeProposedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(CsmoduleNodeOperatorRewardAddressChangeProposed)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(CsmoduleNodeOperatorRewardAddressChangeProposed)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *CsmoduleNodeOperatorRewardAddressChangeProposedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *CsmoduleNodeOperatorRewardAddressChangeProposedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// CsmoduleNodeOperatorRewardAddressChangeProposed represents a NodeOperatorRewardAddressChangeProposed event raised by the Csmodule contract.
+type CsmoduleNodeOperatorRewardAddressChangeProposed struct {
+	NodeOperatorId     *big.Int
+	OldProposedAddress common.Address
+	NewProposedAddress common.Address
+	Raw                types.Log // Blockchain specific contextual infos
+}
+
+// FilterNodeOperatorRewardAddressChangeProposed is a free log retrieval operation binding the contract event 0xb5878cdb1d66f971efe3b138a71c64bc5bc519314db2533e0e4cde954409ea5a.
+//
+// Solidity: event NodeOperatorRewardAddressChangeProposed(uint256 indexed nodeOperatorId, address indexed oldProposedAddress, address indexed newProposedAddress)
+func (_Csmodule *CsmoduleFilterer) FilterNodeOperatorRewardAddressChangeProposed(opts *bind.FilterOpts, nodeOperatorId []*big.Int, oldProposedAddress []common.Address, newProposedAddress []common.Address) (*CsmoduleNodeOperatorRewardAddressChangeProposedIterator, error) {
+
+	var nodeOperatorIdRule []interface{}
+	for _, nodeOperatorIdItem := range nodeOperatorId {
+		nodeOperatorIdRule = append(nodeOperatorIdRule, nodeOperatorIdItem)
+	}
+	var oldProposedAddressRule []interface{}
+	for _, oldProposedAddressItem := range oldProposedAddress {
+		oldProposedAddressRule = append(oldProposedAddressRule, oldProposedAddressItem)
+	}
+	var newProposedAddressRule []interface{}
+	for _, newProposedAddressItem := range newProposedAddress {
+		newProposedAddressRule = append(newProposedAddressRule, newProposedAddressItem)
+	}
+
+	logs, sub, err := _Csmodule.contract.FilterLogs(opts, "NodeOperatorRewardAddressChangeProposed", nodeOperatorIdRule, oldProposedAddressRule, newProposedAddressRule)
+	if err != nil {
+		return nil, err
+	}
+	return &CsmoduleNodeOperatorRewardAddressChangeProposedIterator{contract: _Csmodule.contract, event: "NodeOperatorRewardAddressChangeProposed", logs: logs, sub: sub}, nil
+}
+
+// WatchNodeOperatorRewardAddressChangeProposed is a free log subscription operation binding the contract event 0xb5878cdb1d66f971efe3b138a71c64bc5bc519314db2533e0e4cde954409ea5a.
+//
+// Solidity: event NodeOperatorRewardAddressChangeProposed(uint256 indexed nodeOperatorId, address indexed oldProposedAddress, address indexed newProposedAddress)
+func (_Csmodule *CsmoduleFilterer) WatchNodeOperatorRewardAddressChangeProposed(opts *bind.WatchOpts, sink chan<- *CsmoduleNodeOperatorRewardAddressChangeProposed, nodeOperatorId []*big.Int, oldProposedAddress []common.Address, newProposedAddress []common.Address) (event.Subscription, error) {
+
+	var nodeOperatorIdRule []interface{}
+	for _, nodeOperatorIdItem := range nodeOperatorId {
+		nodeOperatorIdRule = append(nodeOperatorIdRule, nodeOperatorIdItem)
+	}
+	var oldProposedAddressRule []interface{}
+	for _, oldProposedAddressItem := range oldProposedAddress {
+		oldProposedAddressRule = append(oldProposedAddressRule, oldProposedAddressItem)
+	}
+	var newProposedAddressRule []interface{}
+	for _, newProposedAddressItem := range newProposedAddress {
+		newProposedAddressRule = append(newProposedAddressRule, newProposedAddressItem)
+	}
+
+	logs, sub, err := _Csmodule.contract.WatchLogs(opts, "NodeOperatorRewardAddressChangeProposed", nodeOperatorIdRule, oldProposedAddressRule, newProposedAddressRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(CsmoduleNodeOperatorRewardAddressChangeProposed)
+				if err := _Csmodule.contract.UnpackLog(event, "NodeOperatorRewardAddressChangeProposed", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseNodeOperatorRewardAddressChangeProposed is a log parse operation binding the contract event 0xb5878cdb1d66f971efe3b138a71c64bc5bc519314db2533e0e4cde954409ea5a.
+//
+// Solidity: event NodeOperatorRewardAddressChangeProposed(uint256 indexed nodeOperatorId, address indexed oldProposedAddress, address indexed newProposedAddress)
+func (_Csmodule *CsmoduleFilterer) ParseNodeOperatorRewardAddressChangeProposed(log types.Log) (*CsmoduleNodeOperatorRewardAddressChangeProposed, error) {
+	event := new(CsmoduleNodeOperatorRewardAddressChangeProposed)
+	if err := _Csmodule.contract.UnpackLog(event, "NodeOperatorRewardAddressChangeProposed", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// CsmoduleNodeOperatorRewardAddressChangedIterator is returned from FilterNodeOperatorRewardAddressChanged and is used to iterate over the raw logs and unpacked data for NodeOperatorRewardAddressChanged events raised by the Csmodule contract.
+type CsmoduleNodeOperatorRewardAddressChangedIterator struct {
+	Event *CsmoduleNodeOperatorRewardAddressChanged // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *CsmoduleNodeOperatorRewardAddressChangedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(CsmoduleNodeOperatorRewardAddressChanged)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(CsmoduleNodeOperatorRewardAddressChanged)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *CsmoduleNodeOperatorRewardAddressChangedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *CsmoduleNodeOperatorRewardAddressChangedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// CsmoduleNodeOperatorRewardAddressChanged represents a NodeOperatorRewardAddressChanged event raised by the Csmodule contract.
+type CsmoduleNodeOperatorRewardAddressChanged struct {
+	NodeOperatorId *big.Int
+	OldAddress     common.Address
+	NewAddress     common.Address
+	Raw            types.Log // Blockchain specific contextual infos
+}
+
+// FilterNodeOperatorRewardAddressChanged is a free log retrieval operation binding the contract event 0x069ac7cd8230db015b7250c8e5425149cf1a3e912d9569f497165e55b3b6b7b2.
+//
+// Solidity: event NodeOperatorRewardAddressChanged(uint256 indexed nodeOperatorId, address indexed oldAddress, address indexed newAddress)
+func (_Csmodule *CsmoduleFilterer) FilterNodeOperatorRewardAddressChanged(opts *bind.FilterOpts, nodeOperatorId []*big.Int, oldAddress []common.Address, newAddress []common.Address) (*CsmoduleNodeOperatorRewardAddressChangedIterator, error) {
+
+	var nodeOperatorIdRule []interface{}
+	for _, nodeOperatorIdItem := range nodeOperatorId {
+		nodeOperatorIdRule = append(nodeOperatorIdRule, nodeOperatorIdItem)
+	}
+	var oldAddressRule []interface{}
+	for _, oldAddressItem := range oldAddress {
+		oldAddressRule = append(oldAddressRule, oldAddressItem)
+	}
+	var newAddressRule []interface{}
+	for _, newAddressItem := range newAddress {
+		newAddressRule = append(newAddressRule, newAddressItem)
+	}
+
+	logs, sub, err := _Csmodule.contract.FilterLogs(opts, "NodeOperatorRewardAddressChanged", nodeOperatorIdRule, oldAddressRule, newAddressRule)
+	if err != nil {
+		return nil, err
+	}
+	return &CsmoduleNodeOperatorRewardAddressChangedIterator{contract: _Csmodule.contract, event: "NodeOperatorRewardAddressChanged", logs: logs, sub: sub}, nil
+}
+
+// WatchNodeOperatorRewardAddressChanged is a free log subscription operation binding the contract event 0x069ac7cd8230db015b7250c8e5425149cf1a3e912d9569f497165e55b3b6b7b2.
+//
+// Solidity: event NodeOperatorRewardAddressChanged(uint256 indexed nodeOperatorId, address indexed oldAddress, address indexed newAddress)
+func (_Csmodule *CsmoduleFilterer) WatchNodeOperatorRewardAddressChanged(opts *bind.WatchOpts, sink chan<- *CsmoduleNodeOperatorRewardAddressChanged, nodeOperatorId []*big.Int, oldAddress []common.Address, newAddress []common.Address) (event.Subscription, error) {
+
+	var nodeOperatorIdRule []interface{}
+	for _, nodeOperatorIdItem := range nodeOperatorId {
+		nodeOperatorIdRule = append(nodeOperatorIdRule, nodeOperatorIdItem)
+	}
+	var oldAddressRule []interface{}
+	for _, oldAddressItem := range oldAddress {
+		oldAddressRule = append(oldAddressRule, oldAddressItem)
+	}
+	var newAddressRule []interface{}
+	for _, newAddressItem := range newAddress {
+		newAddressRule = append(newAddressRule, newAddressItem)
+	}
+
+	logs, sub, err := _Csmodule.contract.WatchLogs(opts, "NodeOperatorRewardAddressChanged", nodeOperatorIdRule, oldAddressRule, newAddressRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(CsmoduleNodeOperatorRewardAddressChanged)
+				if err := _Csmodule.contract.UnpackLog(event, "NodeOperatorRewardAddressChanged", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseNodeOperatorRewardAddressChanged is a log parse operation binding the contract event 0x069ac7cd8230db015b7250c8e5425149cf1a3e912d9569f497165e55b3b6b7b2.
+//
+// Solidity: event NodeOperatorRewardAddressChanged(uint256 indexed nodeOperatorId, address indexed oldAddress, address indexed newAddress)
+func (_Csmodule *CsmoduleFilterer) ParseNodeOperatorRewardAddressChanged(log types.Log) (*CsmoduleNodeOperatorRewardAddressChanged, error) {
+	event := new(CsmoduleNodeOperatorRewardAddressChanged)
+	if err := _Csmodule.contract.UnpackLog(event, "NodeOperatorRewardAddressChanged", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// CsmoduleNonceChangedIterator is returned from FilterNonceChanged and is used to iterate over the raw logs and unpacked data for NonceChanged events raised by the Csmodule contract.
+type CsmoduleNonceChangedIterator struct {
+	Event *CsmoduleNonceChanged // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *CsmoduleNonceChangedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(CsmoduleNonceChanged)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(CsmoduleNonceChanged)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *CsmoduleNonceChangedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *CsmoduleNonceChangedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// CsmoduleNonceChanged represents a NonceChanged event raised by the Csmodule contract.
+type CsmoduleNonceChanged struct {
+	Nonce *big.Int
+	Raw   types.Log // Blockchain specific contextual infos
+}
+
+// FilterNonceChanged is a free log retrieval operation binding the contract event 0x7220970e1f1f12864ecccd8942690a837c7a8dd45d158cb891eb45a8a69134aa.
+//
+// Solidity: event NonceChanged(uint256 nonce)
+func (_Csmodule *CsmoduleFilterer) FilterNonceChanged(opts *bind.FilterOpts) (*CsmoduleNonceChangedIterator, error) {
+
+	logs, sub, err := _Csmodule.contract.FilterLogs(opts, "NonceChanged")
+	if err != nil {
+		return nil, err
+	}
+	return &CsmoduleNonceChangedIterator{contract: _Csmodule.contract, event: "NonceChanged", logs: logs, sub: sub}, nil
+}
+
+// WatchNonceChanged is a free log subscription operation binding the contract event 0x7220970e1f1f12864ecccd8942690a837c7a8dd45d158cb891eb45a8a69134aa.
+//
+// Solidity: event NonceChanged(uint256 nonce)
+func (_Csmodule *CsmoduleFilterer) WatchNonceChanged(opts *bind.WatchOpts, sink chan<- *CsmoduleNonceChanged) (event.Subscription, error) {
+
+	logs, sub, err := _Csmodule.contract.WatchLogs(opts, "NonceChanged")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(CsmoduleNonceChanged)
+				if err := _Csmodule.contract.UnpackLog(event, "NonceChanged", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseNonceChanged is a log parse operation binding the contract event 0x7220970e1f1f12864ecccd8942690a837c7a8dd45d158cb891eb45a8a69134aa.
+//
+// Solidity: event NonceChanged(uint256 nonce)
+func (_Csmodule *CsmoduleFilterer) ParseNonceChanged(log types.Log) (*CsmoduleNonceChanged, error) {
+	event := new(CsmoduleNonceChanged)
+	if err := _Csmodule.contract.UnpackLog(event, "NonceChanged", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// CsmodulePausedIterator is returned from FilterPaused and is used to iterate over the raw logs and unpacked data for Paused events raised by the Csmodule contract.
+type CsmodulePausedIterator struct {
+	Event *CsmodulePaused // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *CsmodulePausedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(CsmodulePaused)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(CsmodulePaused)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *CsmodulePausedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *CsmodulePausedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// CsmodulePaused represents a Paused event raised by the Csmodule contract.
+type CsmodulePaused struct {
+	Duration *big.Int
+	Raw      types.Log // Blockchain specific contextual infos
+}
+
+// FilterPaused is a free log retrieval operation binding the contract event 0x32fb7c9891bc4f963c7de9f1186d2a7755c7d6e9f4604dabe1d8bb3027c2f49e.
+//
+// Solidity: event Paused(uint256 duration)
+func (_Csmodule *CsmoduleFilterer) FilterPaused(opts *bind.FilterOpts) (*CsmodulePausedIterator, error) {
+
+	logs, sub, err := _Csmodule.contract.FilterLogs(opts, "Paused")
+	if err != nil {
+		return nil, err
+	}
+	return &CsmodulePausedIterator{contract: _Csmodule.contract, event: "Paused", logs: logs, sub: sub}, nil
+}
+
+// WatchPaused is a free log subscription operation binding the contract event 0x32fb7c9891bc4f963c7de9f1186d2a7755c7d6e9f4604dabe1d8bb3027c2f49e.
+//
+// Solidity: event Paused(uint256 duration)
+func (_Csmodule *CsmoduleFilterer) WatchPaused(opts *bind.WatchOpts, sink chan<- *CsmodulePaused) (event.Subscription, error) {
+
+	logs, sub, err := _Csmodule.contract.WatchLogs(opts, "Paused")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(CsmodulePaused)
+				if err := _Csmodule.contract.UnpackLog(event, "Paused", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParsePaused is a log parse operation binding the contract event 0x32fb7c9891bc4f963c7de9f1186d2a7755c7d6e9f4604dabe1d8bb3027c2f49e.
+//
+// Solidity: event Paused(uint256 duration)
+func (_Csmodule *CsmoduleFilterer) ParsePaused(log types.Log) (*CsmodulePaused, error) {
+	event := new(CsmodulePaused)
+	if err := _Csmodule.contract.UnpackLog(event, "Paused", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// CsmodulePublicReleaseIterator is returned from FilterPublicRelease and is used to iterate over the raw logs and unpacked data for PublicRelease events raised by the Csmodule contract.
+type CsmodulePublicReleaseIterator struct {
+	Event *CsmodulePublicRelease // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *CsmodulePublicReleaseIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(CsmodulePublicRelease)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(CsmodulePublicRelease)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *CsmodulePublicReleaseIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *CsmodulePublicReleaseIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// CsmodulePublicRelease represents a PublicRelease event raised by the Csmodule contract.
+type CsmodulePublicRelease struct {
+	Raw types.Log // Blockchain specific contextual infos
+}
+
+// FilterPublicRelease is a free log retrieval operation binding the contract event 0xe5eb57aa4d841adeece4ac87bd294965df4a894f0aa24db4a4a55a39ab101d6e.
+//
+// Solidity: event PublicRelease()
+func (_Csmodule *CsmoduleFilterer) FilterPublicRelease(opts *bind.FilterOpts) (*CsmodulePublicReleaseIterator, error) {
+
+	logs, sub, err := _Csmodule.contract.FilterLogs(opts, "PublicRelease")
+	if err != nil {
+		return nil, err
+	}
+	return &CsmodulePublicReleaseIterator{contract: _Csmodule.contract, event: "PublicRelease", logs: logs, sub: sub}, nil
+}
+
+// WatchPublicRelease is a free log subscription operation binding the contract event 0xe5eb57aa4d841adeece4ac87bd294965df4a894f0aa24db4a4a55a39ab101d6e.
+//
+// Solidity: event PublicRelease()
+func (_Csmodule *CsmoduleFilterer) WatchPublicRelease(opts *bind.WatchOpts, sink chan<- *CsmodulePublicRelease) (event.Subscription, error) {
+
+	logs, sub, err := _Csmodule.contract.WatchLogs(opts, "PublicRelease")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(CsmodulePublicRelease)
+				if err := _Csmodule.contract.UnpackLog(event, "PublicRelease", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParsePublicRelease is a log parse operation binding the contract event 0xe5eb57aa4d841adeece4ac87bd294965df4a894f0aa24db4a4a55a39ab101d6e.
+//
+// Solidity: event PublicRelease()
+func (_Csmodule *CsmoduleFilterer) ParsePublicRelease(log types.Log) (*CsmodulePublicRelease, error) {
+	event := new(CsmodulePublicRelease)
+	if err := _Csmodule.contract.UnpackLog(event, "PublicRelease", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// CsmoduleReferrerSetIterator is returned from FilterReferrerSet and is used to iterate over the raw logs and unpacked data for ReferrerSet events raised by the Csmodule contract.
+type CsmoduleReferrerSetIterator struct {
+	Event *CsmoduleReferrerSet // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *CsmoduleReferrerSetIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(CsmoduleReferrerSet)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(CsmoduleReferrerSet)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *CsmoduleReferrerSetIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *CsmoduleReferrerSetIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// CsmoduleReferrerSet represents a ReferrerSet event raised by the Csmodule contract.
+type CsmoduleReferrerSet struct {
+	NodeOperatorId *big.Int
+	Referrer       common.Address
+	Raw            types.Log // Blockchain specific contextual infos
+}
+
+// FilterReferrerSet is a free log retrieval operation binding the contract event 0x67334334c388385e5f244703f8a8b28b7f4ffe52909130aca69bc62a8e27f09a.
+//
+// Solidity: event ReferrerSet(uint256 indexed nodeOperatorId, address indexed referrer)
+func (_Csmodule *CsmoduleFilterer) FilterReferrerSet(opts *bind.FilterOpts, nodeOperatorId []*big.Int, referrer []common.Address) (*CsmoduleReferrerSetIterator, error) {
+
+	var nodeOperatorIdRule []interface{}
+	for _, nodeOperatorIdItem := range nodeOperatorId {
+		nodeOperatorIdRule = append(nodeOperatorIdRule, nodeOperatorIdItem)
+	}
+	var referrerRule []interface{}
+	for _, referrerItem := range referrer {
+		referrerRule = append(referrerRule, referrerItem)
+	}
+
+	logs, sub, err := _Csmodule.contract.FilterLogs(opts, "ReferrerSet", nodeOperatorIdRule, referrerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &CsmoduleReferrerSetIterator{contract: _Csmodule.contract, event: "ReferrerSet", logs: logs, sub: sub}, nil
+}
+
+// WatchReferrerSet is a free log subscription operation binding the contract event 0x67334334c388385e5f244703f8a8b28b7f4ffe52909130aca69bc62a8e27f09a.
+//
+// Solidity: event ReferrerSet(uint256 indexed nodeOperatorId, address indexed referrer)
+func (_Csmodule *CsmoduleFilterer) WatchReferrerSet(opts *bind.WatchOpts, sink chan<- *CsmoduleReferrerSet, nodeOperatorId []*big.Int, referrer []common.Address) (event.Subscription, error) {
+
+	var nodeOperatorIdRule []interface{}
+	for _, nodeOperatorIdItem := range nodeOperatorId {
+		nodeOperatorIdRule = append(nodeOperatorIdRule, nodeOperatorIdItem)
+	}
+	var referrerRule []interface{}
+	for _, referrerItem := range referrer {
+		referrerRule = append(referrerRule, referrerItem)
+	}
+
+	logs, sub, err := _Csmodule.contract.WatchLogs(opts, "ReferrerSet", nodeOperatorIdRule, referrerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(CsmoduleReferrerSet)
+				if err := _Csmodule.contract.UnpackLog(event, "ReferrerSet", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseReferrerSet is a log parse operation binding the contract event 0x67334334c388385e5f244703f8a8b28b7f4ffe52909130aca69bc62a8e27f09a.
+//
+// Solidity: event ReferrerSet(uint256 indexed nodeOperatorId, address indexed referrer)
+func (_Csmodule *CsmoduleFilterer) ParseReferrerSet(log types.Log) (*CsmoduleReferrerSet, error) {
+	event := new(CsmoduleReferrerSet)
+	if err := _Csmodule.contract.UnpackLog(event, "ReferrerSet", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// CsmoduleResumedIterator is returned from FilterResumed and is used to iterate over the raw logs and unpacked data for Resumed events raised by the Csmodule contract.
+type CsmoduleResumedIterator struct {
+	Event *CsmoduleResumed // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *CsmoduleResumedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(CsmoduleResumed)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(CsmoduleResumed)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *CsmoduleResumedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *CsmoduleResumedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// CsmoduleResumed represents a Resumed event raised by the Csmodule contract.
+type CsmoduleResumed struct {
+	Raw types.Log // Blockchain specific contextual infos
+}
+
+// FilterResumed is a free log retrieval operation binding the contract event 0x62451d457bc659158be6e6247f56ec1df424a5c7597f71c20c2bc44e0965c8f9.
+//
+// Solidity: event Resumed()
+func (_Csmodule *CsmoduleFilterer) FilterResumed(opts *bind.FilterOpts) (*CsmoduleResumedIterator, error) {
+
+	logs, sub, err := _Csmodule.contract.FilterLogs(opts, "Resumed")
+	if err != nil {
+		return nil, err
+	}
+	return &CsmoduleResumedIterator{contract: _Csmodule.contract, event: "Resumed", logs: logs, sub: sub}, nil
+}
+
+// WatchResumed is a free log subscription operation binding the contract event 0x62451d457bc659158be6e6247f56ec1df424a5c7597f71c20c2bc44e0965c8f9.
+//
+// Solidity: event Resumed()
+func (_Csmodule *CsmoduleFilterer) WatchResumed(opts *bind.WatchOpts, sink chan<- *CsmoduleResumed) (event.Subscription, error) {
+
+	logs, sub, err := _Csmodule.contract.WatchLogs(opts, "Resumed")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(CsmoduleResumed)
+				if err := _Csmodule.contract.UnpackLog(event, "Resumed", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseResumed is a log parse operation binding the contract event 0x62451d457bc659158be6e6247f56ec1df424a5c7597f71c20c2bc44e0965c8f9.
+//
+// Solidity: event Resumed()
+func (_Csmodule *CsmoduleFilterer) ParseResumed(log types.Log) (*CsmoduleResumed, error) {
+	event := new(CsmoduleResumed)
+	if err := _Csmodule.contract.UnpackLog(event, "Resumed", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// CsmoduleRoleAdminChangedIterator is returned from FilterRoleAdminChanged and is used to iterate over the raw logs and unpacked data for RoleAdminChanged events raised by the Csmodule contract.
+type CsmoduleRoleAdminChangedIterator struct {
+	Event *CsmoduleRoleAdminChanged // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *CsmoduleRoleAdminChangedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(CsmoduleRoleAdminChanged)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(CsmoduleRoleAdminChanged)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *CsmoduleRoleAdminChangedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *CsmoduleRoleAdminChangedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// CsmoduleRoleAdminChanged represents a RoleAdminChanged event raised by the Csmodule contract.
+type CsmoduleRoleAdminChanged struct {
+	Role              [32]byte
+	PreviousAdminRole [32]byte
+	NewAdminRole      [32]byte
+	Raw               types.Log // Blockchain specific contextual infos
+}
+
+// FilterRoleAdminChanged is a free log retrieval operation binding the contract event 0xbd79b86ffe0ab8e8776151514217cd7cacd52c909f66475c3af44e129f0b00ff.
+//
+// Solidity: event RoleAdminChanged(bytes32 indexed role, bytes32 indexed previousAdminRole, bytes32 indexed newAdminRole)
+func (_Csmodule *CsmoduleFilterer) FilterRoleAdminChanged(opts *bind.FilterOpts, role [][32]byte, previousAdminRole [][32]byte, newAdminRole [][32]byte) (*CsmoduleRoleAdminChangedIterator, error) {
+
+	var roleRule []interface{}
+	for _, roleItem := range role {
+		roleRule = append(roleRule, roleItem)
+	}
+	var previousAdminRoleRule []interface{}
+	for _, previousAdminRoleItem := range previousAdminRole {
+		previousAdminRoleRule = append(previousAdminRoleRule, previousAdminRoleItem)
+	}
+	var newAdminRoleRule []interface{}
+	for _, newAdminRoleItem := range newAdminRole {
+		newAdminRoleRule = append(newAdminRoleRule, newAdminRoleItem)
+	}
+
+	logs, sub, err := _Csmodule.contract.FilterLogs(opts, "RoleAdminChanged", roleRule, previousAdminRoleRule, newAdminRoleRule)
+	if err != nil {
+		return nil, err
+	}
+	return &CsmoduleRoleAdminChangedIterator{contract: _Csmodule.contract, event: "RoleAdminChanged", logs: logs, sub: sub}, nil
+}
+
+// WatchRoleAdminChanged is a free log subscription operation binding the contract event 0xbd79b86ffe0ab8e8776151514217cd7cacd52c909f66475c3af44e129f0b00ff.
+//
+// Solidity: event RoleAdminChanged(bytes32 indexed role, bytes32 indexed previousAdminRole, bytes32 indexed newAdminRole)
+func (_Csmodule *CsmoduleFilterer) WatchRoleAdminChanged(opts *bind.WatchOpts, sink chan<- *CsmoduleRoleAdminChanged, role [][32]byte, previousAdminRole [][32]byte, newAdminRole [][32]byte) (event.Subscription, error) {
+
+	var roleRule []interface{}
+	for _, roleItem := range role {
+		roleRule = append(roleRule, roleItem)
+	}
+	var previousAdminRoleRule []interface{}
+	for _, previousAdminRoleItem := range previousAdminRole {
+		previousAdminRoleRule = append(previousAdminRoleRule, previousAdminRoleItem)
+	}
+	var newAdminRoleRule []interface{}
+	for _, newAdminRoleItem := range newAdminRole {
+		newAdminRoleRule = append(newAdminRoleRule, newAdminRoleItem)
+	}
+
+	logs, sub, err := _Csmodule.contract.WatchLogs(opts, "RoleAdminChanged", roleRule, previousAdminRoleRule, newAdminRoleRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(CsmoduleRoleAdminChanged)
+				if err := _Csmodule.contract.UnpackLog(event, "RoleAdminChanged", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseRoleAdminChanged is a log parse operation binding the contract event 0xbd79b86ffe0ab8e8776151514217cd7cacd52c909f66475c3af44e129f0b00ff.
+//
+// Solidity: event RoleAdminChanged(bytes32 indexed role, bytes32 indexed previousAdminRole, bytes32 indexed newAdminRole)
+func (_Csmodule *CsmoduleFilterer) ParseRoleAdminChanged(log types.Log) (*CsmoduleRoleAdminChanged, error) {
+	event := new(CsmoduleRoleAdminChanged)
+	if err := _Csmodule.contract.UnpackLog(event, "RoleAdminChanged", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// CsmoduleRoleGrantedIterator is returned from FilterRoleGranted and is used to iterate over the raw logs and unpacked data for RoleGranted events raised by the Csmodule contract.
+type CsmoduleRoleGrantedIterator struct {
+	Event *CsmoduleRoleGranted // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *CsmoduleRoleGrantedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(CsmoduleRoleGranted)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(CsmoduleRoleGranted)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *CsmoduleRoleGrantedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *CsmoduleRoleGrantedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// CsmoduleRoleGranted represents a RoleGranted event raised by the Csmodule contract.
+type CsmoduleRoleGranted struct {
+	Role    [32]byte
+	Account common.Address
+	Sender  common.Address
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterRoleGranted is a free log retrieval operation binding the contract event 0x2f8788117e7eff1d82e926ec794901d17c78024a50270940304540a733656f0d.
+//
+// Solidity: event RoleGranted(bytes32 indexed role, address indexed account, address indexed sender)
+func (_Csmodule *CsmoduleFilterer) FilterRoleGranted(opts *bind.FilterOpts, role [][32]byte, account []common.Address, sender []common.Address) (*CsmoduleRoleGrantedIterator, error) {
+
+	var roleRule []interface{}
+	for _, roleItem := range role {
+		roleRule = append(roleRule, roleItem)
+	}
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var senderRule []interface{}
+	for _, senderItem := range sender {
+		senderRule = append(senderRule, senderItem)
+	}
+
+	logs, sub, err := _Csmodule.contract.FilterLogs(opts, "RoleGranted", roleRule, accountRule, senderRule)
+	if err != nil {
+		return nil, err
+	}
+	return &CsmoduleRoleGrantedIterator{contract: _Csmodule.contract, event: "RoleGranted", logs: logs, sub: sub}, nil
+}
+
+// WatchRoleGranted is a free log subscription operation binding the contract event 0x2f8788117e7eff1d82e926ec794901d17c78024a50270940304540a733656f0d.
+//
+// Solidity: event RoleGranted(bytes32 indexed role, address indexed account, address indexed sender)
+func (_Csmodule *CsmoduleFilterer) WatchRoleGranted(opts *bind.WatchOpts, sink chan<- *CsmoduleRoleGranted, role [][32]byte, account []common.Address, sender []common.Address) (event.Subscription, error) {
+
+	var roleRule []interface{}
+	for _, roleItem := range role {
+		roleRule = append(roleRule, roleItem)
+	}
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var senderRule []interface{}
+	for _, senderItem := range sender {
+		senderRule = append(senderRule, senderItem)
+	}
+
+	logs, sub, err := _Csmodule.contract.WatchLogs(opts, "RoleGranted", roleRule, accountRule, senderRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(CsmoduleRoleGranted)
+				if err := _Csmodule.contract.UnpackLog(event, "RoleGranted", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseRoleGranted is a log parse operation binding the contract event 0x2f8788117e7eff1d82e926ec794901d17c78024a50270940304540a733656f0d.
+//
+// Solidity: event RoleGranted(bytes32 indexed role, address indexed account, address indexed sender)
+func (_Csmodule *CsmoduleFilterer) ParseRoleGranted(log types.Log) (*CsmoduleRoleGranted, error) {
+	event := new(CsmoduleRoleGranted)
+	if err := _Csmodule.contract.UnpackLog(event, "RoleGranted", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// CsmoduleRoleRevokedIterator is returned from FilterRoleRevoked and is used to iterate over the raw logs and unpacked data for RoleRevoked events raised by the Csmodule contract.
+type CsmoduleRoleRevokedIterator struct {
+	Event *CsmoduleRoleRevoked // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *CsmoduleRoleRevokedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(CsmoduleRoleRevoked)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(CsmoduleRoleRevoked)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *CsmoduleRoleRevokedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *CsmoduleRoleRevokedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// CsmoduleRoleRevoked represents a RoleRevoked event raised by the Csmodule contract.
+type CsmoduleRoleRevoked struct {
+	Role    [32]byte
+	Account common.Address
+	Sender  common.Address
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterRoleRevoked is a free log retrieval operation binding the contract event 0xf6391f5c32d9c69d2a47ea670b442974b53935d1edc7fd64eb21e047a839171b.
+//
+// Solidity: event RoleRevoked(bytes32 indexed role, address indexed account, address indexed sender)
+func (_Csmodule *CsmoduleFilterer) FilterRoleRevoked(opts *bind.FilterOpts, role [][32]byte, account []common.Address, sender []common.Address) (*CsmoduleRoleRevokedIterator, error) {
+
+	var roleRule []interface{}
+	for _, roleItem := range role {
+		roleRule = append(roleRule, roleItem)
+	}
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var senderRule []interface{}
+	for _, senderItem := range sender {
+		senderRule = append(senderRule, senderItem)
+	}
+
+	logs, sub, err := _Csmodule.contract.FilterLogs(opts, "RoleRevoked", roleRule, accountRule, senderRule)
+	if err != nil {
+		return nil, err
+	}
+	return &CsmoduleRoleRevokedIterator{contract: _Csmodule.contract, event: "RoleRevoked", logs: logs, sub: sub}, nil
+}
+
+// WatchRoleRevoked is a free log subscription operation binding the contract event 0xf6391f5c32d9c69d2a47ea670b442974b53935d1edc7fd64eb21e047a839171b.
+//
+// Solidity: event RoleRevoked(bytes32 indexed role, address indexed account, address indexed sender)
+func (_Csmodule *CsmoduleFilterer) WatchRoleRevoked(opts *bind.WatchOpts, sink chan<- *CsmoduleRoleRevoked, role [][32]byte, account []common.Address, sender []common.Address) (event.Subscription, error) {
+
+	var roleRule []interface{}
+	for _, roleItem := range role {
+		roleRule = append(roleRule, roleItem)
+	}
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var senderRule []interface{}
+	for _, senderItem := range sender {
+		senderRule = append(senderRule, senderItem)
+	}
+
+	logs, sub, err := _Csmodule.contract.WatchLogs(opts, "RoleRevoked", roleRule, accountRule, senderRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(CsmoduleRoleRevoked)
+				if err := _Csmodule.contract.UnpackLog(event, "RoleRevoked", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseRoleRevoked is a log parse operation binding the contract event 0xf6391f5c32d9c69d2a47ea670b442974b53935d1edc7fd64eb21e047a839171b.
+//
+// Solidity: event RoleRevoked(bytes32 indexed role, address indexed account, address indexed sender)
+func (_Csmodule *CsmoduleFilterer) ParseRoleRevoked(log types.Log) (*CsmoduleRoleRevoked, error) {
+	event := new(CsmoduleRoleRevoked)
+	if err := _Csmodule.contract.UnpackLog(event, "RoleRevoked", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// CsmoduleSigningKeyAddedIterator is returned from FilterSigningKeyAdded and is used to iterate over the raw logs and unpacked data for SigningKeyAdded events raised by the Csmodule contract.
+type CsmoduleSigningKeyAddedIterator struct {
+	Event *CsmoduleSigningKeyAdded // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *CsmoduleSigningKeyAddedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(CsmoduleSigningKeyAdded)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(CsmoduleSigningKeyAdded)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *CsmoduleSigningKeyAddedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *CsmoduleSigningKeyAddedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// CsmoduleSigningKeyAdded represents a SigningKeyAdded event raised by the Csmodule contract.
+type CsmoduleSigningKeyAdded struct {
+	NodeOperatorId *big.Int
+	Pubkey         []byte
+	Raw            types.Log // Blockchain specific contextual infos
+}
+
+// FilterSigningKeyAdded is a free log retrieval operation binding the contract event 0xc77a17d6b857abe6d6e6c37301621bc72c4dd52fa8830fb54dfa715c04911a89.
+//
+// Solidity: event SigningKeyAdded(uint256 indexed nodeOperatorId, bytes pubkey)
+func (_Csmodule *CsmoduleFilterer) FilterSigningKeyAdded(opts *bind.FilterOpts, nodeOperatorId []*big.Int) (*CsmoduleSigningKeyAddedIterator, error) {
+
+	var nodeOperatorIdRule []interface{}
+	for _, nodeOperatorIdItem := range nodeOperatorId {
+		nodeOperatorIdRule = append(nodeOperatorIdRule, nodeOperatorIdItem)
+	}
+
+	logs, sub, err := _Csmodule.contract.FilterLogs(opts, "SigningKeyAdded", nodeOperatorIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return &CsmoduleSigningKeyAddedIterator{contract: _Csmodule.contract, event: "SigningKeyAdded", logs: logs, sub: sub}, nil
+}
+
+// WatchSigningKeyAdded is a free log subscription operation binding the contract event 0xc77a17d6b857abe6d6e6c37301621bc72c4dd52fa8830fb54dfa715c04911a89.
+//
+// Solidity: event SigningKeyAdded(uint256 indexed nodeOperatorId, bytes pubkey)
+func (_Csmodule *CsmoduleFilterer) WatchSigningKeyAdded(opts *bind.WatchOpts, sink chan<- *CsmoduleSigningKeyAdded, nodeOperatorId []*big.Int) (event.Subscription, error) {
+
+	var nodeOperatorIdRule []interface{}
+	for _, nodeOperatorIdItem := range nodeOperatorId {
+		nodeOperatorIdRule = append(nodeOperatorIdRule, nodeOperatorIdItem)
+	}
+
+	logs, sub, err := _Csmodule.contract.WatchLogs(opts, "SigningKeyAdded", nodeOperatorIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(CsmoduleSigningKeyAdded)
+				if err := _Csmodule.contract.UnpackLog(event, "SigningKeyAdded", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseSigningKeyAdded is a log parse operation binding the contract event 0xc77a17d6b857abe6d6e6c37301621bc72c4dd52fa8830fb54dfa715c04911a89.
+//
+// Solidity: event SigningKeyAdded(uint256 indexed nodeOperatorId, bytes pubkey)
+func (_Csmodule *CsmoduleFilterer) ParseSigningKeyAdded(log types.Log) (*CsmoduleSigningKeyAdded, error) {
+	event := new(CsmoduleSigningKeyAdded)
+	if err := _Csmodule.contract.UnpackLog(event, "SigningKeyAdded", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// CsmoduleSigningKeyRemovedIterator is returned from FilterSigningKeyRemoved and is used to iterate over the raw logs and unpacked data for SigningKeyRemoved events raised by the Csmodule contract.
+type CsmoduleSigningKeyRemovedIterator struct {
+	Event *CsmoduleSigningKeyRemoved // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *CsmoduleSigningKeyRemovedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(CsmoduleSigningKeyRemoved)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(CsmoduleSigningKeyRemoved)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *CsmoduleSigningKeyRemovedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *CsmoduleSigningKeyRemovedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// CsmoduleSigningKeyRemoved represents a SigningKeyRemoved event raised by the Csmodule contract.
+type CsmoduleSigningKeyRemoved struct {
+	NodeOperatorId *big.Int
+	Pubkey         []byte
+	Raw            types.Log // Blockchain specific contextual infos
+}
+
+// FilterSigningKeyRemoved is a free log retrieval operation binding the contract event 0xea4b75aaf57196f73d338cadf79ecd0a437902e2dd0d2c4c2cf3ea71b8ab27b9.
+//
+// Solidity: event SigningKeyRemoved(uint256 indexed nodeOperatorId, bytes pubkey)
+func (_Csmodule *CsmoduleFilterer) FilterSigningKeyRemoved(opts *bind.FilterOpts, nodeOperatorId []*big.Int) (*CsmoduleSigningKeyRemovedIterator, error) {
+
+	var nodeOperatorIdRule []interface{}
+	for _, nodeOperatorIdItem := range nodeOperatorId {
+		nodeOperatorIdRule = append(nodeOperatorIdRule, nodeOperatorIdItem)
+	}
+
+	logs, sub, err := _Csmodule.contract.FilterLogs(opts, "SigningKeyRemoved", nodeOperatorIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return &CsmoduleSigningKeyRemovedIterator{contract: _Csmodule.contract, event: "SigningKeyRemoved", logs: logs, sub: sub}, nil
+}
+
+// WatchSigningKeyRemoved is a free log subscription operation binding the contract event 0xea4b75aaf57196f73d338cadf79ecd0a437902e2dd0d2c4c2cf3ea71b8ab27b9.
+//
+// Solidity: event SigningKeyRemoved(uint256 indexed nodeOperatorId, bytes pubkey)
+func (_Csmodule *CsmoduleFilterer) WatchSigningKeyRemoved(opts *bind.WatchOpts, sink chan<- *CsmoduleSigningKeyRemoved, nodeOperatorId []*big.Int) (event.Subscription, error) {
+
+	var nodeOperatorIdRule []interface{}
+	for _, nodeOperatorIdItem := range nodeOperatorId {
+		nodeOperatorIdRule = append(nodeOperatorIdRule, nodeOperatorIdItem)
+	}
+
+	logs, sub, err := _Csmodule.contract.WatchLogs(opts, "SigningKeyRemoved", nodeOperatorIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(CsmoduleSigningKeyRemoved)
+				if err := _Csmodule.contract.UnpackLog(event, "SigningKeyRemoved", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseSigningKeyRemoved is a log parse operation binding the contract event 0xea4b75aaf57196f73d338cadf79ecd0a437902e2dd0d2c4c2cf3ea71b8ab27b9.
+//
+// Solidity: event SigningKeyRemoved(uint256 indexed nodeOperatorId, bytes pubkey)
+func (_Csmodule *CsmoduleFilterer) ParseSigningKeyRemoved(log types.Log) (*CsmoduleSigningKeyRemoved, error) {
+	event := new(CsmoduleSigningKeyRemoved)
+	if err := _Csmodule.contract.UnpackLog(event, "SigningKeyRemoved", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// CsmoduleStETHSharesRecoveredIterator is returned from FilterStETHSharesRecovered and is used to iterate over the raw logs and unpacked data for StETHSharesRecovered events raised by the Csmodule contract.
+type CsmoduleStETHSharesRecoveredIterator struct {
+	Event *CsmoduleStETHSharesRecovered // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *CsmoduleStETHSharesRecoveredIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(CsmoduleStETHSharesRecovered)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(CsmoduleStETHSharesRecovered)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *CsmoduleStETHSharesRecoveredIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *CsmoduleStETHSharesRecoveredIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// CsmoduleStETHSharesRecovered represents a StETHSharesRecovered event raised by the Csmodule contract.
+type CsmoduleStETHSharesRecovered struct {
+	Recipient common.Address
+	Shares    *big.Int
+	Raw       types.Log // Blockchain specific contextual infos
+}
+
+// FilterStETHSharesRecovered is a free log retrieval operation binding the contract event 0x426e7e0100db57255d4af4a46cd49552ef74f5f002bbdc8d4ebb6371c0070a02.
+//
+// Solidity: event StETHSharesRecovered(address indexed recipient, uint256 shares)
+func (_Csmodule *CsmoduleFilterer) FilterStETHSharesRecovered(opts *bind.FilterOpts, recipient []common.Address) (*CsmoduleStETHSharesRecoveredIterator, error) {
+
+	var recipientRule []interface{}
+	for _, recipientItem := range recipient {
+		recipientRule = append(recipientRule, recipientItem)
+	}
+
+	logs, sub, err := _Csmodule.contract.FilterLogs(opts, "StETHSharesRecovered", recipientRule)
+	if err != nil {
+		return nil, err
+	}
+	return &CsmoduleStETHSharesRecoveredIterator{contract: _Csmodule.contract, event: "StETHSharesRecovered", logs: logs, sub: sub}, nil
+}
+
+// WatchStETHSharesRecovered is a free log subscription operation binding the contract event 0x426e7e0100db57255d4af4a46cd49552ef74f5f002bbdc8d4ebb6371c0070a02.
+//
+// Solidity: event StETHSharesRecovered(address indexed recipient, uint256 shares)
+func (_Csmodule *CsmoduleFilterer) WatchStETHSharesRecovered(opts *bind.WatchOpts, sink chan<- *CsmoduleStETHSharesRecovered, recipient []common.Address) (event.Subscription, error) {
+
+	var recipientRule []interface{}
+	for _, recipientItem := range recipient {
+		recipientRule = append(recipientRule, recipientItem)
+	}
+
+	logs, sub, err := _Csmodule.contract.WatchLogs(opts, "StETHSharesRecovered", recipientRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(CsmoduleStETHSharesRecovered)
+				if err := _Csmodule.contract.UnpackLog(event, "StETHSharesRecovered", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseStETHSharesRecovered is a log parse operation binding the contract event 0x426e7e0100db57255d4af4a46cd49552ef74f5f002bbdc8d4ebb6371c0070a02.
+//
+// Solidity: event StETHSharesRecovered(address indexed recipient, uint256 shares)
+func (_Csmodule *CsmoduleFilterer) ParseStETHSharesRecovered(log types.Log) (*CsmoduleStETHSharesRecovered, error) {
+	event := new(CsmoduleStETHSharesRecovered)
+	if err := _Csmodule.contract.UnpackLog(event, "StETHSharesRecovered", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// CsmoduleStuckSigningKeysCountChangedIterator is returned from FilterStuckSigningKeysCountChanged and is used to iterate over the raw logs and unpacked data for StuckSigningKeysCountChanged events raised by the Csmodule contract.
+type CsmoduleStuckSigningKeysCountChangedIterator struct {
+	Event *CsmoduleStuckSigningKeysCountChanged // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *CsmoduleStuckSigningKeysCountChangedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(CsmoduleStuckSigningKeysCountChanged)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(CsmoduleStuckSigningKeysCountChanged)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *CsmoduleStuckSigningKeysCountChangedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *CsmoduleStuckSigningKeysCountChangedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// CsmoduleStuckSigningKeysCountChanged represents a StuckSigningKeysCountChanged event raised by the Csmodule contract.
+type CsmoduleStuckSigningKeysCountChanged struct {
+	NodeOperatorId *big.Int
+	StuckKeysCount *big.Int
+	Raw            types.Log // Blockchain specific contextual infos
+}
+
+// FilterStuckSigningKeysCountChanged is a free log retrieval operation binding the contract event 0xb4f5879eca27b32881cec7907d1310378e9b4c79927062fb7d4a321434b5b04a.
+//
+// Solidity: event StuckSigningKeysCountChanged(uint256 indexed nodeOperatorId, uint256 stuckKeysCount)
+func (_Csmodule *CsmoduleFilterer) FilterStuckSigningKeysCountChanged(opts *bind.FilterOpts, nodeOperatorId []*big.Int) (*CsmoduleStuckSigningKeysCountChangedIterator, error) {
+
+	var nodeOperatorIdRule []interface{}
+	for _, nodeOperatorIdItem := range nodeOperatorId {
+		nodeOperatorIdRule = append(nodeOperatorIdRule, nodeOperatorIdItem)
+	}
+
+	logs, sub, err := _Csmodule.contract.FilterLogs(opts, "StuckSigningKeysCountChanged", nodeOperatorIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return &CsmoduleStuckSigningKeysCountChangedIterator{contract: _Csmodule.contract, event: "StuckSigningKeysCountChanged", logs: logs, sub: sub}, nil
+}
+
+// WatchStuckSigningKeysCountChanged is a free log subscription operation binding the contract event 0xb4f5879eca27b32881cec7907d1310378e9b4c79927062fb7d4a321434b5b04a.
+//
+// Solidity: event StuckSigningKeysCountChanged(uint256 indexed nodeOperatorId, uint256 stuckKeysCount)
+func (_Csmodule *CsmoduleFilterer) WatchStuckSigningKeysCountChanged(opts *bind.WatchOpts, sink chan<- *CsmoduleStuckSigningKeysCountChanged, nodeOperatorId []*big.Int) (event.Subscription, error) {
+
+	var nodeOperatorIdRule []interface{}
+	for _, nodeOperatorIdItem := range nodeOperatorId {
+		nodeOperatorIdRule = append(nodeOperatorIdRule, nodeOperatorIdItem)
+	}
+
+	logs, sub, err := _Csmodule.contract.WatchLogs(opts, "StuckSigningKeysCountChanged", nodeOperatorIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(CsmoduleStuckSigningKeysCountChanged)
+				if err := _Csmodule.contract.UnpackLog(event, "StuckSigningKeysCountChanged", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseStuckSigningKeysCountChanged is a log parse operation binding the contract event 0xb4f5879eca27b32881cec7907d1310378e9b4c79927062fb7d4a321434b5b04a.
+//
+// Solidity: event StuckSigningKeysCountChanged(uint256 indexed nodeOperatorId, uint256 stuckKeysCount)
+func (_Csmodule *CsmoduleFilterer) ParseStuckSigningKeysCountChanged(log types.Log) (*CsmoduleStuckSigningKeysCountChanged, error) {
+	event := new(CsmoduleStuckSigningKeysCountChanged)
+	if err := _Csmodule.contract.UnpackLog(event, "StuckSigningKeysCountChanged", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// CsmoduleTargetValidatorsCountChangedIterator is returned from FilterTargetValidatorsCountChanged and is used to iterate over the raw logs and unpacked data for TargetValidatorsCountChanged events raised by the Csmodule contract.
+type CsmoduleTargetValidatorsCountChangedIterator struct {
+	Event *CsmoduleTargetValidatorsCountChanged // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *CsmoduleTargetValidatorsCountChangedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(CsmoduleTargetValidatorsCountChanged)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(CsmoduleTargetValidatorsCountChanged)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *CsmoduleTargetValidatorsCountChangedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *CsmoduleTargetValidatorsCountChangedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// CsmoduleTargetValidatorsCountChanged represents a TargetValidatorsCountChanged event raised by the Csmodule contract.
+type CsmoduleTargetValidatorsCountChanged struct {
+	NodeOperatorId        *big.Int
+	TargetLimitMode       *big.Int
+	TargetValidatorsCount *big.Int
+	Raw                   types.Log // Blockchain specific contextual infos
+}
+
+// FilterTargetValidatorsCountChanged is a free log retrieval operation binding the contract event 0xf92eb109ce5b449e9b121c352c6aeb4319538a90738cb95d84f08e41274e92d2.
+//
+// Solidity: event TargetValidatorsCountChanged(uint256 indexed nodeOperatorId, uint256 targetLimitMode, uint256 targetValidatorsCount)
+func (_Csmodule *CsmoduleFilterer) FilterTargetValidatorsCountChanged(opts *bind.FilterOpts, nodeOperatorId []*big.Int) (*CsmoduleTargetValidatorsCountChangedIterator, error) {
+
+	var nodeOperatorIdRule []interface{}
+	for _, nodeOperatorIdItem := range nodeOperatorId {
+		nodeOperatorIdRule = append(nodeOperatorIdRule, nodeOperatorIdItem)
+	}
+
+	logs, sub, err := _Csmodule.contract.FilterLogs(opts, "TargetValidatorsCountChanged", nodeOperatorIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return &CsmoduleTargetValidatorsCountChangedIterator{contract: _Csmodule.contract, event: "TargetValidatorsCountChanged", logs: logs, sub: sub}, nil
+}
+
+// WatchTargetValidatorsCountChanged is a free log subscription operation binding the contract event 0xf92eb109ce5b449e9b121c352c6aeb4319538a90738cb95d84f08e41274e92d2.
+//
+// Solidity: event TargetValidatorsCountChanged(uint256 indexed nodeOperatorId, uint256 targetLimitMode, uint256 targetValidatorsCount)
+func (_Csmodule *CsmoduleFilterer) WatchTargetValidatorsCountChanged(opts *bind.WatchOpts, sink chan<- *CsmoduleTargetValidatorsCountChanged, nodeOperatorId []*big.Int) (event.Subscription, error) {
+
+	var nodeOperatorIdRule []interface{}
+	for _, nodeOperatorIdItem := range nodeOperatorId {
+		nodeOperatorIdRule = append(nodeOperatorIdRule, nodeOperatorIdItem)
+	}
+
+	logs, sub, err := _Csmodule.contract.WatchLogs(opts, "TargetValidatorsCountChanged", nodeOperatorIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(CsmoduleTargetValidatorsCountChanged)
+				if err := _Csmodule.contract.UnpackLog(event, "TargetValidatorsCountChanged", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseTargetValidatorsCountChanged is a log parse operation binding the contract event 0xf92eb109ce5b449e9b121c352c6aeb4319538a90738cb95d84f08e41274e92d2.
+//
+// Solidity: event TargetValidatorsCountChanged(uint256 indexed nodeOperatorId, uint256 targetLimitMode, uint256 targetValidatorsCount)
+func (_Csmodule *CsmoduleFilterer) ParseTargetValidatorsCountChanged(log types.Log) (*CsmoduleTargetValidatorsCountChanged, error) {
+	event := new(CsmoduleTargetValidatorsCountChanged)
+	if err := _Csmodule.contract.UnpackLog(event, "TargetValidatorsCountChanged", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// CsmoduleTotalSigningKeysCountChangedIterator is returned from FilterTotalSigningKeysCountChanged and is used to iterate over the raw logs and unpacked data for TotalSigningKeysCountChanged events raised by the Csmodule contract.
+type CsmoduleTotalSigningKeysCountChangedIterator struct {
+	Event *CsmoduleTotalSigningKeysCountChanged // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *CsmoduleTotalSigningKeysCountChangedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(CsmoduleTotalSigningKeysCountChanged)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(CsmoduleTotalSigningKeysCountChanged)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *CsmoduleTotalSigningKeysCountChangedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *CsmoduleTotalSigningKeysCountChangedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// CsmoduleTotalSigningKeysCountChanged represents a TotalSigningKeysCountChanged event raised by the Csmodule contract.
+type CsmoduleTotalSigningKeysCountChanged struct {
+	NodeOperatorId *big.Int
+	TotalKeysCount *big.Int
+	Raw            types.Log // Blockchain specific contextual infos
+}
+
+// FilterTotalSigningKeysCountChanged is a free log retrieval operation binding the contract event 0xdd01838a366ae4dc9a86e1922512c0716abebc9a440baae0e22d2dec578223f0.
+//
+// Solidity: event TotalSigningKeysCountChanged(uint256 indexed nodeOperatorId, uint256 totalKeysCount)
+func (_Csmodule *CsmoduleFilterer) FilterTotalSigningKeysCountChanged(opts *bind.FilterOpts, nodeOperatorId []*big.Int) (*CsmoduleTotalSigningKeysCountChangedIterator, error) {
+
+	var nodeOperatorIdRule []interface{}
+	for _, nodeOperatorIdItem := range nodeOperatorId {
+		nodeOperatorIdRule = append(nodeOperatorIdRule, nodeOperatorIdItem)
+	}
+
+	logs, sub, err := _Csmodule.contract.FilterLogs(opts, "TotalSigningKeysCountChanged", nodeOperatorIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return &CsmoduleTotalSigningKeysCountChangedIterator{contract: _Csmodule.contract, event: "TotalSigningKeysCountChanged", logs: logs, sub: sub}, nil
+}
+
+// WatchTotalSigningKeysCountChanged is a free log subscription operation binding the contract event 0xdd01838a366ae4dc9a86e1922512c0716abebc9a440baae0e22d2dec578223f0.
+//
+// Solidity: event TotalSigningKeysCountChanged(uint256 indexed nodeOperatorId, uint256 totalKeysCount)
+func (_Csmodule *CsmoduleFilterer) WatchTotalSigningKeysCountChanged(opts *bind.WatchOpts, sink chan<- *CsmoduleTotalSigningKeysCountChanged, nodeOperatorId []*big.Int) (event.Subscription, error) {
+
+	var nodeOperatorIdRule []interface{}
+	for _, nodeOperatorIdItem := range nodeOperatorId {
+		nodeOperatorIdRule = append(nodeOperatorIdRule, nodeOperatorIdItem)
+	}
+
+	logs, sub, err := _Csmodule.contract.WatchLogs(opts, "TotalSigningKeysCountChanged", nodeOperatorIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(CsmoduleTotalSigningKeysCountChanged)
+				if err := _Csmodule.contract.UnpackLog(event, "TotalSigningKeysCountChanged", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseTotalSigningKeysCountChanged is a log parse operation binding the contract event 0xdd01838a366ae4dc9a86e1922512c0716abebc9a440baae0e22d2dec578223f0.
+//
+// Solidity: event TotalSigningKeysCountChanged(uint256 indexed nodeOperatorId, uint256 totalKeysCount)
+func (_Csmodule *CsmoduleFilterer) ParseTotalSigningKeysCountChanged(log types.Log) (*CsmoduleTotalSigningKeysCountChanged, error) {
+	event := new(CsmoduleTotalSigningKeysCountChanged)
+	if err := _Csmodule.contract.UnpackLog(event, "TotalSigningKeysCountChanged", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// CsmoduleVettedSigningKeysCountChangedIterator is returned from FilterVettedSigningKeysCountChanged and is used to iterate over the raw logs and unpacked data for VettedSigningKeysCountChanged events raised by the Csmodule contract.
+type CsmoduleVettedSigningKeysCountChangedIterator struct {
+	Event *CsmoduleVettedSigningKeysCountChanged // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *CsmoduleVettedSigningKeysCountChangedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(CsmoduleVettedSigningKeysCountChanged)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(CsmoduleVettedSigningKeysCountChanged)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *CsmoduleVettedSigningKeysCountChangedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *CsmoduleVettedSigningKeysCountChangedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// CsmoduleVettedSigningKeysCountChanged represents a VettedSigningKeysCountChanged event raised by the Csmodule contract.
+type CsmoduleVettedSigningKeysCountChanged struct {
+	NodeOperatorId  *big.Int
+	VettedKeysCount *big.Int
+	Raw             types.Log // Blockchain specific contextual infos
+}
+
+// FilterVettedSigningKeysCountChanged is a free log retrieval operation binding the contract event 0x947f955eec7e1f626bee3afd2aa47b5de04ddcdd3fe78dc8838213015ef58dfd.
+//
+// Solidity: event VettedSigningKeysCountChanged(uint256 indexed nodeOperatorId, uint256 vettedKeysCount)
+func (_Csmodule *CsmoduleFilterer) FilterVettedSigningKeysCountChanged(opts *bind.FilterOpts, nodeOperatorId []*big.Int) (*CsmoduleVettedSigningKeysCountChangedIterator, error) {
+
+	var nodeOperatorIdRule []interface{}
+	for _, nodeOperatorIdItem := range nodeOperatorId {
+		nodeOperatorIdRule = append(nodeOperatorIdRule, nodeOperatorIdItem)
+	}
+
+	logs, sub, err := _Csmodule.contract.FilterLogs(opts, "VettedSigningKeysCountChanged", nodeOperatorIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return &CsmoduleVettedSigningKeysCountChangedIterator{contract: _Csmodule.contract, event: "VettedSigningKeysCountChanged", logs: logs, sub: sub}, nil
+}
+
+// WatchVettedSigningKeysCountChanged is a free log subscription operation binding the contract event 0x947f955eec7e1f626bee3afd2aa47b5de04ddcdd3fe78dc8838213015ef58dfd.
+//
+// Solidity: event VettedSigningKeysCountChanged(uint256 indexed nodeOperatorId, uint256 vettedKeysCount)
+func (_Csmodule *CsmoduleFilterer) WatchVettedSigningKeysCountChanged(opts *bind.WatchOpts, sink chan<- *CsmoduleVettedSigningKeysCountChanged, nodeOperatorId []*big.Int) (event.Subscription, error) {
+
+	var nodeOperatorIdRule []interface{}
+	for _, nodeOperatorIdItem := range nodeOperatorId {
+		nodeOperatorIdRule = append(nodeOperatorIdRule, nodeOperatorIdItem)
+	}
+
+	logs, sub, err := _Csmodule.contract.WatchLogs(opts, "VettedSigningKeysCountChanged", nodeOperatorIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(CsmoduleVettedSigningKeysCountChanged)
+				if err := _Csmodule.contract.UnpackLog(event, "VettedSigningKeysCountChanged", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseVettedSigningKeysCountChanged is a log parse operation binding the contract event 0x947f955eec7e1f626bee3afd2aa47b5de04ddcdd3fe78dc8838213015ef58dfd.
+//
+// Solidity: event VettedSigningKeysCountChanged(uint256 indexed nodeOperatorId, uint256 vettedKeysCount)
+func (_Csmodule *CsmoduleFilterer) ParseVettedSigningKeysCountChanged(log types.Log) (*CsmoduleVettedSigningKeysCountChanged, error) {
+	event := new(CsmoduleVettedSigningKeysCountChanged)
+	if err := _Csmodule.contract.UnpackLog(event, "VettedSigningKeysCountChanged", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// CsmoduleVettedSigningKeysCountDecreasedIterator is returned from FilterVettedSigningKeysCountDecreased and is used to iterate over the raw logs and unpacked data for VettedSigningKeysCountDecreased events raised by the Csmodule contract.
+type CsmoduleVettedSigningKeysCountDecreasedIterator struct {
+	Event *CsmoduleVettedSigningKeysCountDecreased // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *CsmoduleVettedSigningKeysCountDecreasedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(CsmoduleVettedSigningKeysCountDecreased)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(CsmoduleVettedSigningKeysCountDecreased)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *CsmoduleVettedSigningKeysCountDecreasedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *CsmoduleVettedSigningKeysCountDecreasedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// CsmoduleVettedSigningKeysCountDecreased represents a VettedSigningKeysCountDecreased event raised by the Csmodule contract.
+type CsmoduleVettedSigningKeysCountDecreased struct {
+	NodeOperatorId *big.Int
+	Raw            types.Log // Blockchain specific contextual infos
+}
+
+// FilterVettedSigningKeysCountDecreased is a free log retrieval operation binding the contract event 0xe5725d045d5c47bd1483feba445e395dc8647486963e6d54aad9ed03ff7d6ce6.
+//
+// Solidity: event VettedSigningKeysCountDecreased(uint256 indexed nodeOperatorId)
+func (_Csmodule *CsmoduleFilterer) FilterVettedSigningKeysCountDecreased(opts *bind.FilterOpts, nodeOperatorId []*big.Int) (*CsmoduleVettedSigningKeysCountDecreasedIterator, error) {
+
+	var nodeOperatorIdRule []interface{}
+	for _, nodeOperatorIdItem := range nodeOperatorId {
+		nodeOperatorIdRule = append(nodeOperatorIdRule, nodeOperatorIdItem)
+	}
+
+	logs, sub, err := _Csmodule.contract.FilterLogs(opts, "VettedSigningKeysCountDecreased", nodeOperatorIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return &CsmoduleVettedSigningKeysCountDecreasedIterator{contract: _Csmodule.contract, event: "VettedSigningKeysCountDecreased", logs: logs, sub: sub}, nil
+}
+
+// WatchVettedSigningKeysCountDecreased is a free log subscription operation binding the contract event 0xe5725d045d5c47bd1483feba445e395dc8647486963e6d54aad9ed03ff7d6ce6.
+//
+// Solidity: event VettedSigningKeysCountDecreased(uint256 indexed nodeOperatorId)
+func (_Csmodule *CsmoduleFilterer) WatchVettedSigningKeysCountDecreased(opts *bind.WatchOpts, sink chan<- *CsmoduleVettedSigningKeysCountDecreased, nodeOperatorId []*big.Int) (event.Subscription, error) {
+
+	var nodeOperatorIdRule []interface{}
+	for _, nodeOperatorIdItem := range nodeOperatorId {
+		nodeOperatorIdRule = append(nodeOperatorIdRule, nodeOperatorIdItem)
+	}
+
+	logs, sub, err := _Csmodule.contract.WatchLogs(opts, "VettedSigningKeysCountDecreased", nodeOperatorIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(CsmoduleVettedSigningKeysCountDecreased)
+				if err := _Csmodule.contract.UnpackLog(event, "VettedSigningKeysCountDecreased", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseVettedSigningKeysCountDecreased is a log parse operation binding the contract event 0xe5725d045d5c47bd1483feba445e395dc8647486963e6d54aad9ed03ff7d6ce6.
+//
+// Solidity: event VettedSigningKeysCountDecreased(uint256 indexed nodeOperatorId)
+func (_Csmodule *CsmoduleFilterer) ParseVettedSigningKeysCountDecreased(log types.Log) (*CsmoduleVettedSigningKeysCountDecreased, error) {
+	event := new(CsmoduleVettedSigningKeysCountDecreased)
+	if err := _Csmodule.contract.UnpackLog(event, "VettedSigningKeysCountDecreased", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// CsmoduleWithdrawalSubmittedIterator is returned from FilterWithdrawalSubmitted and is used to iterate over the raw logs and unpacked data for WithdrawalSubmitted events raised by the Csmodule contract.
+type CsmoduleWithdrawalSubmittedIterator struct {
+	Event *CsmoduleWithdrawalSubmitted // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *CsmoduleWithdrawalSubmittedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(CsmoduleWithdrawalSubmitted)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(CsmoduleWithdrawalSubmitted)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *CsmoduleWithdrawalSubmittedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *CsmoduleWithdrawalSubmittedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// CsmoduleWithdrawalSubmitted represents a WithdrawalSubmitted event raised by the Csmodule contract.
+type CsmoduleWithdrawalSubmitted struct {
+	NodeOperatorId *big.Int
+	KeyIndex       *big.Int
+	Amount         *big.Int
+	Raw            types.Log // Blockchain specific contextual infos
+}
+
+// FilterWithdrawalSubmitted is a free log retrieval operation binding the contract event 0xcb2f99f65711a7d6df7f552255b910bf59f09fcd5935f44c170b4cb0d1b50995.
+//
+// Solidity: event WithdrawalSubmitted(uint256 indexed nodeOperatorId, uint256 keyIndex, uint256 amount)
+func (_Csmodule *CsmoduleFilterer) FilterWithdrawalSubmitted(opts *bind.FilterOpts, nodeOperatorId []*big.Int) (*CsmoduleWithdrawalSubmittedIterator, error) {
+
+	var nodeOperatorIdRule []interface{}
+	for _, nodeOperatorIdItem := range nodeOperatorId {
+		nodeOperatorIdRule = append(nodeOperatorIdRule, nodeOperatorIdItem)
+	}
+
+	logs, sub, err := _Csmodule.contract.FilterLogs(opts, "WithdrawalSubmitted", nodeOperatorIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return &CsmoduleWithdrawalSubmittedIterator{contract: _Csmodule.contract, event: "WithdrawalSubmitted", logs: logs, sub: sub}, nil
+}
+
+// WatchWithdrawalSubmitted is a free log subscription operation binding the contract event 0xcb2f99f65711a7d6df7f552255b910bf59f09fcd5935f44c170b4cb0d1b50995.
+//
+// Solidity: event WithdrawalSubmitted(uint256 indexed nodeOperatorId, uint256 keyIndex, uint256 amount)
+func (_Csmodule *CsmoduleFilterer) WatchWithdrawalSubmitted(opts *bind.WatchOpts, sink chan<- *CsmoduleWithdrawalSubmitted, nodeOperatorId []*big.Int) (event.Subscription, error) {
+
+	var nodeOperatorIdRule []interface{}
+	for _, nodeOperatorIdItem := range nodeOperatorId {
+		nodeOperatorIdRule = append(nodeOperatorIdRule, nodeOperatorIdItem)
+	}
+
+	logs, sub, err := _Csmodule.contract.WatchLogs(opts, "WithdrawalSubmitted", nodeOperatorIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(CsmoduleWithdrawalSubmitted)
+				if err := _Csmodule.contract.UnpackLog(event, "WithdrawalSubmitted", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseWithdrawalSubmitted is a log parse operation binding the contract event 0xcb2f99f65711a7d6df7f552255b910bf59f09fcd5935f44c170b4cb0d1b50995.
+//
+// Solidity: event WithdrawalSubmitted(uint256 indexed nodeOperatorId, uint256 keyIndex, uint256 amount)
+func (_Csmodule *CsmoduleFilterer) ParseWithdrawalSubmitted(log types.Log) (*CsmoduleWithdrawalSubmitted, error) {
+	event := new(CsmoduleWithdrawalSubmitted)
+	if err := _Csmodule.contract.UnpackLog(event, "WithdrawalSubmitted", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}

--- a/internal/lido/contracts/mevboostrelaylist/MEVBoostRelayAllowedList.go
+++ b/internal/lido/contracts/mevboostrelaylist/MEVBoostRelayAllowedList.go
@@ -1,0 +1,1422 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package mevboostrelaylist
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// Struct0 is an auto generated low-level Go binding around an user-defined struct.
+type Struct0 struct {
+	Uri         string
+	Operator    string
+	IsMandatory bool
+	Description string
+}
+
+// MevboostrelaylistMetaData contains all meta data concerning the Mevboostrelaylist contract.
+var MevboostrelaylistMetaData = &bind.MetaData{
+	ABI: "[{\"name\":\"RelayAdded\",\"inputs\":[{\"name\":\"uri_hash\",\"type\":\"string\",\"indexed\":true},{\"name\":\"relay\",\"type\":\"tuple\",\"components\":[{\"name\":\"uri\",\"type\":\"string\"},{\"name\":\"operator\",\"type\":\"string\"},{\"name\":\"is_mandatory\",\"type\":\"bool\"},{\"name\":\"description\",\"type\":\"string\"}],\"indexed\":false}],\"anonymous\":false,\"type\":\"event\"},{\"name\":\"RelayRemoved\",\"inputs\":[{\"name\":\"uri_hash\",\"type\":\"string\",\"indexed\":true},{\"name\":\"uri\",\"type\":\"string\",\"indexed\":false}],\"anonymous\":false,\"type\":\"event\"},{\"name\":\"AllowedListUpdated\",\"inputs\":[{\"name\":\"allowed_list_version\",\"type\":\"uint256\",\"indexed\":true}],\"anonymous\":false,\"type\":\"event\"},{\"name\":\"OwnerChanged\",\"inputs\":[{\"name\":\"new_owner\",\"type\":\"address\",\"indexed\":true}],\"anonymous\":false,\"type\":\"event\"},{\"name\":\"ManagerChanged\",\"inputs\":[{\"name\":\"new_manager\",\"type\":\"address\",\"indexed\":true}],\"anonymous\":false,\"type\":\"event\"},{\"name\":\"ERC20Recovered\",\"inputs\":[{\"name\":\"token\",\"type\":\"address\",\"indexed\":true},{\"name\":\"amount\",\"type\":\"uint256\",\"indexed\":false},{\"name\":\"recipient\",\"type\":\"address\",\"indexed\":true}],\"anonymous\":false,\"type\":\"event\"},{\"stateMutability\":\"nonpayable\",\"type\":\"constructor\",\"inputs\":[{\"name\":\"owner\",\"type\":\"address\"}],\"outputs\":[]},{\"stateMutability\":\"view\",\"type\":\"function\",\"name\":\"get_relays_amount\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\"}]},{\"stateMutability\":\"view\",\"type\":\"function\",\"name\":\"get_owner\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\"}]},{\"stateMutability\":\"view\",\"type\":\"function\",\"name\":\"get_manager\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\"}]},{\"stateMutability\":\"view\",\"type\":\"function\",\"name\":\"get_relays\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"tuple[]\",\"components\":[{\"name\":\"uri\",\"type\":\"string\"},{\"name\":\"operator\",\"type\":\"string\"},{\"name\":\"is_mandatory\",\"type\":\"bool\"},{\"name\":\"description\",\"type\":\"string\"}]}]},{\"stateMutability\":\"view\",\"type\":\"function\",\"name\":\"get_relay_by_uri\",\"inputs\":[{\"name\":\"relay_uri\",\"type\":\"string\"}],\"outputs\":[{\"name\":\"\",\"type\":\"tuple\",\"components\":[{\"name\":\"uri\",\"type\":\"string\"},{\"name\":\"operator\",\"type\":\"string\"},{\"name\":\"is_mandatory\",\"type\":\"bool\"},{\"name\":\"description\",\"type\":\"string\"}]}]},{\"stateMutability\":\"view\",\"type\":\"function\",\"name\":\"get_allowed_list_version\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\"}]},{\"stateMutability\":\"nonpayable\",\"type\":\"function\",\"name\":\"add_relay\",\"inputs\":[{\"name\":\"uri\",\"type\":\"string\"},{\"name\":\"operator\",\"type\":\"string\"},{\"name\":\"is_mandatory\",\"type\":\"bool\"},{\"name\":\"description\",\"type\":\"string\"}],\"outputs\":[]},{\"stateMutability\":\"nonpayable\",\"type\":\"function\",\"name\":\"remove_relay\",\"inputs\":[{\"name\":\"uri\",\"type\":\"string\"}],\"outputs\":[]},{\"stateMutability\":\"nonpayable\",\"type\":\"function\",\"name\":\"change_owner\",\"inputs\":[{\"name\":\"owner\",\"type\":\"address\"}],\"outputs\":[]},{\"stateMutability\":\"nonpayable\",\"type\":\"function\",\"name\":\"set_manager\",\"inputs\":[{\"name\":\"manager\",\"type\":\"address\"}],\"outputs\":[]},{\"stateMutability\":\"nonpayable\",\"type\":\"function\",\"name\":\"dismiss_manager\",\"inputs\":[],\"outputs\":[]},{\"stateMutability\":\"nonpayable\",\"type\":\"function\",\"name\":\"recover_erc20\",\"inputs\":[{\"name\":\"token\",\"type\":\"address\"},{\"name\":\"amount\",\"type\":\"uint256\"},{\"name\":\"recipient\",\"type\":\"address\"}],\"outputs\":[]},{\"stateMutability\":\"nonpayable\",\"type\":\"fallback\"}]",
+	Bin: "0x60206115ff6000396000518060a01c6115fa57604052346115fa5760405161007e5760126060527f7a65726f206f776e65722061646472657373000000000000000000000000000060805260605060605180608001601f826000031636823750506308c379a06020526020604052601f19601f6060510116604401603cfd5b60405160005561156361009661000039611563610000f36003361161000c57611181565b60003560e01c346115515763312c3165811861003657600436186115515760025460405260206040f35b630ac298dc811861005557600436186115515760005460405260206040f35b639e4a0fc4811861007457600436186115515760015460405260206040f35b6304e469ea81186102545760043618611551576020806040528060400160006002548083528060051b6000826028811161155157801561024057905b828160051b60208801015260648102600301836020880101608080825280820183548082526001850160208301600083601f0160051c6020811161155157801561010c57905b808401548160051b8401526001018181186100f6575b50505050508051806020830101601f82600003163682375050601f19601f825160200101169050810190508060208301526021830181830181548082526001830160208301600083601f0160051c6020811161155157801561018057905b808401548160051b84015260010181811861016a575b50505050508051806020830101601f82600003163682375050601f19601f825160200101169050905081019050604283015460408301528060608301526043830181830181548082526001830160208301600083601f0160051c6020811161155157801561020057905b808401548160051b8401526001018181186101ea575b50505050508051806020830101601f82600003163682375050601f19601f82516020010116905090508101905090509050830192506001018181186100b0575b505082016020019150509050810190506040f35b63f5f33c7b81186104b457604436106115515760043560040161040081351161155157803580611120526020820181816111403750505061112051806040528060608261114060045afa50506102ab611560611187565b61156051611540526115405119610322576015611560527f6e6f2072656c61792077697468207468652055524900000000000000000000006115805261156050611560518061158001601f826000031636823750506308c379a061152052602061154052601f19601f61156051011660440161153cfd5b6020806115605260646115405160025481101561155157026003018161156001608080825280820183548082526001850160208301600083601f0160051c6020811161155157801561038657905b808401548160051b840152600101818118610370575b50505050508051806020830101601f82600003163682375050601f19601f825160200101169050810190508060208301526021830181830181548082526001830160208301600083601f0160051c602081116115515780156103fa57905b808401548160051b8401526001018181186103e4575b50505050508051806020830101601f82600003163682375050601f19601f825160200101169050905081019050604283015460408301528060608301526043830181830181548082526001830160208301600083601f0160051c6020811161155157801561047a57905b808401548160051b840152600101818118610464575b50505050508051806020830101601f82600003163682375050601f19601f8251602001011690509050810190509050905081019050611560f35b6376650ad381186104d4576004361861155157610fa35460405260206040f35b632e21ecef81186109805760e43610611551576004356004016104008135116115515780358061112052602082018181611140375050506024356004016104008135116115515780358061154052602082018181611560375050506044358060011c611551576119605260643560040161040081351161155157803580611980526020820181816119a03750505061056a6112ed565b6000611da052611da08051602082012090506111205161114020186105ef57601b6121c0527f72656c617920555249206d757374206e6f7420626520656d70747900000000006121e0526121c0506121c051806121e001601f826000031636823750506308c379a06121805260206121a052601f19601f6121c051011660440161219cfd5b6027600254111561066057601c611da0527f616c7265616479206d6178206e756d626572206f662072656c61797300000000611dc052611da050611da05180611dc001601f826000031636823750506308c379a0611d60526020611d8052601f19601f611da0510116604401611d7cfd5b61112051806040528060608261114060045afa5050610680611dc0611187565b611dc051611da052611da051191561071d576021611dc0527f72656c61792077697468207468652055524920616c7265616479206578697374611de0527f7300000000000000000000000000000000000000000000000000000000000000611e0052611dc050611dc05180611de001601f826000031636823750506308c379a0611d80526020611da052601f19601f611dc0510116604401611d9cfd5b6111205180611dc05280611de08261114060045afa505061154051806121e052806122008261156060045afa5050611960516126005261198051806126205280612640826119a060045afa505060025460278111611551576001810160025560648102600301611dc05180825560018201600082601f0160051c602081116115515780156107bf57905b8060051b611de00151818401556001018181186107a7575b505050506121e05180602183015560016021830101600082601f0160051c6020811161155157801561080557905b8060051b6122000151818401556001018181186107ed575b505050506126005160428201556126205180604383015560016043830101600082601f0160051c6020811161155157801561085457905b8060051b61264001518184015560010181811861083c575b505050505050610862611374565b61112051611140207feee5faa84d45af657ab405cdbf2c6a8a6d466e83fa694a358fee5ff84431d0bf602080612a405280612a40016080808252808201611dc05180825260208201818183611de060045afa5050508051806020830101601f82600003163682375050601f19601f825160200101169050810190508060208301528082016121e0518082526020820181818361220060045afa5050508051806020830101601f82600003163682375050601f19601f82516020010116905081019050612600516040830152806060830152808201612620518082526020820181818361264060045afa5050508051806020830101601f82600003163682375050601f19601f82516020010116905081019050905081019050612a40a2005b63f5a70a808118610ca45760443610611551576004356004016104008135116115515780358061112052602082018181611140375050506109bf6112ed565b600061154052611540805160208201209050611120516111402018610a4457601b611960527f72656c617920555249206d757374206e6f7420626520656d70747900000000006119805261196050611960518061198001601f826000031636823750506308c379a061192052602061194052601f19601f61196051011660440161193cfd5b6002546115405261112051806040528060608261114060045afa5050610a6b611580611187565b6115805161156052611540516115605110610ae6576015611580527f6e6f2072656c61792077697468207468652055524900000000000000000000006115a0526115805061158051806115a001601f826000031636823750506308c379a061154052602061156052601f19601f61158051011660440161155cfd5b61154051600181038181116115515790506115605114610c1257606461156051600254811015611551570260030160646115405160018103818111611551579050600254811015611551570260030180548083556001820160018401600083601f0160051c60208111611551578015610b6e57905b8084015481840155600101818118610b5b575b50505050506021810180548060218501556001820160016021860101600083601f0160051c60208111611551578015610bb657905b8084015481840155600101818118610ba3575b505050505050604281015460428301556043810180548060438501556001820160016043860101600083601f0160051c60208111611551578015610c0957905b8084015481840155600101818118610bf6575b50505050505050505b6001600254801561155157038060025550610c2b611374565b61112051611140207fef756634af7ee7210f786ec0f91930afa63fda84d9ff6493ae681c332055dadb602080611580528061158001611120518082526020820181818361114060045afa5050508051806020830101601f82600003163682375050601f19601f82516020010116905081019050611580a2005b63253c8bd48118610dca5760243618611551576004358060a01c61155157608052610ccd6113ba565b608051610d3157601260a0527f7a65726f206f776e65722061646472657373000000000000000000000000000060c05260a05060a0518060c001601f826000031636823750506308c379a06060526020608052601f19601f60a0510116604401607cfd5b60005460805118610d9957600a60a0527f73616d65206f776e65720000000000000000000000000000000000000000000060c05260a05060a0518060c001601f826000031636823750506308c379a06060526020608052601f19601f60a0510116604401607cfd5b6080516000556080517fa2ea9883a321a3e97b8266c2b078bfeec6d50c711ed71f874a90d500ae2eaf36600060a0a2005b639aece83e8118610ef05760243618611551576004358060a01c61155157608052610df36113ba565b608051610e5757601460a0527f7a65726f206d616e61676572206164647265737300000000000000000000000060c05260a05060a0518060c001601f826000031636823750506308c379a06060526020608052601f19601f60a0510116604401607cfd5b60015460805118610ebf57600c60a0527f73616d65206d616e61676572000000000000000000000000000000000000000060c05260a05060a0518060c001601f826000031636823750506308c379a06060526020608052601f19601f60a0510116604401607cfd5b6080516001556080517f198db6e425fb8aafd1823c6ca50be2d51e5764571a5ae0f0f21c6812e45def0b600060a0a2005b63417a02b48118610f9e576004361861155157610f0b6113ba565b600154610f6f57600e6080527f6e6f206d616e616765722073657400000000000000000000000000000000000060a0526080506080518060a001601f826000031636823750506308c379a06040526020606052601f19601f6080510116604401605cfd5b600060015560007f198db6e425fb8aafd1823c6ca50be2d51e5764571a5ae0f0f21c6812e45def0b60006080a2005b63edd885b4811861117f5760643618611551576004358060a01c611551576101e0526044358060a01c6115515761020052610fd76113ba565b6101e051611045576012610220527f7a65726f20746f6b656e206164647265737300000000000000000000000000006102405261022050610220518061024001601f826000031636823750506308c379a06101e052602061020052601f19601f6102205101166044016101fcfd5b610200516110b3576016610220527f7a65726f20726563697069656e742061646472657373000000000000000000006102405261022050610220518061024001601f826000031636823750506308c379a06101e052602061020052601f19601f6102205101166044016101fcfd5b6101e0513b611122576011610220527f656f6120746f6b656e20616464726573730000000000000000000000000000006102405261022050610220518061024001601f826000031636823750506308c379a06101e052602061020052601f19601f6102205101166044016101fcfd5b6024351561117d576101e05160405261020051606052602435608052611146611423565b610200516101e0517f8619312ed4eff1cf9f0116e6db2f49d9570a86f0350d1c5ad1bd0f7b0cf9e132602435610220526020610220a35b005b505b60006000fd5b7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff610460526000610480526000600254602881116115515780156112e257905b606481026003018054806104a05260018201600082601f0160051c6020811161155157801561120a57905b808301548160051b6104c001526001018181186111f2575b50505050602181018054806108c05260018201600082601f0160051c6020811161155157801561124e57905b808301548160051b6108e00152600101818118611236575b50505050506042810154610ce05260438101805480610d005260018201600082601f0160051c6020811161155157801561129c57905b808301548160051b610d200152600101818118611284575b5050505050506040516060206104a0516104c020186112c25761048051610460526112e2565b6104805160018101818110611551579050610480526001018181186111c7575b505061046051815250565b60005433186112fd576001611311565b600154331861130e57331515611311565b60005b61137257601f6040527f6d73672e73656e646572206e6f74206f776e6572206f72206d616e616765720060605260405060405180606001601f826000031636823750506308c379a06000526020602052601f19601f6040510116604401601cfd5b565b610fa35460018101818110611551579050604052604051610fa3556040517f49f5627aa055ec3fcd474f99c8b7799b798c04af7b9f215305512c867e5a183960006060a2565b6000543318156114215760146040527f6d73672e73656e646572206e6f74206f776e657200000000000000000000000060605260405060405180606001601f826000031636823750506308c379a06000526020602052601f19601f6040510116604401601cfd5b565b6000600460e0527fa9059cbb000000000000000000000000000000000000000000000000000000006101005260e08051602082018361014001815181525050808301925050506060518161014001526020810190506080518161014001526020810190508061012052610120505060206101c06101205161014060006040515af16114b3573d600060003e3d6000fd5b3d602081183d60201002186101a0526101a080518060a05260208201805160c05250505060a0511561154f5760c05160a05160200360031b1c61154f57601560e0527f6572633230207472616e73666572206661696c656400000000000000000000006101005260e05060e0518061010001601f826000031636823750506308c379a060a052602060c052601f19601f60e051011660440160bcfd5b565b600080fda165767970657283000306000b005b600080fd",
+}
+
+// MevboostrelaylistABI is the input ABI used to generate the binding from.
+// Deprecated: Use MevboostrelaylistMetaData.ABI instead.
+var MevboostrelaylistABI = MevboostrelaylistMetaData.ABI
+
+// MevboostrelaylistBin is the compiled bytecode used for deploying new contracts.
+// Deprecated: Use MevboostrelaylistMetaData.Bin instead.
+var MevboostrelaylistBin = MevboostrelaylistMetaData.Bin
+
+// DeployMevboostrelaylist deploys a new Ethereum contract, binding an instance of Mevboostrelaylist to it.
+func DeployMevboostrelaylist(auth *bind.TransactOpts, backend bind.ContractBackend, owner common.Address) (common.Address, *types.Transaction, *Mevboostrelaylist, error) {
+	parsed, err := MevboostrelaylistMetaData.GetAbi()
+	if err != nil {
+		return common.Address{}, nil, nil, err
+	}
+	if parsed == nil {
+		return common.Address{}, nil, nil, errors.New("GetABI returned nil")
+	}
+
+	address, tx, contract, err := bind.DeployContract(auth, *parsed, common.FromHex(MevboostrelaylistBin), backend, owner)
+	if err != nil {
+		return common.Address{}, nil, nil, err
+	}
+	return address, tx, &Mevboostrelaylist{MevboostrelaylistCaller: MevboostrelaylistCaller{contract: contract}, MevboostrelaylistTransactor: MevboostrelaylistTransactor{contract: contract}, MevboostrelaylistFilterer: MevboostrelaylistFilterer{contract: contract}}, nil
+}
+
+// Mevboostrelaylist is an auto generated Go binding around an Ethereum contract.
+type Mevboostrelaylist struct {
+	MevboostrelaylistCaller     // Read-only binding to the contract
+	MevboostrelaylistTransactor // Write-only binding to the contract
+	MevboostrelaylistFilterer   // Log filterer for contract events
+}
+
+// MevboostrelaylistCaller is an auto generated read-only Go binding around an Ethereum contract.
+type MevboostrelaylistCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// MevboostrelaylistTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type MevboostrelaylistTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// MevboostrelaylistFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type MevboostrelaylistFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// MevboostrelaylistSession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type MevboostrelaylistSession struct {
+	Contract     *Mevboostrelaylist // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts      // Call options to use throughout this session
+	TransactOpts bind.TransactOpts  // Transaction auth options to use throughout this session
+}
+
+// MevboostrelaylistCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type MevboostrelaylistCallerSession struct {
+	Contract *MevboostrelaylistCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts            // Call options to use throughout this session
+}
+
+// MevboostrelaylistTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type MevboostrelaylistTransactorSession struct {
+	Contract     *MevboostrelaylistTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts            // Transaction auth options to use throughout this session
+}
+
+// MevboostrelaylistRaw is an auto generated low-level Go binding around an Ethereum contract.
+type MevboostrelaylistRaw struct {
+	Contract *Mevboostrelaylist // Generic contract binding to access the raw methods on
+}
+
+// MevboostrelaylistCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type MevboostrelaylistCallerRaw struct {
+	Contract *MevboostrelaylistCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// MevboostrelaylistTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type MevboostrelaylistTransactorRaw struct {
+	Contract *MevboostrelaylistTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewMevboostrelaylist creates a new instance of Mevboostrelaylist, bound to a specific deployed contract.
+func NewMevboostrelaylist(address common.Address, backend bind.ContractBackend) (*Mevboostrelaylist, error) {
+	contract, err := bindMevboostrelaylist(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &Mevboostrelaylist{MevboostrelaylistCaller: MevboostrelaylistCaller{contract: contract}, MevboostrelaylistTransactor: MevboostrelaylistTransactor{contract: contract}, MevboostrelaylistFilterer: MevboostrelaylistFilterer{contract: contract}}, nil
+}
+
+// NewMevboostrelaylistCaller creates a new read-only instance of Mevboostrelaylist, bound to a specific deployed contract.
+func NewMevboostrelaylistCaller(address common.Address, caller bind.ContractCaller) (*MevboostrelaylistCaller, error) {
+	contract, err := bindMevboostrelaylist(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &MevboostrelaylistCaller{contract: contract}, nil
+}
+
+// NewMevboostrelaylistTransactor creates a new write-only instance of Mevboostrelaylist, bound to a specific deployed contract.
+func NewMevboostrelaylistTransactor(address common.Address, transactor bind.ContractTransactor) (*MevboostrelaylistTransactor, error) {
+	contract, err := bindMevboostrelaylist(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &MevboostrelaylistTransactor{contract: contract}, nil
+}
+
+// NewMevboostrelaylistFilterer creates a new log filterer instance of Mevboostrelaylist, bound to a specific deployed contract.
+func NewMevboostrelaylistFilterer(address common.Address, filterer bind.ContractFilterer) (*MevboostrelaylistFilterer, error) {
+	contract, err := bindMevboostrelaylist(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &MevboostrelaylistFilterer{contract: contract}, nil
+}
+
+// bindMevboostrelaylist binds a generic wrapper to an already deployed contract.
+func bindMevboostrelaylist(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := MevboostrelaylistMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_Mevboostrelaylist *MevboostrelaylistRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _Mevboostrelaylist.Contract.MevboostrelaylistCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_Mevboostrelaylist *MevboostrelaylistRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Mevboostrelaylist.Contract.MevboostrelaylistTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_Mevboostrelaylist *MevboostrelaylistRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _Mevboostrelaylist.Contract.MevboostrelaylistTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_Mevboostrelaylist *MevboostrelaylistCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _Mevboostrelaylist.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_Mevboostrelaylist *MevboostrelaylistTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Mevboostrelaylist.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_Mevboostrelaylist *MevboostrelaylistTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _Mevboostrelaylist.Contract.contract.Transact(opts, method, params...)
+}
+
+// GetAllowedListVersion is a free data retrieval call binding the contract method 0x76650ad3.
+//
+// Solidity: function get_allowed_list_version() view returns(uint256)
+func (_Mevboostrelaylist *MevboostrelaylistCaller) GetAllowedListVersion(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _Mevboostrelaylist.contract.Call(opts, &out, "get_allowed_list_version")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// GetAllowedListVersion is a free data retrieval call binding the contract method 0x76650ad3.
+//
+// Solidity: function get_allowed_list_version() view returns(uint256)
+func (_Mevboostrelaylist *MevboostrelaylistSession) GetAllowedListVersion() (*big.Int, error) {
+	return _Mevboostrelaylist.Contract.GetAllowedListVersion(&_Mevboostrelaylist.CallOpts)
+}
+
+// GetAllowedListVersion is a free data retrieval call binding the contract method 0x76650ad3.
+//
+// Solidity: function get_allowed_list_version() view returns(uint256)
+func (_Mevboostrelaylist *MevboostrelaylistCallerSession) GetAllowedListVersion() (*big.Int, error) {
+	return _Mevboostrelaylist.Contract.GetAllowedListVersion(&_Mevboostrelaylist.CallOpts)
+}
+
+// GetManager is a free data retrieval call binding the contract method 0x9e4a0fc4.
+//
+// Solidity: function get_manager() view returns(address)
+func (_Mevboostrelaylist *MevboostrelaylistCaller) GetManager(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _Mevboostrelaylist.contract.Call(opts, &out, "get_manager")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// GetManager is a free data retrieval call binding the contract method 0x9e4a0fc4.
+//
+// Solidity: function get_manager() view returns(address)
+func (_Mevboostrelaylist *MevboostrelaylistSession) GetManager() (common.Address, error) {
+	return _Mevboostrelaylist.Contract.GetManager(&_Mevboostrelaylist.CallOpts)
+}
+
+// GetManager is a free data retrieval call binding the contract method 0x9e4a0fc4.
+//
+// Solidity: function get_manager() view returns(address)
+func (_Mevboostrelaylist *MevboostrelaylistCallerSession) GetManager() (common.Address, error) {
+	return _Mevboostrelaylist.Contract.GetManager(&_Mevboostrelaylist.CallOpts)
+}
+
+// GetOwner is a free data retrieval call binding the contract method 0x0ac298dc.
+//
+// Solidity: function get_owner() view returns(address)
+func (_Mevboostrelaylist *MevboostrelaylistCaller) GetOwner(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _Mevboostrelaylist.contract.Call(opts, &out, "get_owner")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// GetOwner is a free data retrieval call binding the contract method 0x0ac298dc.
+//
+// Solidity: function get_owner() view returns(address)
+func (_Mevboostrelaylist *MevboostrelaylistSession) GetOwner() (common.Address, error) {
+	return _Mevboostrelaylist.Contract.GetOwner(&_Mevboostrelaylist.CallOpts)
+}
+
+// GetOwner is a free data retrieval call binding the contract method 0x0ac298dc.
+//
+// Solidity: function get_owner() view returns(address)
+func (_Mevboostrelaylist *MevboostrelaylistCallerSession) GetOwner() (common.Address, error) {
+	return _Mevboostrelaylist.Contract.GetOwner(&_Mevboostrelaylist.CallOpts)
+}
+
+// GetRelayByUri is a free data retrieval call binding the contract method 0xf5f33c7b.
+//
+// Solidity: function get_relay_by_uri(string relay_uri) view returns((string,string,bool,string))
+func (_Mevboostrelaylist *MevboostrelaylistCaller) GetRelayByUri(opts *bind.CallOpts, relay_uri string) (Struct0, error) {
+	var out []interface{}
+	err := _Mevboostrelaylist.contract.Call(opts, &out, "get_relay_by_uri", relay_uri)
+
+	if err != nil {
+		return *new(Struct0), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(Struct0)).(*Struct0)
+
+	return out0, err
+
+}
+
+// GetRelayByUri is a free data retrieval call binding the contract method 0xf5f33c7b.
+//
+// Solidity: function get_relay_by_uri(string relay_uri) view returns((string,string,bool,string))
+func (_Mevboostrelaylist *MevboostrelaylistSession) GetRelayByUri(relay_uri string) (Struct0, error) {
+	return _Mevboostrelaylist.Contract.GetRelayByUri(&_Mevboostrelaylist.CallOpts, relay_uri)
+}
+
+// GetRelayByUri is a free data retrieval call binding the contract method 0xf5f33c7b.
+//
+// Solidity: function get_relay_by_uri(string relay_uri) view returns((string,string,bool,string))
+func (_Mevboostrelaylist *MevboostrelaylistCallerSession) GetRelayByUri(relay_uri string) (Struct0, error) {
+	return _Mevboostrelaylist.Contract.GetRelayByUri(&_Mevboostrelaylist.CallOpts, relay_uri)
+}
+
+// GetRelays is a free data retrieval call binding the contract method 0x04e469ea.
+//
+// Solidity: function get_relays() view returns((string,string,bool,string)[])
+func (_Mevboostrelaylist *MevboostrelaylistCaller) GetRelays(opts *bind.CallOpts) ([]Struct0, error) {
+	var out []interface{}
+	err := _Mevboostrelaylist.contract.Call(opts, &out, "get_relays")
+
+	if err != nil {
+		return *new([]Struct0), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([]Struct0)).(*[]Struct0)
+
+	return out0, err
+
+}
+
+// GetRelays is a free data retrieval call binding the contract method 0x04e469ea.
+//
+// Solidity: function get_relays() view returns((string,string,bool,string)[])
+func (_Mevboostrelaylist *MevboostrelaylistSession) GetRelays() ([]Struct0, error) {
+	return _Mevboostrelaylist.Contract.GetRelays(&_Mevboostrelaylist.CallOpts)
+}
+
+// GetRelays is a free data retrieval call binding the contract method 0x04e469ea.
+//
+// Solidity: function get_relays() view returns((string,string,bool,string)[])
+func (_Mevboostrelaylist *MevboostrelaylistCallerSession) GetRelays() ([]Struct0, error) {
+	return _Mevboostrelaylist.Contract.GetRelays(&_Mevboostrelaylist.CallOpts)
+}
+
+// GetRelaysAmount is a free data retrieval call binding the contract method 0x312c3165.
+//
+// Solidity: function get_relays_amount() view returns(uint256)
+func (_Mevboostrelaylist *MevboostrelaylistCaller) GetRelaysAmount(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _Mevboostrelaylist.contract.Call(opts, &out, "get_relays_amount")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// GetRelaysAmount is a free data retrieval call binding the contract method 0x312c3165.
+//
+// Solidity: function get_relays_amount() view returns(uint256)
+func (_Mevboostrelaylist *MevboostrelaylistSession) GetRelaysAmount() (*big.Int, error) {
+	return _Mevboostrelaylist.Contract.GetRelaysAmount(&_Mevboostrelaylist.CallOpts)
+}
+
+// GetRelaysAmount is a free data retrieval call binding the contract method 0x312c3165.
+//
+// Solidity: function get_relays_amount() view returns(uint256)
+func (_Mevboostrelaylist *MevboostrelaylistCallerSession) GetRelaysAmount() (*big.Int, error) {
+	return _Mevboostrelaylist.Contract.GetRelaysAmount(&_Mevboostrelaylist.CallOpts)
+}
+
+// AddRelay is a paid mutator transaction binding the contract method 0x2e21ecef.
+//
+// Solidity: function add_relay(string uri, string operator, bool is_mandatory, string description) returns()
+func (_Mevboostrelaylist *MevboostrelaylistTransactor) AddRelay(opts *bind.TransactOpts, uri string, operator string, is_mandatory bool, description string) (*types.Transaction, error) {
+	return _Mevboostrelaylist.contract.Transact(opts, "add_relay", uri, operator, is_mandatory, description)
+}
+
+// AddRelay is a paid mutator transaction binding the contract method 0x2e21ecef.
+//
+// Solidity: function add_relay(string uri, string operator, bool is_mandatory, string description) returns()
+func (_Mevboostrelaylist *MevboostrelaylistSession) AddRelay(uri string, operator string, is_mandatory bool, description string) (*types.Transaction, error) {
+	return _Mevboostrelaylist.Contract.AddRelay(&_Mevboostrelaylist.TransactOpts, uri, operator, is_mandatory, description)
+}
+
+// AddRelay is a paid mutator transaction binding the contract method 0x2e21ecef.
+//
+// Solidity: function add_relay(string uri, string operator, bool is_mandatory, string description) returns()
+func (_Mevboostrelaylist *MevboostrelaylistTransactorSession) AddRelay(uri string, operator string, is_mandatory bool, description string) (*types.Transaction, error) {
+	return _Mevboostrelaylist.Contract.AddRelay(&_Mevboostrelaylist.TransactOpts, uri, operator, is_mandatory, description)
+}
+
+// ChangeOwner is a paid mutator transaction binding the contract method 0x253c8bd4.
+//
+// Solidity: function change_owner(address owner) returns()
+func (_Mevboostrelaylist *MevboostrelaylistTransactor) ChangeOwner(opts *bind.TransactOpts, owner common.Address) (*types.Transaction, error) {
+	return _Mevboostrelaylist.contract.Transact(opts, "change_owner", owner)
+}
+
+// ChangeOwner is a paid mutator transaction binding the contract method 0x253c8bd4.
+//
+// Solidity: function change_owner(address owner) returns()
+func (_Mevboostrelaylist *MevboostrelaylistSession) ChangeOwner(owner common.Address) (*types.Transaction, error) {
+	return _Mevboostrelaylist.Contract.ChangeOwner(&_Mevboostrelaylist.TransactOpts, owner)
+}
+
+// ChangeOwner is a paid mutator transaction binding the contract method 0x253c8bd4.
+//
+// Solidity: function change_owner(address owner) returns()
+func (_Mevboostrelaylist *MevboostrelaylistTransactorSession) ChangeOwner(owner common.Address) (*types.Transaction, error) {
+	return _Mevboostrelaylist.Contract.ChangeOwner(&_Mevboostrelaylist.TransactOpts, owner)
+}
+
+// DismissManager is a paid mutator transaction binding the contract method 0x417a02b4.
+//
+// Solidity: function dismiss_manager() returns()
+func (_Mevboostrelaylist *MevboostrelaylistTransactor) DismissManager(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Mevboostrelaylist.contract.Transact(opts, "dismiss_manager")
+}
+
+// DismissManager is a paid mutator transaction binding the contract method 0x417a02b4.
+//
+// Solidity: function dismiss_manager() returns()
+func (_Mevboostrelaylist *MevboostrelaylistSession) DismissManager() (*types.Transaction, error) {
+	return _Mevboostrelaylist.Contract.DismissManager(&_Mevboostrelaylist.TransactOpts)
+}
+
+// DismissManager is a paid mutator transaction binding the contract method 0x417a02b4.
+//
+// Solidity: function dismiss_manager() returns()
+func (_Mevboostrelaylist *MevboostrelaylistTransactorSession) DismissManager() (*types.Transaction, error) {
+	return _Mevboostrelaylist.Contract.DismissManager(&_Mevboostrelaylist.TransactOpts)
+}
+
+// RecoverErc20 is a paid mutator transaction binding the contract method 0xedd885b4.
+//
+// Solidity: function recover_erc20(address token, uint256 amount, address recipient) returns()
+func (_Mevboostrelaylist *MevboostrelaylistTransactor) RecoverErc20(opts *bind.TransactOpts, token common.Address, amount *big.Int, recipient common.Address) (*types.Transaction, error) {
+	return _Mevboostrelaylist.contract.Transact(opts, "recover_erc20", token, amount, recipient)
+}
+
+// RecoverErc20 is a paid mutator transaction binding the contract method 0xedd885b4.
+//
+// Solidity: function recover_erc20(address token, uint256 amount, address recipient) returns()
+func (_Mevboostrelaylist *MevboostrelaylistSession) RecoverErc20(token common.Address, amount *big.Int, recipient common.Address) (*types.Transaction, error) {
+	return _Mevboostrelaylist.Contract.RecoverErc20(&_Mevboostrelaylist.TransactOpts, token, amount, recipient)
+}
+
+// RecoverErc20 is a paid mutator transaction binding the contract method 0xedd885b4.
+//
+// Solidity: function recover_erc20(address token, uint256 amount, address recipient) returns()
+func (_Mevboostrelaylist *MevboostrelaylistTransactorSession) RecoverErc20(token common.Address, amount *big.Int, recipient common.Address) (*types.Transaction, error) {
+	return _Mevboostrelaylist.Contract.RecoverErc20(&_Mevboostrelaylist.TransactOpts, token, amount, recipient)
+}
+
+// RemoveRelay is a paid mutator transaction binding the contract method 0xf5a70a80.
+//
+// Solidity: function remove_relay(string uri) returns()
+func (_Mevboostrelaylist *MevboostrelaylistTransactor) RemoveRelay(opts *bind.TransactOpts, uri string) (*types.Transaction, error) {
+	return _Mevboostrelaylist.contract.Transact(opts, "remove_relay", uri)
+}
+
+// RemoveRelay is a paid mutator transaction binding the contract method 0xf5a70a80.
+//
+// Solidity: function remove_relay(string uri) returns()
+func (_Mevboostrelaylist *MevboostrelaylistSession) RemoveRelay(uri string) (*types.Transaction, error) {
+	return _Mevboostrelaylist.Contract.RemoveRelay(&_Mevboostrelaylist.TransactOpts, uri)
+}
+
+// RemoveRelay is a paid mutator transaction binding the contract method 0xf5a70a80.
+//
+// Solidity: function remove_relay(string uri) returns()
+func (_Mevboostrelaylist *MevboostrelaylistTransactorSession) RemoveRelay(uri string) (*types.Transaction, error) {
+	return _Mevboostrelaylist.Contract.RemoveRelay(&_Mevboostrelaylist.TransactOpts, uri)
+}
+
+// SetManager is a paid mutator transaction binding the contract method 0x9aece83e.
+//
+// Solidity: function set_manager(address manager) returns()
+func (_Mevboostrelaylist *MevboostrelaylistTransactor) SetManager(opts *bind.TransactOpts, manager common.Address) (*types.Transaction, error) {
+	return _Mevboostrelaylist.contract.Transact(opts, "set_manager", manager)
+}
+
+// SetManager is a paid mutator transaction binding the contract method 0x9aece83e.
+//
+// Solidity: function set_manager(address manager) returns()
+func (_Mevboostrelaylist *MevboostrelaylistSession) SetManager(manager common.Address) (*types.Transaction, error) {
+	return _Mevboostrelaylist.Contract.SetManager(&_Mevboostrelaylist.TransactOpts, manager)
+}
+
+// SetManager is a paid mutator transaction binding the contract method 0x9aece83e.
+//
+// Solidity: function set_manager(address manager) returns()
+func (_Mevboostrelaylist *MevboostrelaylistTransactorSession) SetManager(manager common.Address) (*types.Transaction, error) {
+	return _Mevboostrelaylist.Contract.SetManager(&_Mevboostrelaylist.TransactOpts, manager)
+}
+
+// Fallback is a paid mutator transaction binding the contract fallback function.
+//
+// Solidity: fallback() returns()
+func (_Mevboostrelaylist *MevboostrelaylistTransactor) Fallback(opts *bind.TransactOpts, calldata []byte) (*types.Transaction, error) {
+	return _Mevboostrelaylist.contract.RawTransact(opts, calldata)
+}
+
+// Fallback is a paid mutator transaction binding the contract fallback function.
+//
+// Solidity: fallback() returns()
+func (_Mevboostrelaylist *MevboostrelaylistSession) Fallback(calldata []byte) (*types.Transaction, error) {
+	return _Mevboostrelaylist.Contract.Fallback(&_Mevboostrelaylist.TransactOpts, calldata)
+}
+
+// Fallback is a paid mutator transaction binding the contract fallback function.
+//
+// Solidity: fallback() returns()
+func (_Mevboostrelaylist *MevboostrelaylistTransactorSession) Fallback(calldata []byte) (*types.Transaction, error) {
+	return _Mevboostrelaylist.Contract.Fallback(&_Mevboostrelaylist.TransactOpts, calldata)
+}
+
+// MevboostrelaylistAllowedListUpdatedIterator is returned from FilterAllowedListUpdated and is used to iterate over the raw logs and unpacked data for AllowedListUpdated events raised by the Mevboostrelaylist contract.
+type MevboostrelaylistAllowedListUpdatedIterator struct {
+	Event *MevboostrelaylistAllowedListUpdated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *MevboostrelaylistAllowedListUpdatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(MevboostrelaylistAllowedListUpdated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(MevboostrelaylistAllowedListUpdated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *MevboostrelaylistAllowedListUpdatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *MevboostrelaylistAllowedListUpdatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// MevboostrelaylistAllowedListUpdated represents a AllowedListUpdated event raised by the Mevboostrelaylist contract.
+type MevboostrelaylistAllowedListUpdated struct {
+	AllowedListVersion *big.Int
+	Raw                types.Log // Blockchain specific contextual infos
+}
+
+// FilterAllowedListUpdated is a free log retrieval operation binding the contract event 0x49f5627aa055ec3fcd474f99c8b7799b798c04af7b9f215305512c867e5a1839.
+//
+// Solidity: event AllowedListUpdated(uint256 indexed allowed_list_version)
+func (_Mevboostrelaylist *MevboostrelaylistFilterer) FilterAllowedListUpdated(opts *bind.FilterOpts, allowed_list_version []*big.Int) (*MevboostrelaylistAllowedListUpdatedIterator, error) {
+
+	var allowed_list_versionRule []interface{}
+	for _, allowed_list_versionItem := range allowed_list_version {
+		allowed_list_versionRule = append(allowed_list_versionRule, allowed_list_versionItem)
+	}
+
+	logs, sub, err := _Mevboostrelaylist.contract.FilterLogs(opts, "AllowedListUpdated", allowed_list_versionRule)
+	if err != nil {
+		return nil, err
+	}
+	return &MevboostrelaylistAllowedListUpdatedIterator{contract: _Mevboostrelaylist.contract, event: "AllowedListUpdated", logs: logs, sub: sub}, nil
+}
+
+// WatchAllowedListUpdated is a free log subscription operation binding the contract event 0x49f5627aa055ec3fcd474f99c8b7799b798c04af7b9f215305512c867e5a1839.
+//
+// Solidity: event AllowedListUpdated(uint256 indexed allowed_list_version)
+func (_Mevboostrelaylist *MevboostrelaylistFilterer) WatchAllowedListUpdated(opts *bind.WatchOpts, sink chan<- *MevboostrelaylistAllowedListUpdated, allowed_list_version []*big.Int) (event.Subscription, error) {
+
+	var allowed_list_versionRule []interface{}
+	for _, allowed_list_versionItem := range allowed_list_version {
+		allowed_list_versionRule = append(allowed_list_versionRule, allowed_list_versionItem)
+	}
+
+	logs, sub, err := _Mevboostrelaylist.contract.WatchLogs(opts, "AllowedListUpdated", allowed_list_versionRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(MevboostrelaylistAllowedListUpdated)
+				if err := _Mevboostrelaylist.contract.UnpackLog(event, "AllowedListUpdated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseAllowedListUpdated is a log parse operation binding the contract event 0x49f5627aa055ec3fcd474f99c8b7799b798c04af7b9f215305512c867e5a1839.
+//
+// Solidity: event AllowedListUpdated(uint256 indexed allowed_list_version)
+func (_Mevboostrelaylist *MevboostrelaylistFilterer) ParseAllowedListUpdated(log types.Log) (*MevboostrelaylistAllowedListUpdated, error) {
+	event := new(MevboostrelaylistAllowedListUpdated)
+	if err := _Mevboostrelaylist.contract.UnpackLog(event, "AllowedListUpdated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// MevboostrelaylistERC20RecoveredIterator is returned from FilterERC20Recovered and is used to iterate over the raw logs and unpacked data for ERC20Recovered events raised by the Mevboostrelaylist contract.
+type MevboostrelaylistERC20RecoveredIterator struct {
+	Event *MevboostrelaylistERC20Recovered // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *MevboostrelaylistERC20RecoveredIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(MevboostrelaylistERC20Recovered)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(MevboostrelaylistERC20Recovered)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *MevboostrelaylistERC20RecoveredIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *MevboostrelaylistERC20RecoveredIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// MevboostrelaylistERC20Recovered represents a ERC20Recovered event raised by the Mevboostrelaylist contract.
+type MevboostrelaylistERC20Recovered struct {
+	Token     common.Address
+	Amount    *big.Int
+	Recipient common.Address
+	Raw       types.Log // Blockchain specific contextual infos
+}
+
+// FilterERC20Recovered is a free log retrieval operation binding the contract event 0x8619312ed4eff1cf9f0116e6db2f49d9570a86f0350d1c5ad1bd0f7b0cf9e132.
+//
+// Solidity: event ERC20Recovered(address indexed token, uint256 amount, address indexed recipient)
+func (_Mevboostrelaylist *MevboostrelaylistFilterer) FilterERC20Recovered(opts *bind.FilterOpts, token []common.Address, recipient []common.Address) (*MevboostrelaylistERC20RecoveredIterator, error) {
+
+	var tokenRule []interface{}
+	for _, tokenItem := range token {
+		tokenRule = append(tokenRule, tokenItem)
+	}
+
+	var recipientRule []interface{}
+	for _, recipientItem := range recipient {
+		recipientRule = append(recipientRule, recipientItem)
+	}
+
+	logs, sub, err := _Mevboostrelaylist.contract.FilterLogs(opts, "ERC20Recovered", tokenRule, recipientRule)
+	if err != nil {
+		return nil, err
+	}
+	return &MevboostrelaylistERC20RecoveredIterator{contract: _Mevboostrelaylist.contract, event: "ERC20Recovered", logs: logs, sub: sub}, nil
+}
+
+// WatchERC20Recovered is a free log subscription operation binding the contract event 0x8619312ed4eff1cf9f0116e6db2f49d9570a86f0350d1c5ad1bd0f7b0cf9e132.
+//
+// Solidity: event ERC20Recovered(address indexed token, uint256 amount, address indexed recipient)
+func (_Mevboostrelaylist *MevboostrelaylistFilterer) WatchERC20Recovered(opts *bind.WatchOpts, sink chan<- *MevboostrelaylistERC20Recovered, token []common.Address, recipient []common.Address) (event.Subscription, error) {
+
+	var tokenRule []interface{}
+	for _, tokenItem := range token {
+		tokenRule = append(tokenRule, tokenItem)
+	}
+
+	var recipientRule []interface{}
+	for _, recipientItem := range recipient {
+		recipientRule = append(recipientRule, recipientItem)
+	}
+
+	logs, sub, err := _Mevboostrelaylist.contract.WatchLogs(opts, "ERC20Recovered", tokenRule, recipientRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(MevboostrelaylistERC20Recovered)
+				if err := _Mevboostrelaylist.contract.UnpackLog(event, "ERC20Recovered", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseERC20Recovered is a log parse operation binding the contract event 0x8619312ed4eff1cf9f0116e6db2f49d9570a86f0350d1c5ad1bd0f7b0cf9e132.
+//
+// Solidity: event ERC20Recovered(address indexed token, uint256 amount, address indexed recipient)
+func (_Mevboostrelaylist *MevboostrelaylistFilterer) ParseERC20Recovered(log types.Log) (*MevboostrelaylistERC20Recovered, error) {
+	event := new(MevboostrelaylistERC20Recovered)
+	if err := _Mevboostrelaylist.contract.UnpackLog(event, "ERC20Recovered", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// MevboostrelaylistManagerChangedIterator is returned from FilterManagerChanged and is used to iterate over the raw logs and unpacked data for ManagerChanged events raised by the Mevboostrelaylist contract.
+type MevboostrelaylistManagerChangedIterator struct {
+	Event *MevboostrelaylistManagerChanged // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *MevboostrelaylistManagerChangedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(MevboostrelaylistManagerChanged)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(MevboostrelaylistManagerChanged)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *MevboostrelaylistManagerChangedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *MevboostrelaylistManagerChangedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// MevboostrelaylistManagerChanged represents a ManagerChanged event raised by the Mevboostrelaylist contract.
+type MevboostrelaylistManagerChanged struct {
+	NewManager common.Address
+	Raw        types.Log // Blockchain specific contextual infos
+}
+
+// FilterManagerChanged is a free log retrieval operation binding the contract event 0x198db6e425fb8aafd1823c6ca50be2d51e5764571a5ae0f0f21c6812e45def0b.
+//
+// Solidity: event ManagerChanged(address indexed new_manager)
+func (_Mevboostrelaylist *MevboostrelaylistFilterer) FilterManagerChanged(opts *bind.FilterOpts, new_manager []common.Address) (*MevboostrelaylistManagerChangedIterator, error) {
+
+	var new_managerRule []interface{}
+	for _, new_managerItem := range new_manager {
+		new_managerRule = append(new_managerRule, new_managerItem)
+	}
+
+	logs, sub, err := _Mevboostrelaylist.contract.FilterLogs(opts, "ManagerChanged", new_managerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &MevboostrelaylistManagerChangedIterator{contract: _Mevboostrelaylist.contract, event: "ManagerChanged", logs: logs, sub: sub}, nil
+}
+
+// WatchManagerChanged is a free log subscription operation binding the contract event 0x198db6e425fb8aafd1823c6ca50be2d51e5764571a5ae0f0f21c6812e45def0b.
+//
+// Solidity: event ManagerChanged(address indexed new_manager)
+func (_Mevboostrelaylist *MevboostrelaylistFilterer) WatchManagerChanged(opts *bind.WatchOpts, sink chan<- *MevboostrelaylistManagerChanged, new_manager []common.Address) (event.Subscription, error) {
+
+	var new_managerRule []interface{}
+	for _, new_managerItem := range new_manager {
+		new_managerRule = append(new_managerRule, new_managerItem)
+	}
+
+	logs, sub, err := _Mevboostrelaylist.contract.WatchLogs(opts, "ManagerChanged", new_managerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(MevboostrelaylistManagerChanged)
+				if err := _Mevboostrelaylist.contract.UnpackLog(event, "ManagerChanged", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseManagerChanged is a log parse operation binding the contract event 0x198db6e425fb8aafd1823c6ca50be2d51e5764571a5ae0f0f21c6812e45def0b.
+//
+// Solidity: event ManagerChanged(address indexed new_manager)
+func (_Mevboostrelaylist *MevboostrelaylistFilterer) ParseManagerChanged(log types.Log) (*MevboostrelaylistManagerChanged, error) {
+	event := new(MevboostrelaylistManagerChanged)
+	if err := _Mevboostrelaylist.contract.UnpackLog(event, "ManagerChanged", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// MevboostrelaylistOwnerChangedIterator is returned from FilterOwnerChanged and is used to iterate over the raw logs and unpacked data for OwnerChanged events raised by the Mevboostrelaylist contract.
+type MevboostrelaylistOwnerChangedIterator struct {
+	Event *MevboostrelaylistOwnerChanged // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *MevboostrelaylistOwnerChangedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(MevboostrelaylistOwnerChanged)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(MevboostrelaylistOwnerChanged)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *MevboostrelaylistOwnerChangedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *MevboostrelaylistOwnerChangedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// MevboostrelaylistOwnerChanged represents a OwnerChanged event raised by the Mevboostrelaylist contract.
+type MevboostrelaylistOwnerChanged struct {
+	NewOwner common.Address
+	Raw      types.Log // Blockchain specific contextual infos
+}
+
+// FilterOwnerChanged is a free log retrieval operation binding the contract event 0xa2ea9883a321a3e97b8266c2b078bfeec6d50c711ed71f874a90d500ae2eaf36.
+//
+// Solidity: event OwnerChanged(address indexed new_owner)
+func (_Mevboostrelaylist *MevboostrelaylistFilterer) FilterOwnerChanged(opts *bind.FilterOpts, new_owner []common.Address) (*MevboostrelaylistOwnerChangedIterator, error) {
+
+	var new_ownerRule []interface{}
+	for _, new_ownerItem := range new_owner {
+		new_ownerRule = append(new_ownerRule, new_ownerItem)
+	}
+
+	logs, sub, err := _Mevboostrelaylist.contract.FilterLogs(opts, "OwnerChanged", new_ownerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &MevboostrelaylistOwnerChangedIterator{contract: _Mevboostrelaylist.contract, event: "OwnerChanged", logs: logs, sub: sub}, nil
+}
+
+// WatchOwnerChanged is a free log subscription operation binding the contract event 0xa2ea9883a321a3e97b8266c2b078bfeec6d50c711ed71f874a90d500ae2eaf36.
+//
+// Solidity: event OwnerChanged(address indexed new_owner)
+func (_Mevboostrelaylist *MevboostrelaylistFilterer) WatchOwnerChanged(opts *bind.WatchOpts, sink chan<- *MevboostrelaylistOwnerChanged, new_owner []common.Address) (event.Subscription, error) {
+
+	var new_ownerRule []interface{}
+	for _, new_ownerItem := range new_owner {
+		new_ownerRule = append(new_ownerRule, new_ownerItem)
+	}
+
+	logs, sub, err := _Mevboostrelaylist.contract.WatchLogs(opts, "OwnerChanged", new_ownerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(MevboostrelaylistOwnerChanged)
+				if err := _Mevboostrelaylist.contract.UnpackLog(event, "OwnerChanged", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseOwnerChanged is a log parse operation binding the contract event 0xa2ea9883a321a3e97b8266c2b078bfeec6d50c711ed71f874a90d500ae2eaf36.
+//
+// Solidity: event OwnerChanged(address indexed new_owner)
+func (_Mevboostrelaylist *MevboostrelaylistFilterer) ParseOwnerChanged(log types.Log) (*MevboostrelaylistOwnerChanged, error) {
+	event := new(MevboostrelaylistOwnerChanged)
+	if err := _Mevboostrelaylist.contract.UnpackLog(event, "OwnerChanged", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// MevboostrelaylistRelayAddedIterator is returned from FilterRelayAdded and is used to iterate over the raw logs and unpacked data for RelayAdded events raised by the Mevboostrelaylist contract.
+type MevboostrelaylistRelayAddedIterator struct {
+	Event *MevboostrelaylistRelayAdded // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *MevboostrelaylistRelayAddedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(MevboostrelaylistRelayAdded)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(MevboostrelaylistRelayAdded)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *MevboostrelaylistRelayAddedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *MevboostrelaylistRelayAddedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// MevboostrelaylistRelayAdded represents a RelayAdded event raised by the Mevboostrelaylist contract.
+type MevboostrelaylistRelayAdded struct {
+	UriHash common.Hash
+	Relay   Struct0
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterRelayAdded is a free log retrieval operation binding the contract event 0xeee5faa84d45af657ab405cdbf2c6a8a6d466e83fa694a358fee5ff84431d0bf.
+//
+// Solidity: event RelayAdded(string indexed uri_hash, (string,string,bool,string) relay)
+func (_Mevboostrelaylist *MevboostrelaylistFilterer) FilterRelayAdded(opts *bind.FilterOpts, uri_hash []string) (*MevboostrelaylistRelayAddedIterator, error) {
+
+	var uri_hashRule []interface{}
+	for _, uri_hashItem := range uri_hash {
+		uri_hashRule = append(uri_hashRule, uri_hashItem)
+	}
+
+	logs, sub, err := _Mevboostrelaylist.contract.FilterLogs(opts, "RelayAdded", uri_hashRule)
+	if err != nil {
+		return nil, err
+	}
+	return &MevboostrelaylistRelayAddedIterator{contract: _Mevboostrelaylist.contract, event: "RelayAdded", logs: logs, sub: sub}, nil
+}
+
+// WatchRelayAdded is a free log subscription operation binding the contract event 0xeee5faa84d45af657ab405cdbf2c6a8a6d466e83fa694a358fee5ff84431d0bf.
+//
+// Solidity: event RelayAdded(string indexed uri_hash, (string,string,bool,string) relay)
+func (_Mevboostrelaylist *MevboostrelaylistFilterer) WatchRelayAdded(opts *bind.WatchOpts, sink chan<- *MevboostrelaylistRelayAdded, uri_hash []string) (event.Subscription, error) {
+
+	var uri_hashRule []interface{}
+	for _, uri_hashItem := range uri_hash {
+		uri_hashRule = append(uri_hashRule, uri_hashItem)
+	}
+
+	logs, sub, err := _Mevboostrelaylist.contract.WatchLogs(opts, "RelayAdded", uri_hashRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(MevboostrelaylistRelayAdded)
+				if err := _Mevboostrelaylist.contract.UnpackLog(event, "RelayAdded", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseRelayAdded is a log parse operation binding the contract event 0xeee5faa84d45af657ab405cdbf2c6a8a6d466e83fa694a358fee5ff84431d0bf.
+//
+// Solidity: event RelayAdded(string indexed uri_hash, (string,string,bool,string) relay)
+func (_Mevboostrelaylist *MevboostrelaylistFilterer) ParseRelayAdded(log types.Log) (*MevboostrelaylistRelayAdded, error) {
+	event := new(MevboostrelaylistRelayAdded)
+	if err := _Mevboostrelaylist.contract.UnpackLog(event, "RelayAdded", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// MevboostrelaylistRelayRemovedIterator is returned from FilterRelayRemoved and is used to iterate over the raw logs and unpacked data for RelayRemoved events raised by the Mevboostrelaylist contract.
+type MevboostrelaylistRelayRemovedIterator struct {
+	Event *MevboostrelaylistRelayRemoved // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *MevboostrelaylistRelayRemovedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(MevboostrelaylistRelayRemoved)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(MevboostrelaylistRelayRemoved)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *MevboostrelaylistRelayRemovedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *MevboostrelaylistRelayRemovedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// MevboostrelaylistRelayRemoved represents a RelayRemoved event raised by the Mevboostrelaylist contract.
+type MevboostrelaylistRelayRemoved struct {
+	UriHash common.Hash
+	Uri     string
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterRelayRemoved is a free log retrieval operation binding the contract event 0xef756634af7ee7210f786ec0f91930afa63fda84d9ff6493ae681c332055dadb.
+//
+// Solidity: event RelayRemoved(string indexed uri_hash, string uri)
+func (_Mevboostrelaylist *MevboostrelaylistFilterer) FilterRelayRemoved(opts *bind.FilterOpts, uri_hash []string) (*MevboostrelaylistRelayRemovedIterator, error) {
+
+	var uri_hashRule []interface{}
+	for _, uri_hashItem := range uri_hash {
+		uri_hashRule = append(uri_hashRule, uri_hashItem)
+	}
+
+	logs, sub, err := _Mevboostrelaylist.contract.FilterLogs(opts, "RelayRemoved", uri_hashRule)
+	if err != nil {
+		return nil, err
+	}
+	return &MevboostrelaylistRelayRemovedIterator{contract: _Mevboostrelaylist.contract, event: "RelayRemoved", logs: logs, sub: sub}, nil
+}
+
+// WatchRelayRemoved is a free log subscription operation binding the contract event 0xef756634af7ee7210f786ec0f91930afa63fda84d9ff6493ae681c332055dadb.
+//
+// Solidity: event RelayRemoved(string indexed uri_hash, string uri)
+func (_Mevboostrelaylist *MevboostrelaylistFilterer) WatchRelayRemoved(opts *bind.WatchOpts, sink chan<- *MevboostrelaylistRelayRemoved, uri_hash []string) (event.Subscription, error) {
+
+	var uri_hashRule []interface{}
+	for _, uri_hashItem := range uri_hash {
+		uri_hashRule = append(uri_hashRule, uri_hashItem)
+	}
+
+	logs, sub, err := _Mevboostrelaylist.contract.WatchLogs(opts, "RelayRemoved", uri_hashRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(MevboostrelaylistRelayRemoved)
+				if err := _Mevboostrelaylist.contract.UnpackLog(event, "RelayRemoved", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseRelayRemoved is a log parse operation binding the contract event 0xef756634af7ee7210f786ec0f91930afa63fda84d9ff6493ae681c332055dadb.
+//
+// Solidity: event RelayRemoved(string indexed uri_hash, string uri)
+func (_Mevboostrelaylist *MevboostrelaylistFilterer) ParseRelayRemoved(log types.Log) (*MevboostrelaylistRelayRemoved, error) {
+	event := new(MevboostrelaylistRelayRemoved)
+	if err := _Mevboostrelaylist.contract.UnpackLog(event, "RelayRemoved", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}


### PR DESCRIPTION
## Changes:
- Remove the need for users cloning the repository to run `make generate` and `make compile`, rolling back to only `make compile`

## Types of changes
- [x] Build related changes
