### PR TITLE
fix #521 - validator-blocker: add missing $ sign

### DIFF
--- a/templates/services/validator-blocker.tmpl
+++ b/templates/services/validator-blocker.tmpl
@@ -12,7 +12,7 @@
         echo 'Done';
         while true; do
           response=$(wget -S ${CC_API_URL}/eth/v1/node/health -O /dev/null 2>&1 | grep -m 1 'HTTP/' | awk '{print $2}')
-          if [ \"$response\" = \"200\" ]; then
+          if [ \"$$response\" = \"200\" ]; then
             echo 'Endpoint is up!'
             break
           else


### PR DESCRIPTION
Fixes #521

## Changes:
- Added the missing $ sign (To enable the correct escape sequence) to the ENTRYPOINT script in the generated docker-compose for validator-blocker deployment.

## Types of changes

What types of changes does your code introduce?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [ ] Yes
- [x] No

**In case you checked yes, did you write tests?**

- [ ] Yes
- [x] No

**Comments about testing , should you have some** (optional)

Tested it localy on my mac machine as well as a VM with Ubuntu as a base image and the validator-blocker was configured correctly and succesfully exited when the depending deployments/healthcheck to validator response was 200 (OK).

## Further comments (optional)

Not a complex PR, really simple fix and probably mergable/ready for merge.
