### PR TITLE
test: stabilize formatting and live RPC fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Pin gofumpt and abigen versions for reproducible formatting and code-generation checks.
+
+### Fixed
+- Apply gofumpt formatting to the E2E key tests and generated script cleanup.
+- Replace the Hoodi Tatum RPC endpoint with the public ethPandaOps endpoint.
+
 ## [v1.11.1] - 2026-02-10
 
 ### Changed

--- a/Makefile
+++ b/Makefile
@@ -69,13 +69,13 @@ codecov-test: generate ## unit tests with coverage using the courtney tool
 	@go tool cover -html=coverage/coverage.out -o coverage/coverage.html
 
 install-gofumpt: ## install gofumpt
-	go install mvdan.cc/gofumpt@latest
+	go install mvdan.cc/gofumpt@v0.9.2
 
 install-mockgen: ## install mockgen
 	go install github.com/golang/mock/mockgen@v1.6.0 
 
 install-abigen: ## install abigen
-	go install github.com/ethereum/go-ethereum/cmd/abigen@latest
+	go install github.com/ethereum/go-ethereum/cmd/abigen@v1.16.8
 
 install-deps: | install-gofumpt install-mockgen install-abigen ## Install some project dependencies
 

--- a/configs/public_rpcs.go
+++ b/configs/public_rpcs.go
@@ -41,7 +41,6 @@ var networkRPCs = map[string]RPC{
 		PublicRPCs: []string{
 			"https://0xrpc.io/hoodi",
 			"https://rpc.hoodi.ethpandaops.io",
-			"https://ethereum-hoodi.gateway.tatum.io",
 			"https://rpc.sentio.xyz/hoodi",
 		},
 		PublicWSs: []string{

--- a/e2e/lido-exporter/args_test.go
+++ b/e2e/lido-exporter/args_test.go
@@ -418,7 +418,7 @@ func TestE2E_ValidFlags_All(t *testing.T) {
 		// Act
 		func(t *testing.T, binaryPath string) *exec.Cmd {
 			cmd = base.RunCommandCMD(t, binaryPath, "lido-exporter", "lido-exporter",
-				"--rpc-endpoints", "https://ethereum-hoodi.gateway.tatum.io", "https://0xrpc.io/hoodi",
+				"--rpc-endpoints", "https://rpc.hoodi.ethpandaops.io", "https://0xrpc.io/hoodi",
 				"--ws-endpoints", "wss://0xrpc.io/hoodi", // https endpoint should be ignored
 				"--port", "9989",
 				"--scrape-time", "1s",
@@ -467,7 +467,7 @@ func TestE2E_ValidEnv_All(t *testing.T) {
 		// Arrange
 		func(t *testing.T, binaryPath string) (map[string]string, error) {
 			return map[string]string{
-				"LIDO_EXPORTER_RPC_ENDPOINTS":    "'https://ethereum-hoodi.gateway.tatum.io','https://0xrpc.io/hoodi'",
+				"LIDO_EXPORTER_RPC_ENDPOINTS":    "'https://rpc.hoodi.ethpandaops.io','https://0xrpc.io/hoodi'",
 				"LIDO_EXPORTER_WS_ENDPOINTS":     "'wss://0xrpc.io/hoodi'",
 				"LIDO_EXPORTER_PORT":             "9990",
 				"LIDO_EXPORTER_SCRAPE_TIME":      "2s",
@@ -593,7 +593,7 @@ func TestE2E_ValidEnv_All_Mainnet(t *testing.T) {
 		// Arrange
 		func(t *testing.T, binaryPath string) (map[string]string, error) {
 			return map[string]string{
-				"LIDO_EXPORTER_RPC_ENDPOINTS":    "'https://eth.llamarpc.com','https://eth-pokt.nodies.app','https://rpc.mevblocker.io'",
+				"LIDO_EXPORTER_RPC_ENDPOINTS":    "'https://ethereum-rpc.publicnode.com','https://eth-pokt.nodies.app','https://rpc.mevblocker.io'",
 				"LIDO_EXPORTER_WS_ENDPOINTS":     "'wss://ethereum-rpc.publicnode.com'",
 				"LIDO_EXPORTER_PORT":             "9990",
 				"LIDO_EXPORTER_SCRAPE_TIME":      "2s",
@@ -647,7 +647,7 @@ func TestE2E_ValidFlags_All_Mainnet(t *testing.T) {
 		// Act
 		func(t *testing.T, binaryPath string) *exec.Cmd {
 			cmd = base.RunCommandCMD(t, binaryPath, "lido-exporter", "lido-exporter",
-				"--rpc-endpoints", "https://eth.llamarpc.com", "https://eth-pokt.nodies.app", "https://rpc.mevblocker.io",
+				"--rpc-endpoints", "https://ethereum-rpc.publicnode.com", "https://eth-pokt.nodies.app", "https://rpc.mevblocker.io",
 				"--ws-endpoints", "wss://ethereum-rpc.publicnode.com", // https endpoint should be ignored
 				"--port", "9989",
 				"--scrape-time", "1s",

--- a/e2e/sedge/keys_test.go
+++ b/e2e/sedge/keys_test.go
@@ -155,7 +155,7 @@ func TestE2E_Keys_Lido_Mainnet(t *testing.T) {
 			for _, key := range keys {
 				assert.Regexp(t, regex, key.WithdrawalCredentials, "withdrawal_credentials should match the pattern")
 				assert.Equal(t, key.NetworkName, "mainnet", "network_name should be mainnet")
-				expectedWithdrawalAddress := "010000000000000000000000" + (wa[2:])
+				expectedWithdrawalAddress := "010000000000000000000000" + wa[2:]
 				assert.Equal(t, expectedWithdrawalAddress, key.WithdrawalCredentials, "WithdrawalAddress value should match expected value")
 			}
 		},
@@ -217,7 +217,7 @@ func TestE2E_Keys_Lido_Hoodi(t *testing.T) {
 			for _, key := range keys {
 				assert.Regexp(t, regex, key.WithdrawalCredentials, "withdrawal_credentials should match the pattern")
 				assert.Equal(t, key.NetworkName, "hoodi", "network_name should be hoodi")
-				expectedWithdrawalCredentials := "010000000000000000000000" + (wa[2:])
+				expectedWithdrawalCredentials := "010000000000000000000000" + wa[2:]
 				expectedWithdrawalCredentials = strings.ToLower(expectedWithdrawalCredentials)
 				assert.Equal(t, expectedWithdrawalCredentials, key.WithdrawalCredentials, "WithdrawalAddress value should match expected value")
 			}

--- a/internal/lido/contracts/client_test.go
+++ b/internal/lido/contracts/client_test.go
@@ -66,7 +66,7 @@ func TestConnectClientWithRPCs(t *testing.T) {
 		{
 			name:    "ConnectClientWithRPCs, Hoodi",
 			network: "hoodi",
-			RPCs:    []string{"https://0xrpc.io/hoodi", "https://ethereum-hoodi.gateway.tatum.io"},
+			RPCs:    []string{"https://0xrpc.io/hoodi", "https://rpc.hoodi.ethpandaops.io"},
 			wantErr: false,
 		},
 		{
@@ -78,7 +78,7 @@ func TestConnectClientWithRPCs(t *testing.T) {
 		{
 			name:    "ConnectClientWithRPCs, invalid Network RPCs",
 			network: "hoodi",
-			RPCs:    []string{"https://eth.llamarpc.com"}, // Mainnet RPC
+			RPCs:    []string{"https://ethereum-rpc.publicnode.com"}, // Mainnet RPC
 			wantErr: true,
 		},
 		{
@@ -96,7 +96,7 @@ func TestConnectClientWithRPCs(t *testing.T) {
 		{
 			name:    "ConnectClient, Mainnet",
 			network: "mainnet",
-			RPCs:    []string{"https://eth.llamarpc.com"},
+			RPCs:    []string{"https://ethereum-rpc.publicnode.com"},
 			wantErr: false,
 		},
 	}
@@ -158,7 +158,7 @@ func TestConnectClientWSWithRPCs(t *testing.T) {
 		{
 			name:    "ConnectClientWithRPCs, Hoodi",
 			network: "hoodi",
-			RPCs:    []string{"https://ethereum-hoodi.gateway.tatum.io", "wss://0xrpc.io/hoodi"},
+			RPCs:    []string{"https://rpc.hoodi.ethpandaops.io", "wss://0xrpc.io/hoodi"},
 			wantErr: false,
 		},
 		{

--- a/internal/lido/contracts/mevboostrelaylist/relays.yaml
+++ b/internal/lido/contracts/mevboostrelaylist/relays.yaml
@@ -31,10 +31,6 @@ mainnet:
     Operator: "Gattaca"
     IsMandatory: false
     Description: "Titan Relay Global (non-filtering)"
-  - Uri: "https://0x98650451ba02064f7b000f5768cf0cf4d4e492317d82871bdc87ef841a0743f69f0f1eea11168503240ac35d101c9135@mainnet-relay.securerpc.com/"
-    Operator: "Manifold Finance"
-    IsMandatory: true
-    Description: "Manifold SecureRPC Relay"
   - Uri: "https://0xa1559ace749633b997cb3fdacffb890aeebdb0f5a3b6aaa7eeeaf1a38af0a8fe88b9e4b1f61f236d2e64d95733327a62@relay-filtered.ultrasound.money"
     Operator: "Ultra Sound"
     IsMandatory: true

--- a/internal/pkg/generate/clean_scripts.go
+++ b/internal/pkg/generate/clean_scripts.go
@@ -238,8 +238,8 @@ func CleanEnvFile(envFilePath string) error {
 		}
 		result := ReENVVAR.FindStringSubmatch(line) // Check line its a valid variable
 		if len(result) >= 3 {
-			envVar := result[1]            // Get var name
-			existingVars[(envVar)] = index // Save latest apparition for the var name
+			envVar := result[1]          // Get var name
+			existingVars[envVar] = index // Save latest apparition for the var name
 		}
 	}
 


### PR DESCRIPTION
## Changes

- Apply gofumpt v0.9.2 formatting to the E2E key tests and generated script cleanup.
- Pin gofumpt and abigen to the versions used when PR #546 passed.
- Resolve generated-file and format-check drift caused by unpinned latest tools.
- Replace the Hoodi Tatum RPC endpoint with the public ethPandaOps endpoint to avoid paid-plan `eth_call` failures.
- Replace the unreliable Mainnet LlamaRPC test endpoint with the existing keyless PublicNode endpoint.
- Refresh the static Mainnet relay fixture to match the current on-chain MEV-Boost allowed list.

## Types of changes

- [ ] Bugfix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change
- [ ] Documentation Update
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Build related changes
- [x] Other

## Testing

- [x] Yes
- [ ] No new tests required; this change updates formatting, tool version pins, and live RPC test fixtures.

Validation completed:
- `gofumpt v0.9.2 -l .`
- `make generate` with `abigen v1.16.8`
- `make format-check`
- `go test ./configs ./internal/pkg/clients ./internal/pkg/generate`
- `go test ./e2e/sedge -run '^$'`
- Focused Hoodi contract connection tests
- Focused Mainnet contract connection test
- `go test ./e2e/lido-exporter -run '^TestE2E_Valid(Env|Flags)_All_Mainnet$'`
- Focused Mainnet relay-list comparison against the on-chain contract

The relay-list test uses live on-chain data and may be affected by transient public RPC timeouts.
