### PR TITLE
feat: add support for ethrex execution client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Add support for ethrex execution client on mainnet, sepolia and hoodi networks.
+
 ## [v1.11.1] - 2026-02-10
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Integrating Charon with Sedge would make it easy for stakers to setup and run a 
 | Nethermind | Lodestar   | Lodestar   |
 | Erigon     | Prysm      | Prysm      |
 | Besu       | Teku       | Teku       |
-|            | Nimbus     | Nimbus     |
+| ethrex     | Nimbus     | Nimbus     |
 
 ### Hoodi
 
@@ -161,7 +161,7 @@ Integrating Charon with Sedge would make it easy for stakers to setup and run a 
 | Nethermind | Lodestar   | Lodestar   |
 | Erigon     | Teku       | Teku       |
 | Besu       | Prysm      | Prysm      |
-|            | Nimbus     | Nimbus     |
+| ethrex     | Nimbus     | Nimbus     |
 
 ### Sepolia
 
@@ -171,7 +171,7 @@ Integrating Charon with Sedge would make it easy for stakers to setup and run a 
 | Nethermind | Lodestar   | Lodestar   |
 | Erigon     | Prysm      | Prysm      |
 | Besu       | Teku       | Teku       |
-|            | Nimbus     | Nimbus     |
+| ethrex     | Nimbus     | Nimbus     |
 
 
 ### Gnosis

--- a/cli/sub_gen.go
+++ b/cli/sub_gen.go
@@ -89,7 +89,7 @@ Additionally, you can use this syntax '<CLIENT>:<DOCKER_IMAGE>' to override the 
 	}
 	// Bind flags
 	cmd.Flags().StringVarP(&flags.consensusName, "consensus", "c", "", "Consensus engine client, e.g. teku, lodestar, prysm, lighthouse, Nimbus. Additionally, you can use this syntax '<CLIENT>:<DOCKER_IMAGE>' to override the docker image used for the client. If you want to use the default docker image, just use the client name")
-	cmd.Flags().StringVarP(&flags.executionName, "execution", "e", "", "Execution engine client, e.g. geth, nethermind, besu, erigon. Additionally, you can use this syntax '<CLIENT>:<DOCKER_IMAGE>' to override the docker image used for the client. If you want to use the default docker image, just use the client name")
+	cmd.Flags().StringVarP(&flags.executionName, "execution", "e", "", "Execution engine client, e.g. geth, nethermind, besu, erigon, ethrex. Additionally, you can use this syntax '<CLIENT>:<DOCKER_IMAGE>' to override the docker image used for the client. If you want to use the default docker image, just use the client name")
 	cmd.Flags().StringVarP(&flags.validatorName, "validator", "v", "", "Validator engine client, e.g. teku, lodestar, prysm, lighthouse, Nimbus. Additionally, you can use this syntax '<CLIENT>:<DOCKER_IMAGE>' to override the docker image used for the client. If you want to use the default docker image, just use the client name")
 	cmd.Flags().BoolVar(&flags.distributed, "distributed", false, "Deploy a node configured to run as part of a Distributed Validator Cluster.")
 	cmd.Flags().StringVarP(&flags.distributedValidatorName, "distributedValidator", "d", "", "Distributed Validator client, e.g. charon. Additionally, you can use this syntax '<CLIENT>:<DOCKER_IMAGE>' to override the docker image used for the client. If you want to use the default docker image, just use the client name")
@@ -155,7 +155,7 @@ This command does not generate a validator configuration, as Optimism and Base u
 	cmd.Flags().StringVarP(&flags.consensusName, "consensus", "c", "", "Consensus engine client, e.g. teku, lodestar, prysm, lighthouse, Nimbus. Additionally, you can use this syntax '<CLIENT>:<DOCKER_IMAGE>' to override the docker image used for the client. If you want to use the default docker image, just use the client name")
 	cmd.Flags().StringVar(&flags.optimismName, "op-image", "", "Optimism consensus client image.")
 	cmd.Flags().StringVar(&flags.optimismExecutionName, "op-execution", "", "Optimism Execution client to be used, op-nethermind, op-geth, or op-reth. Additionally, you can use this syntax '<CLIENT>:<DOCKER_IMAGE>' to override the docker image used for the client. If you want to use the default docker image, just use the client name.")
