### PR TITLE
fix(nimbus): bump gnosis/chiado image to v26.6.0 (ws-reconnect fix)

### DIFF
--- a/cli/factory/node_factory.go
+++ b/cli/factory/node_factory.go
@@ -142,7 +142,11 @@ func (c *ConsensusNodeInitializer) Initialize(allClients clients.OrderedClients,
 	// Special handling for Gnosis and Chiado networks
 	if flags.GetNetwork() == NetworkGnosis || flags.GetNetwork() == NetworkChiado {
 		if flags.GetConsensusName() == "nimbus" {
-			c.config.flagName = "nimbus:ghcr.io/gnosischain/gnosis-nimbus-eth2:v26.3"
+			// v26.6.0 minimum: v26.3 predates the nimbus ws-reconnect fix
+			// (status-im/nimbus-eth2#8595, fixed in v26.6.0) — over web3-url=ws://
+			// it never re-dials the EL after an EL restart, wedging any
+			// fuzz/restart scenario on gnosis/chiado.
+			c.config.flagName = "nimbus:ghcr.io/gnosischain/gnosis-nimbus-eth2:v26.6.0"
 		}
 	}
 


### PR DESCRIPTION
One-line pin bump on `core` (the branch the post-merge-smoke-tests harness builds).

## Problem

`cli/factory/node_factory.go` pins gnosis/chiado nimbus to `ghcr.io/gnosischain/gnosis-nimbus-eth2:v26.3`, which predates the nimbus **ws-reconnect fix** ([status-im/nimbus-eth2#8595](https://github.com/status-im/nimbus-eth2/issues/8595), fixed in v26.6.0): over `web3-url=ws://` nimbus never re-dials the execution client after an EL restart.

Effect in the smoke lanes: every gnosis `nimbus_ws` fuzz/restart scenario wedges. Concrete case: [FuzzGN in release-validation run 30865692535](https://github.com/NethermindEth/post-merge-smoke-tests/actions/runs/30865692535) — after a fuzz docker-kill at 01:09:43, the EL sat FCU-starved in StateNodes for ~2.5 h (2,088 `Not receiving ForkChoices` warnings) until the 180-min stage timer force-stopped the lane. The EL was healthy; nimbus simply never reconnected.

(The harness's `bounce-consensus-after-el-fuzz` safety net sets the config flag, but the consuming side in nethermind-node-tests never merged — and the right fix is the image anyway.)

## Fix

Bump the pin to `v26.6.0` — published on ghcr (verified: `ghcr.io/v2/gnosischain/gnosis-nimbus-eth2/tags/list` shows v26.6/v26.6.0 as latest).