### PR TITLE
feat(network): add Plataberget testnet support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Support `Plataberget` testnet for Ethereum node setup (Nethermind execution + Nimbus consensus only).
+
 ### Changed
 - Bump pinned client images to latest stable releases:
   - Execution: geth `v1.17.3`, besu `26.5.0`, nethermind `1.37.2` (shared with op-execution and t-execution), erigon `v3.4.2`.
-  - Consensus & Validator: lodestar `v1.43.0`, prysm `v7.1.4`, nimbus `multiarch-v26.5.0`.
+  - Consensus & Validator: lodestar `v1.43.0`, prysm `v7.1.4`, nimbus `multiarch-v26.8.0`.
   - DV: charon `v1.10.1`.
   - Optimism: op-node `v1.18.2`, op-geth `v1.101702.2`.
   - Arbitrum: nethermind-arbitrum `0.2.0`, nitro-node `v3.10.1-d7f07be`.

--- a/configs/client_images.yaml
+++ b/configs/client_images.yaml
@@ -29,7 +29,7 @@ consensus:
     version: v7.1.4
   nimbus:
     name: statusim/nimbus-eth2
-    version: multiarch-v26.5.0
+    version: multiarch-v26.8.0
 validator:
   lighthouse:
     name: sigp/lighthouse
@@ -45,7 +45,7 @@ validator:
     version: v7.1.4
   nimbus:
     name: statusim/nimbus-validator-client
-    version: multiarch-v26.5.0
+    version: multiarch-v26.8.0
 distributed:
   charon:
     name: ghcr.io/obolnetwork/charon

--- a/configs/init.go
+++ b/configs/init.go
@@ -90,6 +90,18 @@ var networksConfigs map[string]NetworkConfig = map[string]NetworkConfig{
 		ChainID: 560048,
 		Weight:  2,
 	},