-	cmd.Flags().StringVarP(&flags.executionName, "execution", "e", "", "Execution engine client, e.g. geth, nethermind, besu, erigon. Additionally, you can use this syntax '<CLIENT>:<DOCKER_IMAGE>' to override the docker image used for the client. If you want to use the default docker image, just use the client name")
+	cmd.Flags().StringVarP(&flags.executionName, "execution", "e", "", "Execution engine client, e.g. geth, nethermind, besu, erigon, ethrex. Additionally, you can use this syntax '<CLIENT>:<DOCKER_IMAGE>' to override the docker image used for the client. If you want to use the default docker image, just use the client name")
 	cmd.Flags().StringVarP(&flags.executionApiUrl, "execution-api-url", "", "", "Set execution api url. If Set, will omit the creation of execution and beacon nodes, and only create optimism nodes.")
 	cmd.Flags().StringVarP(&flags.consensusApiUrl, "consensus-url", "", "", "Set consensus api url. If Set, will omit the creation of execution and beacon nodes, and only create optimism nodes.")
 	cmd.Flags().BoolVar(&flags.latestVersion, "latest", false, "Use the latest version of clients. This sets the \"latest\" tag on the client's docker images. Latest version might not work.")
@@ -184,7 +184,7 @@ func ExecutionSubCmd(sedgeAction actions.SedgeActions) *cobra.Command {
 		Short: "Generate a execution node config",
 		Long: "Generate a docker-compose and an environment file with a execution node configuration.\n" +
 			"Valid args: name of execution clients according to network\n\n" +
-			"Should be one of: nethermind, geth, besu, erigon. If you don't provide one, it will chosen randomly.\n" +
+			"Should be one of: nethermind, geth, besu, erigon, ethrex. If you don't provide one, it will chosen randomly.\n" +
 			"Additionally, you can use this syntax '<CLIENT>:<DOCKER_IMAGE>' to override the docker image used for the client, for example 'sedge generate execution nethermind:docker.image'. If you want to use the default docker image, just use the client name",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) > 0 {
@@ -420,7 +420,7 @@ Additionally, you can use the syntax '<CLIENT>:<DOCKER_IMAGE>' to override the d
 	cmd.Flags().StringArrayVar(&flags.aztecExtraFlags, "aztec-extra-flag", []string{}, "Additional flag to configure the Aztec node service in the generated docker-compose script. Example: 'sedge generate aztec --aztec-extra-flag \"p2p.maxPeers=200\" --aztec-extra-flag \"txPool.maxSize=10000\"'")
 	cmd.Flags().Uint16Var(&flags.aztecOtelMetricsPort, "otel-metrics-port", 4318, "OTLP HTTP metrics port on the monitoring stack collector (default: 4318). The host is fixed to sedge_aztec_exporter and path to /v1/metrics.")
 	cmd.Flags().StringVarP(&flags.consensusName, "consensus", "c", "", "Consensus engine client, e.g. teku, lodestar, prysm, lighthouse, Nimbus. Additionally, you can use this syntax '<CLIENT>:<DOCKER_IMAGE>' to override the docker image used for the client. If you want to use the default docker image, just use the client name")
-	cmd.Flags().StringVarP(&flags.executionName, "execution", "e", "", "Execution engine client, e.g. geth, nethermind, besu, erigon. Additionally, you can use this syntax '<CLIENT>:<DOCKER_IMAGE>' to override the docker image used for the client. If you want to use the default docker image, just use the client name")
+	cmd.Flags().StringVarP(&flags.executionName, "execution", "e", "", "Execution engine client, e.g. geth, nethermind, besu, erigon, ethrex. Additionally, you can use this syntax '<CLIENT>:<DOCKER_IMAGE>' to override the docker image used for the client. If you want to use the default docker image, just use the client name")
 	cmd.Flags().StringVarP(&flags.executionApiUrl, "execution-api-url", "", "", "Set execution api url. If Set, will omit the creation of execution and beacon nodes, and only create azte  nodes.")
 	cmd.Flags().StringVarP(&flags.consensusApiUrl, "consensus-url", "", "", "Set consensus api url. If Set, will omit the creation of execution and beacon nodes, and only create aztec nodes.")
 	cmd.Flags().BoolVar(&flags.latestVersion, "latest", false, "Use the latest version of clients. This sets the \"latest\" tag on the client's docker images. Latest version might not work.")

--- a/configs/client_images.yaml
+++ b/configs/client_images.yaml
@@ -11,6 +11,9 @@ execution:
   erigon:
     name: erigontech/erigon
     version: v3.2.2
+  ethrex:
+    name: ghcr.io/lambdaclass/ethrex
+    version: 21.0.0
 consensus:
   lighthouse:
     name: sigp/lighthouse

--- a/configs/images.go
+++ b/configs/images.go
@@ -23,6 +23,7 @@ var ClientImages struct {
 		Besu       Image `yaml:"besu"`
 		Nethermind Image `yaml:"nethermind"`
 		Erigon     Image `yaml:"erigon"`
+		Ethrex     Image `yaml:"ethrex"`
 	}
 	Consensus struct {
 		Lighthouse Image `yaml:"lighthouse"`

--- a/docs/docs/commands/clients.mdx
+++ b/docs/docs/commands/clients.mdx
@@ -78,7 +78,7 @@ $ sedge clients
   2       │geth                   │prysm                  │prysm
   3       │erigon                 │teku                   │teku
   4       │besu                   │lodestar               │lodestar
-  5       │-                      │nimbus                 │nimbus
+  5       │ethrex                 │nimbus                 │nimbus
 
 
 2025-03-21 17:55:50 -- [INFO] Listing supported clients for network mainnet
@@ -91,7 +91,7 @@ $ sedge clients
   2       │geth                   │prysm                  │prysm
   3       │erigon                 │teku                   │teku
   4       │besu                   │lodestar               │lodestar
-  5       │-                      │nimbus                 │nimbus
+  5       │ethrex                 │nimbus                 │nimbus
 
 
 2025-03-21 17:55:50 -- [INFO] Listing supported clients for network sepolia
@@ -104,6 +104,6 @@ $ sedge clients
   2       │geth                   │prysm                  │prysm
   3       │erigon                 │teku                   │teku
   4       │besu                   │lodestar               │lodestar
-  5       │-                      │nimbus                 │nimbus
+  5       │ethrex                 │nimbus                 │nimbus
 
 ```

--- a/docs/docs/commands/generate.mdx
+++ b/docs/docs/commands/generate.mdx
@@ -88,7 +88,7 @@ Usage:
 
 Flags:
   -c, --consensus string                  Consensus engine client, e.g. teku, lodestar, prysm, lighthouse, Nimbus. Additionally, you can use this syntax '<CLIENT>:<DOCKER_IMAGE>' to override the docker image used for the client. If you want to use the default docker image, just use the client name
-  -e, --execution string                  Execution engine client, e.g. geth, nethermind, besu, erigon. Additionally, you can use this syntax '<CLIENT>:<DOCKER_IMAGE>' to override the docker image used for the client. If you want to use the default docker image, just use the client name
+  -e, --execution string                  Execution engine client, e.g. geth, nethermind, besu, erigon, ethrex. Additionally, you can use this syntax '<CLIENT>:<DOCKER_IMAGE>' to override the docker image used for the client. If you want to use the default docker image, just use the client name
   -v, --validator string                  Validator engine client, e.g. teku, lodestar, prysm, lighthouse, Nimbus. Additionally, you can use this syntax '<CLIENT>:<DOCKER_IMAGE>' to override the docker image used for the client. If you want to use the default docker image, just use the client name
       --distributed boolean               Deploy a node configured to run as part of a Distributed Validator Cluster.
   -d  --distributedValidator string       Distributed Validator client, e.g. charon. Additionally, you can use this syntax '<CLIENT>:<DOCKER_IMAGE>' to override the docker image used for the client. If you want to use the default docker image, just use the client name
@@ -151,7 +151,7 @@ Flags:
   -c, --consensus string                  Consensus engine client, e.g. teku, lodestar, prysm, lighthouse, Nimbus. Additionally, you can use this syntax '<CLIENT>:<DOCKER_IMAGE>' to override the docker image used for the client. If you want to use the default docker image, just use the client name
       --op-image string                   Optimism consensus client image.
       --op-execution string               Optimism Execution client to be used, op-nethermind, op-geth, or op-reth. Additionally, you can use this syntax '<CLIENT>:<DOCKER_IMAGE>' to override the docker image used for the client. If you want to use the default docker image, just use the client name.
-  -e, --execution string                  Execution engine client, e.g. geth, nethermind, besu, erigon. Additionally, you can use this syntax '<CLIENT>:<DOCKER_IMAGE>' to override the docker image used for the client. If you want to use the default docker image, just use the client name
+  -e, --execution string                  Execution engine client, e.g. geth, nethermind, besu, erigon, ethrex. Additionally, you can use this syntax '<CLIENT>:<DOCKER_IMAGE>' to override the docker image used for the client. If you want to use the default docker image, just use the client name
       --execution-api-url string          Set execution api url. If Set, will omit the creation of execution and beacon nodes, and only create optimism nodes.
       --consensus-url string          Set consensus api url. If Set, will omit the creation of execution and beacon nodes, and only create optimism nodes.
       --latest                            Use the latest version of clients. This sets the "latest" tag on the client's docker images. Latest version might not work.
@@ -236,7 +236,7 @@ $ sedge generate execution -h
 Generate a docker-compose and an environment file with a execution node configuration.
 Valid args: name of execution clients according to network
 
-Should be one of: nethermind, geth, besu, erigon. If you don't provide one, it will chosen randomly.
+Should be one of: nethermind, geth, besu, erigon, ethrex. If you don't provide one, it will chosen randomly.
 Additionally, you can use this syntax '<CLIENT>:<DOCKER_IMAGE>' to override the docker image used for the client, for example 'sedge generate execution nethermind:docker.image'. If you want to use the default docker image, just use the client name
 
 Usage:

--- a/docs/docs/networks/hoodi.mdx
+++ b/docs/docs/networks/hoodi.mdx
@@ -12,6 +12,7 @@ Hoodi is Ethereum's public testnet that serves as a technical experimentation pl
 - [Geth](https://geth.ethereum.org/docs/)
 - [Erigon](https://github.com/ledgerwatch/erigon)
 - [Besu](https://besu.hyperledger.org/en/stable/)
+- [ethrex](https://docs.ethrex.xyz/)
 
 ## Supported Consensus Clients
 - [Lighthouse](https://lighthouse-book.sigmaprime.io/)

--- a/docs/docs/networks/mainnet.mdx
+++ b/docs/docs/networks/mainnet.mdx
@@ -14,6 +14,7 @@ secured by the Proof-of-Stake (PoS) algorithm.
 - [Geth](https://geth.ethereum.org/docs/)
 - [Erigon](https://github.com/ledgerwatch/erigon)
 - [Besu](https://besu.hyperledger.org/en/stable/)
+- [ethrex](https://docs.ethrex.xyz/)
 
 ## Supported Consensus Clients
 - [Lighthouse](https://lighthouse-book.sigmaprime.io/)

--- a/docs/docs/networks/sepolia.mdx
+++ b/docs/docs/networks/sepolia.mdx
@@ -12,6 +12,7 @@ Sepolia is a permissioned Ethereum test network. It is one of the testnets that 
 - [Geth](https://geth.ethereum.org/docs/)
 - [Erigon](https://github.com/ledgerwatch/erigon)
 - [Besu](https://besu.hyperledger.org/en/stable/)
+- [ethrex](https://docs.ethrex.xyz/)
 
 ## Supported Consensus Clients
 - [Lighthouse](https://lighthouse-book.sigmaprime.io/)

--- a/internal/pkg/clients/clients_test.go
+++ b/internal/pkg/clients/clients_test.go
@@ -94,7 +94,7 @@ func TestClients(t *testing.T) {
 			map[string][]string{
 				"consensus": {"lighthouse", "prysm", "teku", "lodestar", "nimbus"},
 				"validator": {"lighthouse", "prysm", "teku", "lodestar", "nimbus"},
-				"execution": {"nethermind", "geth", "besu", "erigon"},
+				"execution": {"nethermind", "geth", "besu", "erigon", "ethrex"},
 			},
 			[]string{"consensus"},
 			"mainnet",
@@ -113,7 +113,7 @@ func TestClients(t *testing.T) {
 		{
 			map[string][]string{
 				"validator": {"lighthouse", "prysm", "teku", "lodestar", "nimbus"},
-				"execution": {"nethermind", "geth", "besu", "erigon"},
+				"execution": {"nethermind", "geth", "besu", "erigon", "ethrex"},
 			},
 			[]string{"execution", "validator"},
 			"mainnet",
@@ -123,7 +123,7 @@ func TestClients(t *testing.T) {
 			map[string][]string{
 				"validator": {"lighthouse", "prysm", "teku", "lodestar", "nimbus"},
 				"consensus": {"lighthouse", "prysm", "teku", "lodestar", "nimbus"},
-				"execution": {"nethermind", "geth", "besu", "erigon"},
+				"execution": {"nethermind", "geth", "besu", "erigon", "ethrex"},
 			},
 			[]string{"consensus", "other"},
 			"mainnet",
@@ -143,7 +143,7 @@ func TestClients(t *testing.T) {
 			map[string][]string{
 				"validator":            {"lighthouse", "prysm", "teku", "lodestar", "nimbus"},
 				"consensus":            {"lighthouse", "prysm", "teku", "lodestar", "nimbus"},
-				"execution":            {"nethermind", "geth", "besu", "erigon"},
+				"execution":            {"nethermind", "geth", "besu", "erigon", "ethrex"},
 				"distributedValidator": {"charon"},
 			},
 			[]string{"consensus", "execution", "validator", "distributedValidator"},

--- a/internal/pkg/clients/init.go
+++ b/internal/pkg/clients/init.go
@@ -21,6 +21,7 @@ var AllClients map[string][]string = map[string][]string{
 		"geth",
 		"erigon",
 		"besu",
+		"ethrex",
 	},
 	"consensus": {
 		"lighthouse",

--- a/internal/pkg/clients/types.go
+++ b/internal/pkg/clients/types.go
@@ -58,6 +58,8 @@ func (c *Client) setExecutionImage(image string) {
 		c.Image = valueOrDefault(image, configs.ClientImages.Execution.Nethermind.String())
 	case "erigon":
 		c.Image = valueOrDefault(image, configs.ClientImages.Execution.Erigon.String())
+	case "ethrex":
+		c.Image = valueOrDefault(image, configs.ClientImages.Execution.Ethrex.String())
 	}
 }
 

--- a/internal/pkg/clients/types_test.go
+++ b/internal/pkg/clients/types_test.go
@@ -55,6 +55,13 @@ func TestSetImageOrDefault_Execution(t *testing.T) {
 			},
 			expectedImage: *regexp.MustCompile(`^erigontech/erigon:v\d+\.\d+\.\d+$`),
 		},
+		{
+			client: Client{
+				Name: "ethrex",
+				Type: "execution",
+			},
+			expectedImage: *regexp.MustCompile(`^ghcr.io/lambdaclass/ethrex:\d+\.\d+\.\d+$`),
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.client.Name, func(t *testing.T) {

--- a/internal/pkg/generate/generate_scripts_test.go
+++ b/internal/pkg/generate/generate_scripts_test.go
@@ -125,6 +125,9 @@ func checkECBootnodesOnExecution(t *testing.T, data *GenData, compose, env io.Re
 		if composeData.Services.Execution != nil && data.ExecutionClient.Name == "geth" {
 			checkFlagOnCommands(t, composeData.Services.Execution.Command, "--bootnodes="+bootnodes)
 		}
+		if composeData.Services.Execution != nil && data.ExecutionClient.Name == "ethrex" {
+			checkFlagOnCommands(t, composeData.Services.Execution.Command, "--bootnodes="+bootnodes)
+		}
 	}
 	return nil
 }

--- a/scripts/check-image-updates.sh
+++ b/scripts/check-image-updates.sh
@@ -40,6 +40,10 @@ update-client "Nethermind" "execution" ".execution.nethermind" "$NETHERMIND_LATE
 ERIGON_LATEST=$(curl -H "Authorization: Bearer $PAT" -sL https://api.github.com/repos/ledgerwatch/erigon/releases/latest | jq -r ".tag_name")
 update-client "Erigon" "execution" ".execution.erigon" "$ERIGON_LATEST"
 
+# Ethrex
+ETHREX_LATEST_VERSION=$(curl -H "Authorization: Bearer $PAT" -sL https://api.github.com/repos/lambdaclass/ethrex/releases/latest | jq -r '.tag_name | ltrimstr("v")')
+update-client "Ethrex" "execution" ".execution.ethrex" "$ETHREX_LATEST_VERSION"
+
 # Lighthouse
 LIGHTHOUSE_LATEST_VERSION=$(curl -H "Authorization: Bearer $PAT" -sL https://api.github.com/repos/sigp/lighthouse/releases/latest | jq -r ".tag_name")
 update-client "Lighthouse" "consensus" ".consensus.lighthouse" "$LIGHTHOUSE_LATEST_VERSION"

--- a/templates/envs/hoodi/execution/ethrex.tmpl
+++ b/templates/envs/hoodi/execution/ethrex.tmpl
@@ -1,0 +1,9 @@
+{{/* ethrex.tmpl */}}
+{{ define "execution" }}
+# --- Execution Layer - Execution Node - configuration ---
+EC_IMAGE_VERSION={{.ElImage}}
+ETHREX_LOG_LEVEL=info
+EC_DATA_DIR={{.ElDataDir}}
+EC_SYNC_MODE=snap
+EC_JWT_SECRET_PATH={{.JWTSecretPath}}
+{{ end }}

--- a/templates/envs/mainnet/execution/ethrex.tmpl
+++ b/templates/envs/mainnet/execution/ethrex.tmpl
@@ -1,0 +1,9 @@
+{{/* ethrex.tmpl */}}
+{{ define "execution" }}
+# --- Execution Layer - Execution Node - configuration ---
+EC_IMAGE_VERSION={{.ElImage}}
+ETHREX_LOG_LEVEL=info
+EC_DATA_DIR={{.ElDataDir}}
+EC_SYNC_MODE=snap
+EC_JWT_SECRET_PATH={{.JWTSecretPath}}
+{{ end }}

--- a/templates/envs/sepolia/execution/ethrex.tmpl
+++ b/templates/envs/sepolia/execution/ethrex.tmpl
@@ -1,0 +1,9 @@
+{{/* ethrex.tmpl */}}
+{{ define "execution" }}
+# --- Execution Layer - Execution Node - configuration ---
+EC_IMAGE_VERSION={{.ElImage}}
+ETHREX_LOG_LEVEL=info
+EC_DATA_DIR={{.ElDataDir}}
+EC_SYNC_MODE=snap
+EC_JWT_SECRET_PATH={{.JWTSecretPath}}
+{{ end }}

--- a/templates/services/merge/execution/ethrex.tmpl
+++ b/templates/services/merge/execution/ethrex.tmpl
@@ -1,0 +1,46 @@
+{{/* ethrex.tmpl */}}
+{{ define "execution" }}
+  execution:
+    stop_grace_period: 30m
+    container_name: sedge-execution-client{{if .ContainerTag}}-{{.ContainerTag}}{{end}}
+    restart: unless-stopped
+    image: ${EC_IMAGE_VERSION}
+    networks:
+      - sedge
+    volumes:
+      - ${EC_DATA_DIR}:/var/lib/ethrex
+      - ${EC_JWT_SECRET_PATH}:/tmp/jwt/jwtsecret
+    ports:
+      - "{{.ElDiscoveryPort}}:{{.ElDiscoveryPort}}/tcp"
+      - "{{.ElDiscoveryPort}}:{{.ElDiscoveryPort}}/udp"
+      - "{{.ElMetricsPort}}:{{.ElMetricsPort}}/tcp"{{if .MapAllPorts}}
+      - "{{.ElApiPort}}:{{.ElApiPort}}"
+      - "{{.ElAuthPort}}:{{.ElAuthPort}}"{{end}}
+    expose:
+      - {{.ElApiPort}}
+      - {{.ElAuthPort}}
+    command:
+      - --network={{if .SplittedNetwork}}${EL_NETWORK}{{else}}${NETWORK}{{end}}
+      - --datadir=/var/lib/ethrex
+      - --syncmode=${EC_SYNC_MODE}
+      - --log.level=${ETHREX_LOG_LEVEL}{{if .ECBootnodes}}
+      - --bootnodes={{.ECBootnodes}}{{end}}
+      - --http.addr=0.0.0.0
+      - --http.port={{.ElApiPort}}
+      - --http.api=eth,net,web3
+      - --authrpc.addr=0.0.0.0
+      - --authrpc.port={{.ElAuthPort}}
+      - --authrpc.jwtsecret=/tmp/jwt/jwtsecret
+      - --p2p.addr=0.0.0.0
+      - --p2p.port={{.ElDiscoveryPort}}
+      - --discovery.port={{.ElDiscoveryPort}}
+      - --metrics
+      - --metrics.addr=0.0.0.0
+      - --metrics.port={{.ElMetricsPort}}{{range $flag := .ElExtraFlags}}
+      - --{{$flag}}{{end}}{{if .LoggingDriver}}
+    logging:
+      driver: "{{.LoggingDriver}}"{{if eq .LoggingDriver "json-file"}}
+      options:
+        max-size: "10m"
+        max-file: "10"{{end}}{{end}}
+{{ end }}


### PR DESCRIPTION
## Motivation

[ethrex](https://github.com/lambdaclass/ethrex) is an Ethereum execution client written in Rust, focused on simplicity and auditability. It runs on Ethereum mainnet in production, passed an external security audit by Least Authority, and runs the EF execution-spec-tests and cross-client Hive suites in CI. Adding it to Sedge gives node operators one more execution-layer option and improves client diversity, following the same integration pattern as the existing clients.

This PR was discussed with the Nethermind team beforehand, who suggested opening it.

## Description

Adds ethrex as a selectable execution client on **mainnet, sepolia, and hoodi** (the networks ethrex currently supports — no gnosis/chiado, so no templates are added there and Sedge won't offer it on those networks).

Follows the checklist in `docs/docs/guidelines/new-clients.mdx`:

- **Client registry:** `ethrex` added to `AllClients["execution"]`, `ClientImages` struct, `setExecutionImage`, and `configs/client_images.yaml` pinned to `ghcr.io/lambdaclass/ethrex:21.0.0` (multi-arch amd64+arm64). Note: ethrex docker tags carry no leading `v` (release CI strips it), while its GitHub release tags do — `scripts/check-image-updates.sh` therefore uses `ltrimstr("v")`.
- **Templates:** `templates/services/merge/execution/ethrex.tmpl` (compose service) + env fragments for mainnet/sepolia/hoodi. Flags verified against the ethrex CLI: `--http.addr/--authrpc.addr` bound to 0.0.0.0 for docker, JWT via `--authrpc.jwtsecret`, single P2P port for both `--p2p.port` and `--discovery.port`, Prometheus metrics on the standard Sedge metrics port, `--bootnodes` passthrough, `ElExtraFlags` supported. No CORS flag is passed (ethrex has none; its CORS is permissive by default).
- **Help text:** execution-client enumerations in `cli/sub_gen.go` updated (and mirrored in `docs/docs/commands/generate.mdx`).
- **Docs:** README client tables, `clients.mdx` sample output, `networks/{mainnet,sepolia,hoodi}.mdx`.
- **Tests:** `clients_test.go` execution lists, an ethrex case in `TestSetImageOrDefault_Execution`, and an ethrex branch in `checkECBootnodesOnExecution` so the generate-matrix asserts its bootnodes flag. The compose-generation test matrix picks ethrex up automatically for the three networks.
- **CHANGELOG:** entry under Unreleased.

## How to test

```bash
make test-no-e2e
./sedge clients                          # ethrex listed for mainnet/hoodi/sepolia only
./sedge generate full-node --network sepolia -c lighthouse -e ethrex --no-validator -p $PWD
docker compose config                    # valid compose; image ghcr.io/lambdaclass/ethrex:21.0.0
```

Validation already run on this branch:
- `make test-no-e2e` — passing (the only failures are the pre-existing live-RPC Lido tests, which fail identically on clean `develop`)
- `sedge clients` — ethrex on mainnet/hoodi/sepolia; absent on gnosis/chiado/custom
- `sedge generate full-node --network sepolia -c lighthouse -e ethrex` — compose + .env render correctly, `docker compose config` clean
- Docker smoke test (hoodi): generated stack brought up; ethrex `21.0.0` (arm64) started with zero flag errors and ran with **0 restarts**; HTTP-RPC on 8545, auth-RPC on the Sedge-assigned port, discv4+discv5 up; `engine_exchangeCapabilities` answered through the generated JWT (full capability list) and `eth_chainId` returned `0x88bb0` (hoodi), proving the JWT mount and `--network` env plumbing end to end
- `cd docs && npm run build` — Docusaurus build passing

Note from the smoke test, unrelated to this PR: Lighthouse v8 checkpoint sync failed against three public hoodi checkpointz instances ("Error fetching finalized blobs: 500 not found") before ever dialing the EL — the same failure occurs with any execution client.

## Possible follow-ups (out of scope)

- `custom` network support via ethrex's `--network <genesis.json>` (custom currently offers only nethermind).
- WebSocket port wiring (`--ws.enabled`); omitted to match the other non-geth EL templates.
