### PR TITLE
JWTsecret to relative path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Support Mainnet for Lido CSM setup.
 
+### Changed
+- JWT secret path set as relative path when not provided.
+
 ## [v1.6.0] - 2024-10-18
 
 

--- a/cli/actions/jwt_secrets_test.go
+++ b/cli/actions/jwt_secrets_test.go
@@ -78,7 +78,11 @@ func TestCreateJwtSecrets(t *testing.T) {
 			if jwtPath == "" {
 				return
 			}
-			assert.FileExists(t, jwtPath)
+			if tc.options.JWTPath == "" {
+				assert.FileExists(t, filepath.Join(tempDir, "jwtsecret"))
+			} else {
+				assert.FileExists(t, jwtPath)
+			}
 		})
 	}
 }

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -68,6 +68,9 @@ func TestCli(t *testing.T) {
 			name: "full node with validator mainnet",
 			setup: func(t *testing.T, sedgeActions *sedge_mocks.MockSedgeActions, prompter *sedge_mocks.MockPrompter, depsMgr *sedge_mocks.MockDependenciesManager) {
 				generationPath := t.TempDir()
+				jwtPathAbs, _ := filepath.Abs(filepath.Join(generationPath, "jwtsecret"))
+				jwtPath, _ := filepath.Rel(generationPath, jwtPathAbs)
+				relativeJWTPath := "." + string(filepath.Separator) + jwtPath
 				genData := generate.GenData{
 					Services: []string{"execution", "consensus", "validator", "mev-boost"},
 					ExecutionClient: &clients.Client{
@@ -95,7 +98,7 @@ func TestCli(t *testing.T) {
 					MevImage:           "flashbots/mev-boost:latest",
 					RelayURLs:          configs.NetworksConfigs()[NetworkMainnet].RelayURLs,
 					ContainerTag:       "tag",
-					JWTSecretPath:      filepath.Join(generationPath, "jwtsecret"),
+					JWTSecretPath:      relativeJWTPath,
 				}
 				sedgeActions.EXPECT().GetCommandRunner().Return(&test.SimpleCMDRunner{})
 				gomock.InOrder(
@@ -151,6 +154,9 @@ func TestCli(t *testing.T) {
 			name: "full node without validator mainnet",
 			setup: func(t *testing.T, sedgeActions *sedge_mocks.MockSedgeActions, prompter *sedge_mocks.MockPrompter, depsMgr *sedge_mocks.MockDependenciesManager) {
 				generationPath := t.TempDir()
+				jwtPathAbs, _ := filepath.Abs(filepath.Join(generationPath, "jwtsecret"))
+				jwtPath, _ := filepath.Rel(generationPath, jwtPathAbs)
+				relativeJWTPath := "." + string(filepath.Separator) + jwtPath
 				genData := generate.GenData{
 					Services: []string{"execution", "consensus"},
 					ExecutionClient: &clients.Client{
@@ -168,7 +174,7 @@ func TestCli(t *testing.T) {
 					FeeRecipient:      "0x2d07a21ebadde0c13e6b91022a7e5722eb6bf5d5",
 					MapAllPorts:       true,
 					ContainerTag:      "tag",
-					JWTSecretPath:     filepath.Join(generationPath, "jwtsecret"),
+					JWTSecretPath:     relativeJWTPath,
 				}
 				gomock.InOrder(
 					prompter.EXPECT().Select("Select node setup", "", []string{sedgeOpts.EthereumNode, sedgeOpts.LidoNode}).Return(0, nil),
@@ -196,6 +202,9 @@ func TestCli(t *testing.T) {
 			name: "full node without validator holesky",
 			setup: func(t *testing.T, sedgeActions *sedge_mocks.MockSedgeActions, prompter *sedge_mocks.MockPrompter, depsMgr *sedge_mocks.MockDependenciesManager) {
 				generationPath := t.TempDir()
+				jwtPathAbs, _ := filepath.Abs(filepath.Join(generationPath, "jwtsecret"))
+				jwtPath, _ := filepath.Rel(generationPath, jwtPathAbs)
+				relativeJWTPath := "." + string(filepath.Separator) + jwtPath
 				genData := generate.GenData{
 					Services: []string{"execution", "consensus"},
 					ExecutionClient: &clients.Client{
@@ -213,7 +222,7 @@ func TestCli(t *testing.T) {
 					FeeRecipient:      "0x2d07a21ebadde0c13e6b91022a7e5722eb6bf5d5",
 					MapAllPorts:       true,
 					ContainerTag:      "tag",
-					JWTSecretPath:     filepath.Join(generationPath, "jwtsecret"),
+					JWTSecretPath:     relativeJWTPath,
 				}
 				gomock.InOrder(
 					prompter.EXPECT().Select("Select node setup", "", []string{sedgeOpts.EthereumNode, sedgeOpts.LidoNode}).Return(0, nil),
@@ -331,6 +340,9 @@ func TestCli(t *testing.T) {
 			name: "consensus node",
 			setup: func(t *testing.T, sedgeActions *sedge_mocks.MockSedgeActions, prompter *sedge_mocks.MockPrompter, depsMgr *sedge_mocks.MockDependenciesManager) {
 				generationPath := t.TempDir()
+				jwtPathAbs, _ := filepath.Abs(filepath.Join(generationPath, "jwtsecret"))
+				jwtPath, _ := filepath.Rel(generationPath, jwtPathAbs)
+				relativeJWTPath := "." + string(filepath.Separator) + jwtPath
 				genData := generate.GenData{
 					Services: []string{"consensus"},
 					ConsensusClient: &clients.Client{
@@ -346,7 +358,7 @@ func TestCli(t *testing.T) {
 					ExecutionAuthUrl:  "http://execution:5051",
 					MevBoostEndpoint:  "http://mev-boost:3030",
 					ContainerTag:      "tag",
-					JWTSecretPath:     filepath.Join(generationPath, "jwtsecret"),
+					JWTSecretPath:     relativeJWTPath,
 				}
 
 				gomock.InOrder(
@@ -376,6 +388,9 @@ func TestCli(t *testing.T) {
 			name: "consensus node holesky",
 			setup: func(t *testing.T, sedgeActions *sedge_mocks.MockSedgeActions, prompter *sedge_mocks.MockPrompter, depsMgr *sedge_mocks.MockDependenciesManager) {
 				generationPath := t.TempDir()
+				jwtPathAbs, _ := filepath.Abs(filepath.Join(generationPath, "jwtsecret"))
+				jwtPath, _ := filepath.Rel(generationPath, jwtPathAbs)
+				relativeJWTPath := "." + string(filepath.Separator) + jwtPath
 				genData := generate.GenData{
 					Services: []string{"consensus"},
 					ConsensusClient: &clients.Client{
@@ -391,7 +406,7 @@ func TestCli(t *testing.T) {
 					ExecutionAuthUrl:  "http://execution:5051",
 					MevBoostEndpoint:  "http://mev-boost:3030",
 					ContainerTag:      "tag",
-					JWTSecretPath:     filepath.Join(generationPath, "jwtsecret"),
+					JWTSecretPath:     relativeJWTPath,
 				}
 
 				gomock.InOrder(
@@ -485,6 +500,9 @@ func TestCli(t *testing.T) {
 			name: "consensus node",
 			setup: func(t *testing.T, sedgeActions *sedge_mocks.MockSedgeActions, prompter *sedge_mocks.MockPrompter, depsMgr *sedge_mocks.MockDependenciesManager) {
 				generationPath := t.TempDir()
+				jwtPathAbs, _ := filepath.Abs(filepath.Join(generationPath, "jwtsecret"))
+				jwtPath, _ := filepath.Rel(generationPath, jwtPathAbs)
+				relativeJWTPath := "." + string(filepath.Separator) + jwtPath
 				genData := generate.GenData{
 					Services: []string{"consensus"},
 					ConsensusClient: &clients.Client{
@@ -500,7 +518,7 @@ func TestCli(t *testing.T) {
 					ExecutionAuthUrl:  "http://execution:5051",
 					MevBoostEndpoint:  "http://mev-boost:3030",
 					ContainerTag:      "tag",
-					JWTSecretPath:     filepath.Join(generationPath, "jwtsecret"),
+					JWTSecretPath:     relativeJWTPath,
 				}
 
 				gomock.InOrder(
@@ -530,6 +548,9 @@ func TestCli(t *testing.T) {
 			name: "full node with Lido, mainnet",
 			setup: func(t *testing.T, sedgeActions *sedge_mocks.MockSedgeActions, prompter *sedge_mocks.MockPrompter, depsMgr *sedge_mocks.MockDependenciesManager) {
 				generationPath := t.TempDir()
+				jwtPathAbs, _ := filepath.Abs(filepath.Join(generationPath, "jwtsecret"))
+				jwtPath, _ := filepath.Rel(generationPath, jwtPathAbs)
+				relativeJWTPath := "." + string(filepath.Separator) + jwtPath
 				genData := generate.GenData{
 					Services: []string{"execution", "consensus", "validator", "mev-boost"},
 					ExecutionClient: &clients.Client{
@@ -557,7 +578,7 @@ func TestCli(t *testing.T) {
 					MevImage:           "flashbots/mev-boost:latest",
 					RelayURLs:          mainnetMevboostRelayListUris,
 					ContainerTag:       "tag",
-					JWTSecretPath:      filepath.Join(generationPath, "jwtsecret"),
+					JWTSecretPath:      relativeJWTPath,
 				}
 				sedgeActions.EXPECT().GetCommandRunner().Return(&test.SimpleCMDRunner{})
 				gomock.InOrder(
@@ -609,6 +630,9 @@ func TestCli(t *testing.T) {
 			name: "full node with Lido, holesky",
 			setup: func(t *testing.T, sedgeActions *sedge_mocks.MockSedgeActions, prompter *sedge_mocks.MockPrompter, depsMgr *sedge_mocks.MockDependenciesManager) {
 				generationPath := t.TempDir()
+				jwtPathAbs, _ := filepath.Abs(filepath.Join(generationPath, "jwtsecret"))
+				jwtPath, _ := filepath.Rel(generationPath, jwtPathAbs)
+				relativeJWTPath := "." + string(filepath.Separator) + jwtPath
 				genData := generate.GenData{
 					Services: []string{"execution", "consensus", "validator", "mev-boost"},
 					ExecutionClient: &clients.Client{
@@ -636,7 +660,7 @@ func TestCli(t *testing.T) {
 					MevImage:           "flashbots/mev-boost:latest",
 					RelayURLs:          holeskyMevboostRelayListUris,
 					ContainerTag:       "tag",
-					JWTSecretPath:      filepath.Join(generationPath, "jwtsecret"),
+					JWTSecretPath:      relativeJWTPath,
 				}
 				sedgeActions.EXPECT().GetCommandRunner().Return(&test.SimpleCMDRunner{})
 				gomock.InOrder(

--- a/cli/generate.go
+++ b/cli/generate.go
@@ -593,7 +593,6 @@ func handleJWTSecret(generationPath, name string) (string, error) {
 	return relativeJWTPath, nil
 }
 
-// TODO: Add unit tests
 func loadJWTSecret(from string) (absFrom string, err error) {
 	// Ensure from is absolute
 	absFrom, err = filepath.Abs(from)

--- a/cli/generate.go
+++ b/cli/generate.go
@@ -578,7 +578,19 @@ func handleJWTSecret(generationPath, name string) (string, error) {
 	}
 
 	log.Info(configs.JWTSecretGenerated)
-	return jwtPath, nil
+
+	// Convert the absolute path to a relative path
+	relativeJWTPath, err := filepath.Rel(generationPath, jwtPath)
+	if err != nil {
+		return "", fmt.Errorf(configs.GenerateJWTSecretError, err)
+	}
+
+	// Prepend "./" to ensure compatibility with relative paths
+	if !filepath.IsAbs(relativeJWTPath) && !filepath.HasPrefix(relativeJWTPath, ".") {
+		relativeJWTPath = "." + string(filepath.Separator) + relativeJWTPath
+	}
+
+	return relativeJWTPath, nil
 }
 
 // TODO: Add unit tests

--- a/e2e/sedge/jwt_test.go
+++ b/e2e/sedge/jwt_test.go
@@ -1,0 +1,150 @@
+/*
+Copyright 2022 Nethermind
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package e2e
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	base "github.com/NethermindEth/sedge/e2e"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	// validJWTSecret is a 32-byte hex string used as a valid JWT secret
+	validJWTSecret = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	// jwtSecretPath is the default path for JWT secrets
+	jwtSecretPath = "jwtsecret"
+)
+
+func TestE2E_Generate_JWTSecret_RelativePath(t *testing.T) {
+	// Test context
+	var (
+		runErr error
+		jwtPath = "custom/path/jwtsecret"
+	)
+
+	// Build test case
+	e2eTest := newE2ESedgeTestCase(
+		t,
+		// Arrange
+		func(t *testing.T, sedgePath string) error {
+			// Create the JWT secret file in the data directory
+			dataDir := filepath.Join(filepath.Dir(sedgePath), "sedge-data")
+			fullJWTPath := filepath.Join(dataDir, jwtPath)
+			if err := os.MkdirAll(filepath.Dir(fullJWTPath), 0o755); err != nil {
+				return err
+			}
+			if err := os.WriteFile(fullJWTPath, []byte(validJWTSecret), 0o644); err != nil {
+				return err
+			}
+			return nil
+		},
+		// Act
+		func(t *testing.T, binaryPath, dataDirPath string) {
+			// Use the full path when running the generate command
+			fullJWTPath := filepath.Join(dataDirPath, jwtPath)
+			runErr = base.RunSedge(t, binaryPath, "generate", "full-node", "--network", "mainnet", "--jwt-secret-path", fullJWTPath)
+		},
+		// Assert
+		func(t *testing.T, dataDirPath string) {
+			assert.NoError(t, runErr)
+			// Check if JWT file exists in the relative path
+			fullJWTPath := filepath.Join(dataDirPath, jwtPath)
+			_, err := os.Stat(fullJWTPath)
+			assert.NoError(t, err, "JWT secret file should exist at relative path")
+			
+			// Verify the JWT secret content
+			content, err := os.ReadFile(fullJWTPath)
+			assert.NoError(t, err)
+			assert.Equal(t, validJWTSecret, string(content), "JWT secret content should match")
+		},
+	)
+	e2eTest.run()
+}
+
+func TestE2E_Generate_JWTSecret_AbsolutePath(t *testing.T) {
+	// Test context
+	var (
+		runErr error
+		tempJWTDir string
+	)
+
+	// Build test case
+	e2eTest := newE2ESedgeTestCase(
+		t,
+		// Arrange
+		func(t *testing.T, sedgePath string) error {
+			// Create a temporary directory for JWT secret
+			tempJWTDir = t.TempDir()
+			// Create the JWT secret file
+			jwtPath := filepath.Join(tempJWTDir, "jwtsecret")
+			return os.WriteFile(jwtPath, []byte(validJWTSecret), 0o644)
+		},
+		// Act
+		func(t *testing.T, binaryPath, dataDirPath string) {
+			jwtPath := filepath.Join(tempJWTDir, "jwtsecret")
+			runErr = base.RunSedge(t, binaryPath, "generate", "full-node", "--network", "mainnet", "--jwt-secret-path", jwtPath)
+		},
+		// Assert
+		func(t *testing.T, dataDirPath string) {
+			assert.NoError(t, runErr)
+			// Check if JWT file exists in the absolute path
+			jwtPath := filepath.Join(tempJWTDir, "jwtsecret")
+			_, err := os.Stat(jwtPath)
+			assert.NoError(t, err, "JWT secret file should exist at absolute path")
+			
+			// Verify the JWT secret content
+			content, err := os.ReadFile(jwtPath)
+			assert.NoError(t, err)
+			assert.Equal(t, validJWTSecret, string(content), "JWT secret content should match")
+		},
+	)
+	e2eTest.run()
+}
+
+func TestE2E_Generate_JWTSecret_DefaultPath(t *testing.T) {
+	// Test context
+	var (
+		runErr error
+	)
+
+	// Build test case
+	e2eTest := newE2ESedgeTestCase(
+		t,
+		// Arrange
+		nil,
+		// Act
+		func(t *testing.T, binaryPath, dataDirPath string) {
+			runErr = base.RunSedge(t, binaryPath, "generate", "full-node", "--network", "mainnet")
+		},
+		// Assert
+		func(t *testing.T, dataDirPath string) {
+			assert.NoError(t, runErr)
+			// Check if JWT file exists in the default path
+			defaultJWTPath := filepath.Join(dataDirPath, "jwtsecret")
+			_, err := os.Stat(defaultJWTPath)
+			assert.NoError(t, err, "JWT secret file should exist at default path")
+			
+			// Read the file to ensure it's not empty
+			content, err := os.ReadFile(defaultJWTPath)
+			assert.NoError(t, err)
+			assert.NotEmpty(t, content, "JWT secret file should not be empty")
+		},
+	)
+	e2eTest.run()
+}

--- a/e2e/sedge/jwt_test.go
+++ b/e2e/sedge/jwt_test.go
@@ -34,7 +34,7 @@ const (
 func TestE2E_Generate_JWTSecret_RelativePath(t *testing.T) {
 	// Test context
 	var (
-		runErr error
+		runErr  error
 		jwtPath = "custom/path/jwtsecret"
 	)
 
@@ -67,7 +67,7 @@ func TestE2E_Generate_JWTSecret_RelativePath(t *testing.T) {
 			fullJWTPath := filepath.Join(dataDirPath, jwtPath)
 			_, err := os.Stat(fullJWTPath)
 			assert.NoError(t, err, "JWT secret file should exist at relative path")
-			
+
 			// Verify the JWT secret content
 			content, err := os.ReadFile(fullJWTPath)
 			assert.NoError(t, err)
@@ -80,7 +80,7 @@ func TestE2E_Generate_JWTSecret_RelativePath(t *testing.T) {
 func TestE2E_Generate_JWTSecret_AbsolutePath(t *testing.T) {
 	// Test context
 	var (
-		runErr error
+		runErr     error
 		tempJWTDir string
 	)
 
@@ -107,7 +107,7 @@ func TestE2E_Generate_JWTSecret_AbsolutePath(t *testing.T) {
 			jwtPath := filepath.Join(tempJWTDir, "jwtsecret")
 			_, err := os.Stat(jwtPath)
 			assert.NoError(t, err, "JWT secret file should exist at absolute path")
-			
+
 			// Verify the JWT secret content
 			content, err := os.ReadFile(jwtPath)
 			assert.NoError(t, err)
@@ -139,7 +139,7 @@ func TestE2E_Generate_JWTSecret_DefaultPath(t *testing.T) {
 			defaultJWTPath := filepath.Join(dataDirPath, "jwtsecret")
 			_, err := os.Stat(defaultJWTPath)
 			assert.NoError(t, err, "JWT secret file should exist at default path")
-			
+
 			// Read the file to ensure it's not empty
 			content, err := os.ReadFile(defaultJWTPath)
 			assert.NoError(t, err)


### PR DESCRIPTION
## Changes:
- When not provided, the jwt secret is set as a relative path. This allows users to share their setup more easily. 

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [x] Yes
- [ ] No

**In case you checked yes, did you write tests?**

- [x] Yes
- [ ] No

**Comments about testing , should you have some** (optional)

## Further comments (optional)

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
