### PR TITLE
Typo rewards.go

### DIFF
--- a/internal/lido/contracts/csfeedistributor/rewards.go
+++ b/internal/lido/contracts/csfeedistributor/rewards.go
@@ -31,7 +31,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// Tree : struct that reperesents Merkle Tree data
+// Tree : struct that represents Merkle Tree data
 type Tree struct {
 	Format       string   `json:"format"`
 	LeafEncoding []string `json:"leafEncoding"`


### PR DESCRIPTION
Corrected a typo in rewards.go: "reperesents" → "represents" in a struct comment. Improves readability and documentation clarity. No functional changes.