### PR TITLE
refactor:  remove obsolete // +build tag

### DIFF
--- a/configs/messages_unix.go
+++ b/configs/messages_unix.go
@@ -1,5 +1,4 @@
 //go:build linux || darwin
-// +build linux darwin
 
 /*
 Copyright 2022 Nethermind

--- a/e2e/lido-exporter/cleanup_unix.go
+++ b/e2e/lido-exporter/cleanup_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 /*
 Copyright 2022 Nethermind

--- a/e2e/lido-exporter/cleanup_windows.go
+++ b/e2e/lido-exporter/cleanup_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 /*
 Copyright 2022 Nethermind

--- a/internal/pkg/commands/cmd_runner_helper_unix.go
+++ b/internal/pkg/commands/cmd_runner_helper_unix.go
@@ -1,5 +1,4 @@
 //go:build linux || darwin
-// +build linux darwin
 
 /*
 Copyright 2022 Nethermind

--- a/internal/pkg/commands/cmd_runner_unix.go
+++ b/internal/pkg/commands/cmd_runner_unix.go
@@ -1,5 +1,4 @@
 //go:build linux || darwin
-// +build linux darwin
 
 /*
 Copyright 2022 Nethermind

--- a/internal/pkg/commands/commands_unix_test.go
+++ b/internal/pkg/commands/commands_unix_test.go
@@ -1,5 +1,4 @@
 //go:build linux || darwin
-// +build linux darwin
 
 /*
 Copyright 2022 Nethermind

--- a/internal/pkg/commands/commands_windows_test.go
+++ b/internal/pkg/commands/commands_windows_test.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 /*
 Copyright 2022 Nethermind

--- a/internal/utils/utils_unix.go
+++ b/internal/utils/utils_unix.go
@@ -1,5 +1,4 @@
 //go:build linux || darwin
-// +build linux darwin
 
 /*
 Copyright 2022 Nethermind


### PR DESCRIPTION
Fixes | Closes | Resolves #

> Anything marked as optional that you didn't need to fill in, please remove it from the PR description. Choose one of the keywords above to refer to the issue this PR solves, followed by the issue number (e.g Fixes # 666). If there is no issue, remove the line. Remove this note after reading.
## Changes:


From Go 1.17, the preferred syntax for build constraints is `//go:build`,
which replaces the old `// +build` form. The old style is now considered
deprecated but still supported for backward compatibility.

This change removes the obsolete `// +build xxx` line, keeping only the
modern `//go:build xxx` directive.

More info: https://github.com/golang/go/issues/41184 and https://go.dev/doc/go1.17#build-lines

Design Doc / Proposal：
https://go.dev/design/draft-gobuild




## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [ ] Yes
- [x] No

**In case you checked yes, did you write tests?**

- [ ] Yes
- [x] No

**Comments about testing , should you have some** (optional)

## Further comments (optional)

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