+	NetworkPlataberget: {
+		Name:               NetworkPlataberget,
+		NetworkService:     "merge",
+		GenesisForkVersion: "0x10733183",
+		// mev-boost is launched with -${NETWORK} and rejects unknown networks,
+		// and no relay serves plataberget.
+		SupportsMEVBoost:  false,
+		CheckpointSyncURL: "https://checkpoint-sync.plataberget.ethpandaops.io",
+		RelayURLs:         []string{},
+		ChainID:           7091047534,
+		Weight:            3,
+	},
 	NetworkMekong: {
 		Name:              NetworkMekong,
 		NetworkService:    "merge",

--- a/configs/networks.go
+++ b/configs/networks.go
@@ -40,6 +40,7 @@ const (
 	NetworkXdc          = "xdc"
 	NetworkXdcTestnet   = "xdc-testnet"
 	NetworkHoodi        = "hoodi"
+	NetworkPlataberget  = "plataberget"
 	NetworkCustom       = "custom"
 )
 
@@ -48,7 +49,7 @@ var ErrInvalidNetwork = errors.New("invalid network")
 // added volta and EnergyWeb
 func NetworkCheck(value string) error {
 	switch value {
-	case NetworkMainnet, NetworkSepolia, NetworkGnosis, NetworkChiado, NetworkHolesky, NetworkMekong, NetworkCustom, NetworkVolta, NetworkEnergyWeb, NetworkJocMainnet, NetworkJocTestnet, NetworkLineaMainnet, NetworkLineaSepolia, NetworkXdc, NetworkXdcTestnet:
+	case NetworkMainnet, NetworkSepolia, NetworkGnosis, NetworkChiado, NetworkHolesky, NetworkMekong, NetworkCustom, NetworkVolta, NetworkEnergyWeb, NetworkJocMainnet, NetworkJocTestnet, NetworkLineaMainnet, NetworkLineaSepolia, NetworkXdc, NetworkXdcTestnet, NetworkPlataberget:
 		return nil
 	default:
 		return fmt.Errorf("%w: %s", ErrInvalidNetwork, value)
@@ -65,6 +66,7 @@ func NetworkSupported() []string {
 		NetworkHolesky,
 		NetworkMekong,
 		NetworkHoodi,
+		NetworkPlataberget,
 		NetworkCustom,
 		NetworkVolta,
 		NetworkEnergyWeb,

--- a/configs/networks_test.go
+++ b/configs/networks_test.go
@@ -49,6 +49,11 @@ func TestNetworkCheck(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name:    "Valid network, plataberget",
+			network: "plataberget",
+			wantErr: false,
+		},
+		{
 			name:    "Invalid network",
 			network: "invalid",
 			wantErr: true,

--- a/templates/envs/plataberget/consensus/nimbus.tmpl
+++ b/templates/envs/plataberget/consensus/nimbus.tmpl
@@ -1,0 +1,14 @@
+{{/* nimbus.tmpl */}}
+{{ define "consensus" }}
+# --- Consensus Layer - Beacon Node - configuration ---
+CC_PEER_COUNT=50
+CC_LOG_LEVEL=info
+EC_API_URL={{.ExecutionApiURL}}
+EC_AUTH_URL={{.ExecutionAuthURL}}
+CC_INSTANCE_NAME=Nimbus
+CC_IMAGE_VERSION={{.CcImage}}
+CC_DATA_DIR={{.CcDataDir}}
+CC_JWT_SECRET_PATH={{.JWTSecretPath}}
+CC_FEE_RECIPIENT={{.FeeRecipient}}
+{{if .CheckpointSyncUrl}}CHECKPOINT_SYNC_URL={{.CheckpointSyncUrl}}{{end}}
+{{ end }}

--- a/templates/envs/plataberget/env_base.tmpl
+++ b/templates/envs/plataberget/env_base.tmpl
@@ -1,0 +1,9 @@
+{{/* docker-compose_base.tmpl */}}
+{{ define "env" }}
+# --- Global configuration ---
+NETWORK=plataberget{{if .FeeRecipient}}
+FEE_RECIPIENT={{.FeeRecipient}}{{end}}
+{{template "execution" .}}
+{{template "consensus" .}}
+{{template "validator" .}}
+{{ end }}

--- a/templates/envs/plataberget/execution/nethermind.tmpl
+++ b/templates/envs/plataberget/execution/nethermind.tmpl
@@ -1,0 +1,7 @@
+{{/* nethermind.tmpl */}}
+{{ define "execution" }}
+# --- Execution Layer - Execution Node - configuration ---
+EC_IMAGE_VERSION={{.ElImage}}
+EC_DATA_DIR={{.ElDataDir}}
+EC_JWT_SECRET_PATH={{.JWTSecretPath}}
+{{ end }}

--- a/templates/envs/plataberget/validator/nimbus.tmpl
+++ b/templates/envs/plataberget/validator/nimbus.tmpl
@@ -1,0 +1,12 @@
+{{/* nimbus.tmpl */}}
+{{ define "validator" }}
+# --- Consensus Layer - Validator Node - configuration ---
+CC_API_URL={{.ConsensusApiURL}}
+CC_ADD_API_URL={{.ConsensusAdditionalApiURL}}
+GRAFFITI={{.Graffiti}}
+VL_LOG_LEVEL=info
+VL_IMAGE_VERSION={{.VlImage}}
+KEYSTORE_DIR={{.KeystoreDir}}
+WALLET_DIR=./wallet
+VL_DATA_DIR={{.VlDataDir}}
+{{ end }}


### PR DESCRIPTION
## feat(network): add Plataberget testnet support

**Base branch: `core`** (not `main`/`develop`). Branch `feature/add-plataberget-network`, one commit off `0056b89`.

Adds `plataberget` (= ethpandaops `glamsterdam-devnet-8`, public endpoints under `*.plataberget.ethpandaops.io`) as a supported network, with **Nethermind** execution and **Nimbus** consensus/validator.

```
sedge generate full-node --network plataberget -e nethermind -c nimbus
```

### Network parameters

Read live from the network's own beacon API rather than copied from a doc:

| | value | source |
|---|---|---|
| chain / network id | `7091047534` | `/eth/v1/config/spec` → `DEPOSIT_CHAIN_ID` |
| genesis fork version | `0x10733183` | `/eth/v1/beacon/genesis` |
| genesis time | `1786622400` (2026-08-13T12:00:00Z) | `/eth/v1/beacon/genesis` |
| deposit contract | `0x00000000219ab540356cBB839Cbe05303d7705Fa` | `/eth/v1/config/spec` |
| checkpoint sync | `https://checkpoint-sync.plataberget.ethpandaops.io` | responded to both calls above |

### Nimbus is the only consensus client, and why

A client is supported on a network **iff** `templates/envs/<network>/<role>/<client>.tmpl` exists, so shipping a template for a client that cannot join would only hand users a crash-looping container. I version-gated each upstream:

- **nimbus — supported.** v26.8.0 bakes plataberget in at compile time: `beacon_chain/networking/network_metadata.nim` has a `plataberget` enum member, `platabergetMetadata = loadCompileTimeNetworkMetadata(..., useBakedInGenesis = Opt.some "plataberget")`, and `getMetadataForNetwork` dispatches `of "plataberget": platabergetMetadata` in the `IsMainnetSupported` branch. v26.7.0 contains zero occurrences of the string.
- **lodestar** — only from `v1.47.0-rc.0`, a release candidate.
- **teku** — master only, no released tag.
- **lighthouse** — no support on any branch.
- **prysm** — moot regardless: `imageOrEmpty` pins prysm to `v6.1.4`.

So: execution templates for nethermind only, consensus/validator for nimbus only. This mirrors the `xdc` precedent (PR #548), which ships only `env_base.tmpl` + `execution/nethermind.tmpl`.

**A validator template is required, not optional.** `generate_scripts.go` calls `env.CheckVariable(env.ReMEV, network, "validator", <client>)`, which `ReadFile`s `envs/<network>/validator/<client>.tmpl` and returns an **error** if it is absent — so generation would hard-fail for any node with a validator without it.

### `SupportsMEVBoost: false`, `RelayURLs: []`

`templates/services/docker-compose_base.tmpl` launches mev-boost with `-${NETWORK}` → `-plataberget`, which mev-boost rejects as an unknown network, and no relay serves this testnet. Note the `hoodi` entry on `core` has `SupportsMEVBoost: true`, so it must not be blind-copied.

I followed **chiado**, not mekong: `validator/nimbus.tmpl` omits `MEV=true` and `env_base.tmpl` omits the `RELAY_URLS` block. This is load-bearing, not cosmetic. `MEV=` in the validator env is exactly what `generate_scripts.go` greps via `env.ReMEV` to set `mevSupported`. mekong kept `MEV=true` while declaring `SupportsMEVBoost: false`, and that combination is why its `network: mekong, all` case asserts a non-nil mev-boost service at `generation_test.go:537` and then **panics** on a nil dereference at `:539`. Verified by rendering with `Mev: true` forced: no `mev-boost` service, no `RELAY_URLS`, no `MEV=` anywhere in the output.

`Weight: 3` is reused (already shared with holesky and mekong); weight only orders the interactive picker.

`plataberget` is deliberately **not** added to `validatePOANetwork` — it is proof-of-stake.

### Nimbus image bump

`multiarch-v26.5.0` → `multiarch-v26.8.0` for both `statusim/nimbus-eth2` and `statusim/nimbus-validator-client` (both tags confirmed published on Docker Hub). v26.5.0 cannot join this network at all, so the bump is a prerequisite. No other client touched. The existing `[Unreleased]` CHANGELOG bullet naming `nimbus multiarch-v26.5.0` is corrected in the same commit, since this change falsifies it.

### ⚠️ Known limitation: no released Nethermind image can join yet

`plataberget.json` landed in nethermind via **PR #12807 on 2026-08-14**; the newest release tag is **1.39.3, cut 2026-08-04**. I checked 1.37.2, 1.38.0, 1.38.1, 1.39.0–1.39.3 — absent from all of them. sedge's default pin is `nethermind/nethermind:1.37.2`, and the EL is launched with `--config=${NETWORK}`, so **the EL will fail on defaults while the CL is fine.** Until a release ships it:

```
sedge generate full-node --network plataberget -e nethermind:nethermindeth/nethermind:master-<sha> -c nimbus
```

I did **not** bump the global nethermind pin (that would change mainnet and every other network), and did not add a per-network pin — though precedent exists if you want one: `cli/factory/node_factory.go` hardcodes gnosis/chiado nimbus today, and the original mekong commit `6e3b079` pinned devnet EL+CL images in `cli/generate.go valClients()`. **Please decide.**

### Validation — local only

`core` has **no CI**: no workflow declares it as a trigger branch (`build.yml`, `e2e_tests.yml` → `[main, develop]`; the only `core` matches in `.github/workflows` are `git config core.autocrlf false` lines). Only `codeql.yml` and `dependency_review.yml` would fire on a PR here, and neither runs the Go suite. So everything below was run locally.

- **gofumpt** (the repo's `format-check` formatter) and **gofmt**: clean on all three changed `.go` files. Checked on `\r`-stripped copies, since `core.autocrlf=true` makes `gofmt -l .` false-positive nearly the whole repo. `make format` was **not** run — it would rewrite everything and destroy the diff.
- **`go vet ./configs/...`**: clean.
- **`go test ./configs/... ./internal/... ./cli/actions/...`**, baseline re-measured on the stashed pristine tree in the identical environment:

| | baseline | after |
|---|---|---|
| packages ok | 16 | 16 |
| packages FAIL | 13 (9 `[build failed]`) | 13 (9 `[build failed]`) |
| failing subtests | 19 | 19 |
| `file does not exist` errors | 36 | 36 |

Diffs of the ok/FAIL verdict set, the failing-test-name set, and the missing-template-error set are all **empty**. **Zero delta.**

- **Positive proof**, `go test -v -run TestGenerateComposeServices ./internal/pkg/generate/`: **12 plataberget subtests, 12 PASS, 0 FAIL**, covering `only_execution`, `only_consensus`, `only_validator`, `no_validator` and `all`. The `all` case — the one that panics for mekong — passes.
- Rendered `.env` sanity: `NETWORK=plataberget`, nimbus images at `multiarch-v26.8.0`, correct `CHECKPOINT_SYNC_URL`, and no MEV/relay keys.

### Pre-existing red tests — unchanged, nothing edited to pass

The suite is **already red on `core`** and stays exactly as red. Same 5 top-level failures before and after: `TestGenerateComposeServices`, `TestGenerateDockerCompose`, `TestSetImageOrDefault_Consensus`, `TestSetImageOrDefault_Validator`, `TestSupportedNetworks`.

- `internal/utils` — `TestSupportedNetworks` hardcodes a 7-item list against the real template dirs. Its message now reads 18 instead of 17 (plataberget included); same test, same failure, **not edited**.
- `internal/pkg/generate` / `cli/actions` — 36 `open envs/<net>/<role>: file does not exist` errors across 9 partially-templated networks (energyweb, goerli, joc-*, linea-*, volta, xdc, xdc-testnet). **plataberget adds none**: `SupportedClients()` errors only on a missing role *directory*, and all three of ours exist.
- `internal/pkg/clients` — 2 lighthouse `SetImageOrDefault` subtests.
- `cli/actions` — `network: mekong, all` panics and aborts that whole test binary (see the MEV discussion above), truncating results for networks sorted after `mekong`. That is why plataberget was validated in `internal/pkg/generate`.
- The pre-existing omission of `NetworkHoodi` from `NetworkCheck` was left untouched, and deliberately not replicated for plataberget.

9 `[build failed]` packages (lido contracts, keystores, options) are **environmental on my box**: `herumi/bls-eth-go-binary` needs cgo and this machine has a 32-bit-only mingw `cc1.exe`. A pristine `core` tree fails identically, so it is not from this change — but it does mean `internal/pkg/options` (which covers `ethereumOptions.SupportedNetworks()`, the one function the new `NetworkConfig` feeds) was never executed. **Worth a CI run on a box with working cgo.**

### Files

```
templates/envs/plataberget/env_base.tmpl                (new)
templates/envs/plataberget/execution/nethermind.tmpl    (new)
templates/envs/plataberget/consensus/nimbus.tmpl        (new)
templates/envs/plataberget/validator/nimbus.tmpl        (new)
configs/networks.go            const + NetworkCheck + NetworkSupported
configs/init.go                NetworkConfig entry
configs/networks_test.go       NetworkCheck case (mirrors the xdc commit)
configs/client_images.yaml     nimbus 26.5.0 -> 26.8.0 (2 lines)
CHANGELOG.md                   Added entry + correct the stale nimbus version
```

The three template files other than `env_base.tmpl` are byte-identical to chiado's; `env_base.tmpl` differs from chiado's only in the network name. All committed blobs are LF, verified with `git cat-file blob`.
