### PR TITLE
fix  troubleshoot.md

### DIFF
--- a/docs/docs/troubleshoot.md
+++ b/docs/docs/troubleshoot.md
@@ -9,7 +9,7 @@ slug: troubleshooting
 If you see a log similar to this just before Sedge is going to interact with the docker-compose script:
 
 ```
-2022-XX-XX 00:00:00 -- [ERRO] it seems docker compose plugin is not installed. Please install it and try again.
+2022-XX-XX 00:00:00 -- [ERROR] it seems docker compose plugin is not installed. Please install it and try again.
 ```
 
 Then probably is because the `compose` plugin is not installed for the `root` user. Currently Sedge uses `sudo` (root /


### PR DESCRIPTION
### Title
`fix troubleshoot.md`

### Description
This pull request fixes a typo in the `docs/docs/troubleshoot.md` file:
- Corrected "ERRO" to "ERROR" in the example log message for improved clarity and accuracy.

### Details of Changes
- Replaced "ERRO" with the correct spelling "ERROR" in the troubleshooting documentation.
